### PR TITLE
Add default_permission parameter to user/message commands

### DIFF
--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -51,11 +51,11 @@ class InvokableUserCommand(InvokableApplicationCommand):
         Whether to sync the command in the API with ``body`` or not.
     """
 
-    def __init__(self, func, *, name: str = None, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs):
+    def __init__(self, func, *, name: str = None, default_permission: bool = True, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs):
         super().__init__(func, name=name, **kwargs)
         self.guild_ids: Optional[Sequence[int]] = guild_ids
         self.auto_sync: bool = auto_sync
-        self.body = UserCommand(name=self.name)
+        self.body = UserCommand(name=self.name, default_permission=default_permission)
 
     async def _call_external_error_handlers(self, inter: ApplicationCommandInteraction, error: CommandError) -> None:
         cog = self.cog
@@ -108,11 +108,11 @@ class InvokableMessageCommand(InvokableApplicationCommand):
         Whether to sync the command in the API with ``body`` or not.
     """
 
-    def __init__(self, func, *, name: str = None, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs):
+    def __init__(self, func, *, name: str = None, default_permission: bool = True, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs):
         super().__init__(func, name=name, **kwargs)
         self.guild_ids: Optional[Sequence[int]] = guild_ids
         self.auto_sync: bool = auto_sync
-        self.body = MessageCommand(name=self.name)
+        self.body = MessageCommand(name=self.name, default_permission=default_permission)
 
     async def _call_external_error_handlers(self, inter: ApplicationCommandInteraction, error: CommandError) -> None:
         cog = self.cog
@@ -137,7 +137,7 @@ class InvokableMessageCommand(InvokableApplicationCommand):
 
 
 def user_command(
-    *, name: str = None, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs
+    *, name: str = None, default_permission: bool = True, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs
 ) -> Callable[
     [
         Union[
@@ -176,13 +176,13 @@ def user_command(
             raise TypeError(f"<{func.__qualname__}> must be a coroutine function")
         if hasattr(func, "__command_flag__"):
             raise TypeError("Callback is already a command.")
-        return InvokableUserCommand(func, name=name, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)
+        return InvokableUserCommand(func, name=name, default_permission=default_permission, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)
 
     return decorator
 
 
 def message_command(
-    *, name: str = None, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs
+    *, name: str = None, default_permission: bool = True, guild_ids: Sequence[int] = None, auto_sync: bool = True, **kwargs
 ) -> Callable[
     [
         Union[
@@ -221,6 +221,6 @@ def message_command(
             raise TypeError(f"<{func.__qualname__}> must be a coroutine function")
         if hasattr(func, "__command_flag__"):
             raise TypeError("Callback is already a command.")
-        return InvokableMessageCommand(func, name=name, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)
+        return InvokableMessageCommand(func, name=name, default_permission=default_permission, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)
 
     return decorator

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -471,6 +471,7 @@ class InteractionBotBase(CommonBotBase):
         self,
         *,
         name: str = None,
+        default_permission: bool = True,
         guild_ids: Sequence[int] = None,
         auto_sync: bool = True,
         **kwargs
@@ -508,7 +509,7 @@ class InteractionBotBase(CommonBotBase):
                 Callable[Concatenate[ApplicationCommandInteractionT, P], Coroutine]
             ]
         ) -> InvokableUserCommand:
-            result = user_command(name=name, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)(func)
+            result = user_command(name=name, default_permission=default_permission, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)(func)
             self.add_user_command(result)
             return result
         return decorator
@@ -517,6 +518,7 @@ class InteractionBotBase(CommonBotBase):
         self,
         *,
         name: str = None,
+        default_permission: bool = True,
         guild_ids: Sequence[int] = None,
         auto_sync: bool = True,
         **kwargs
@@ -554,7 +556,7 @@ class InteractionBotBase(CommonBotBase):
                 Callable[Concatenate[ApplicationCommandInteractionT, P], Coroutine]
             ]
         ) -> InvokableMessageCommand:
-            result = message_command(name=name, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)(func)
+            result = message_command(name=name, default_permission=default_permission, guild_ids=guild_ids, auto_sync=auto_sync, **kwargs)(func)
             self.add_message_command(result)
             return result
         return decorator


### PR DESCRIPTION
## Summary
Adds missing `default_permission` parameter to `InvokableUserCommand`/`InvokableMessageCommand` and `user_command`/`message_command` decorators, similar to slash commands.  
Previously, the default value (`True`) set in `UserCommand`/`MessageCommand` couldn't be modified easily.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
