### PR TITLE
Fix incorrect types for `_guild_application_commands` in `bulk_overwrite_guild_commands`

### DIFF
--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1587,7 +1587,7 @@ class ConnectionState:
             self.application_id, guild_id, payload # type: ignore
         )
         commands = [application_command_factory(data) for data in results]
-        self._guild_application_commands[guild_id] = {cmd.id for cmd in commands} # type: ignore
+        self._guild_application_commands[guild_id] = {cmd.id: cmd for cmd in commands}
         return commands
 
     # Application command permissions


### PR DESCRIPTION
## Summary

`ConnectionState.bulk_overwrite_guild_commands` assigns a `set` to `_guild_application_commands[guild_id]`, it should be a dict.

Currently methods like `Client.get_guild_application_commands` are broken if application commands were updated beforehand:
https://github.com/EQUENOS/disnake/blob/76d76fb697b517507f81ca7dd9542096fd53c867/disnake/client.py#L1049-L1050

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
