### PR TITLE
Fix application command permissions sync

### DIFF
--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -750,12 +750,12 @@ class InteractionBotBase(CommonBotBase):
         # Once per-guild permissions are collected from the code,
         # we can compare them to the cached permissions
         for guild_id, new_array in guilds_to_compare.items():
-            old_array = list(self._connection._application_command_permissions.get(guild_id, {}).values())
+            old_perms = self._connection._application_command_permissions.get(guild_id, {})
             if (
-                len(new_array) == len(old_array)
+                len(new_array) == len(old_perms)
                 and all(
-                    new_perms.permissions == old_perms.permissions
-                    for new_perms, old_perms in zip(new_array, old_array)
+                    new_cmd_perms.id in old_perms and old_perms[new_cmd_perms.id].permissions == new_cmd_perms.permissions
+                    for new_cmd_perms in new_array
                 )
             ):
                 if self._sync_commands_debug:


### PR DESCRIPTION
## Summary

Application command permissions set using the `guild_permissions` decorator are currently being synced incorrectly (synced when not required, or not synced when required) in a few edge cases, either due to a change in the order of permissions, or due to command type migration.
This fixes those issues by taking command IDs into account, which also makes the code independent of the order of permissions when comparing.
<sub>(more details on Discord)</sub>

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
