### PR TITLE
Add created_at property for threads

### DIFF
--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -32,7 +32,7 @@ from .mixins import Hashable
 from .abc import Messageable
 from .enums import ChannelType, try_enum
 from .errors import ClientException
-from .utils import MISSING, parse_time, _get_as_snowflake
+from .utils import MISSING, parse_time, snowflake_time, _get_as_snowflake
 
 __all__ = (
     'Thread',
@@ -55,6 +55,8 @@ if TYPE_CHECKING:
     from .role import Role
     from .permissions import Permissions
     from .state import ConnectionState
+
+    import datetime
 
 
 class Thread(Messageable, Hashable):
@@ -293,6 +295,11 @@ class Thread(Messageable, Hashable):
         if parent is None:
             raise ClientException('Parent channel not found')
         return parent.category_id
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the thread's creation time in UTC."""
+        return snowflake_time(self.id)
 
     def is_private(self) -> bool:
         """:class:`bool`: Whether the thread is a private thread.


### PR DESCRIPTION
## Summary

Added the `created_at` property to the `disnake.Thread` class.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
