### PR TITLE
Don't clear application command caches on 'READY' event

### DIFF
--- a/disnake/state.py
+++ b/disnake/state.py
@@ -248,7 +248,7 @@ class ConnectionState:
 
         self.clear()
 
-    def clear(self, *, views: bool = True) -> None:
+    def clear(self, *, views: bool = True, application_commands: bool = True) -> None:
         self.user: ClientUser = MISSING
         # Originally, this code used WeakValueDictionary to maintain references to the
         # global user mapping.
@@ -266,9 +266,11 @@ class ConnectionState:
         self._emojis: Dict[int, Emoji] = {}
         self._stickers: Dict[int, GuildSticker] = {}
         self._guilds: Dict[int, Guild] = {}
-        self._global_application_commands: Dict[int, ApplicationCommand] = {}
-        self._guild_application_commands: Dict[int, Dict[int, ApplicationCommand]] = {}
-        self._application_command_permissions: Dict[int, Dict[int, GuildApplicationCommandPermissions]] = {}
+
+        if application_commands:
+            self._global_application_commands: Dict[int, ApplicationCommand] = {}
+            self._guild_application_commands: Dict[int, Dict[int, ApplicationCommand]] = {}
+            self._application_command_permissions: Dict[int, Dict[int, GuildApplicationCommandPermissions]] = {}
 
         if views:
             self._view_store: ViewStore = ViewStore(self)
@@ -650,7 +652,7 @@ class ConnectionState:
             self._ready_task.cancel()
 
         self._ready_state = asyncio.Queue()
-        self.clear(views=False)
+        self.clear(views=False, application_commands=False)
         self.user = ClientUser(state=self, data=data['user'])
         self.store_user(data['user'])
 


### PR DESCRIPTION
## Summary

Reconnects (e.g. due to timeouts) result in a new 'READY' event being received, which eventually results in `ConnectionState.clear` being called. This cleared cached application commands, making them non-functional (`This is a deprecated local command, which is now deleted.`).
By not clearing the application command cache in `parse_ready`, commands and permissions are preserved through reconnects, similar to `_view_store`.

Would be great if someone with knowledge of the state management could look over this again, I'm not too sure if this could break things somewhere down the line.

The MWE below forces a reconnect by timing out (blocking code shouldn't be used, asyncio exists for a reason), but the same problem occurs while debugging when sitting on a breakpoint for too long and subsequently reconnecting.

<details>
<summary>MWE to reproduce:</summary>

Invoke command, wait for it to reconnect, invoke command again
```py
import os
import time
import logging
import disnake
from disnake.ext import commands


logging.basicConfig()
logging.getLogger('disnake').setLevel(logging.DEBUG)

bot = commands.Bot(
    test_guilds=[int(os.environ['DISCORD_GUILD_ID'])]
)

@bot.slash_command()
async def test(inter: disnake.ApplicationCommandInteraction) -> None:
    await inter.response.send_message('Hello World!')
    time.sleep(120)

bot.run(os.environ['DISCORD_TOKEN'])
```
</details>

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
