### PR TITLE
Fix `disnake.ext.commands.param` shim import

### DIFF
--- a/discord/ext/commands/__init__.py
+++ b/discord/ext/commands/__init__.py
@@ -10,3 +10,4 @@ from .converter import *
 from .cooldowns import *
 from .cog import *
 from .flags import *
+from .params import *


### PR DESCRIPTION
## Summary

Fixes inability to import `Param`/`option_enum`/etc. from the `discord.ext.commands` shim.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
