### PR TITLE
Add default_auto_archive_duration to __repr__

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -181,6 +181,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             ('nsfw', self.nsfw),
             ('news', self.is_news()),
             ('category_id', self.category_id),
+            ('default_auto_archive_duration', self.default_auto_archive_duration),
         ]
         joined = ' '.join('%s=%r' % t for t in attrs)
         return f'<{self.__class__.__name__} {joined}>'


### PR DESCRIPTION
## Summary

For debugging and logging purposes, this is quite handy to have.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
