### PR TITLE
Support animated guild banners

### DIFF
--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -236,12 +236,12 @@ class Asset(AssetMixin):
         )
 
     @classmethod
-    def _from_user_banner(cls, state, user_id: int, banner_hash: str) -> Asset:
+    def _from_banner(cls, state, id: int, banner_hash: str) -> Asset:
         animated = banner_hash.startswith('a_')
         format = 'gif' if animated else 'png'
         return cls(
             state,
-            url=f'{cls.BASE}/banners/{user_id}/{banner_hash}.{format}?size=512',
+            url=f'{cls.BASE}/banners/{id}/{banner_hash}.{format}?size=1024',
             key=banner_hash,
             animated=animated
         )

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -201,6 +201,7 @@ class Guild(Hashable):
 
         They are currently as follows:
 
+        - ``ANIMATED_BANNER``: Guild can upload an animated banner.
         - ``ANIMATED_ICON``: Guild can upload an animated icon.
         - ``BANNER``: Guild can upload and use a banner. (i.e. :attr:`.banner`)
         - ``COMMERCE``: Guild can sell things using store channels.
@@ -888,7 +889,7 @@ class Guild(Hashable):
         """Optional[:class:`Asset`]: Returns the guild's banner asset, if available."""
         if self._banner is None:
             return None
-        return Asset._from_guild_image(self._state, self.id, self._banner, path='banners')
+        return Asset._from_banner(self._state, self.id, self._banner)
 
     @property
     def splash(self) -> Optional[Asset]:
@@ -1421,6 +1422,7 @@ class Guild(Hashable):
             Could be ``None`` to denote removal of the icon.
         banner: :class:`bytes`
             A :term:`py:bytes-like object` representing the banner.
+            GIF is only available to guilds that contain ``ANIMATED_BANNER`` in :attr:`Guild.features`.
             Could be ``None`` to denote removal of the banner. This is only available to guilds that contain
             ``BANNER`` in :attr:`Guild.features`.
         splash: :class:`bytes`

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -194,7 +194,7 @@ class PartialInviteGuild:
         """Optional[:class:`Asset`]: Returns the guild's banner asset, if available."""
         if self._banner is None:
             return None
-        return Asset._from_guild_image(self._state, self.id, self._banner, path='banners')
+        return Asset._from_banner(self._state, self.id, self._banner)
 
     @property
     def splash(self) -> Optional[Asset]:

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -75,6 +75,7 @@ VerificationLevel = Literal[0, 1, 2, 3, 4]
 NSFWLevel = Literal[0, 1, 2, 3]
 PremiumTier = Literal[0, 1, 2, 3]
 GuildFeature = Literal[
+    'ANIMATED_BANNER',
     'ANIMATED_ICON',
     'BANNER',
     'COMMERCE',

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -184,7 +184,7 @@ class BaseUser(_UserTag):
         """
         if self._banner is None:
             return None
-        return Asset._from_user_banner(self._state, self.id, self._banner)
+        return Asset._from_banner(self._state, self.id, self._banner)
 
     @property
     def accent_colour(self) -> Optional[Colour]:


### PR DESCRIPTION
## Summary

Pretty self-explanatory.

Could be considered a breaking change, however `_from_user_banner` isn't documented, so it should be alright.

See https://github.com/discord/discord-api-docs/pull/3948.

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
