### PR TITLE
Add 'on_raw_member_screening_reject' event, rename previous event

### DIFF
--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -538,7 +538,6 @@ class Intents(BaseFlags):
         - :func:`on_member_join`
         - :func:`on_member_remove`
         - :func:`on_member_update`
-        - :func:`on_member_screening_decline`
         - :func:`on_user_update`
 
         This also corresponds to the following attributes and classes in terms of cache:
@@ -555,6 +554,10 @@ class Intents(BaseFlags):
         - :attr:`User.name`
         - :attr:`User.avatar`
         - :attr:`User.discriminator`
+
+        Note that due to an implicit relationship this also corresponds to the following events:
+
+        - :func:`on_member_screening_reject`
 
         For more information go to the :ref:`member intent documentation <need_members_intent>`.
 

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         MessageUpdateEvent,
         ReactionClearEvent,
         ReactionClearEmojiEvent,
+        MemberScreeningRejectEvent,
         IntegrationDeleteEvent,
     )
     from .message import Message
@@ -48,6 +49,7 @@ __all__ = (
     "RawReactionActionEvent",
     "RawReactionClearEvent",
     "RawReactionClearEmojiEvent",
+    "RawMemberScreeningRejectEvent",
     "RawIntegrationDeleteEvent",
 )
 
@@ -248,6 +250,26 @@ class RawReactionClearEmojiEvent(_RawReprMixin):
             self.guild_id: Optional[int] = int(data["guild_id"])
         except KeyError:
             self.guild_id: Optional[int] = None
+
+
+class RawMemberScreeningRejectEvent(_RawReprMixin):
+    """Represents the payload for a :func:`on_raw_member_screening_reject` event.
+
+    .. versionadded:: 2.3
+
+    Attributes
+    -----------
+    guild_id: :class:`int`
+        The guild ID of the guild which the user left.
+    user_id: :class:`int`
+        The user ID of the user who left the guild.
+    """
+
+    __slots__ = ("guild_id", "user_id")
+
+    def __init__(self, data: MemberScreeningRejectEvent) -> None:
+        self.guild_id: int = int(data["guild_id"])
+        self.user_id: int = int(data["user_id"])
 
 
 class RawIntegrationDeleteEvent(_RawReprMixin):

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1224,7 +1224,8 @@ class ConnectionState:
             )
 
     def parse_guild_join_request_delete(self, data) -> None:
-        guild = self._get_guild(int(data["guild_id"]))
+        raw = RawMemberScreeningRejectEvent(data)
+        guild = self._get_guild(raw.guild_id)
         if guild is None:
             _log.debug(
                 "GUILD_JOIN_REQUEST_DELETE referencing an unknown guild ID: %s. Discarding.",
@@ -1232,9 +1233,10 @@ class ConnectionState:
             )
             return
 
-        member = guild.get_member(int(data["user_id"]))
+        self.dispatch("raw_member_screening_reject", raw)
+        member = guild.get_member(raw.user_id)
         if member is not None:
-            self.dispatch("member_screening_decline", member)
+            self.dispatch("member_screening_reject", member)
 
     def parse_guild_emojis_update(self, data) -> None:
         guild = self._get_guild(int(data["guild_id"]))

--- a/disnake/types/raw_models.py
+++ b/disnake/types/raw_models.py
@@ -78,6 +78,11 @@ class ReactionClearEmojiEvent(_ReactionClearEmojiEventOptional):
     emoji: PartialEmoji
 
 
+class MemberScreeningRejectEvent(TypedDict):
+    guild_id: Snowflake
+    user_id: Snowflake
+
+
 class _IntegrationDeleteEventOptional(TypedDict, total=False):
     application_id: Snowflake
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -891,16 +891,34 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param after: The updated member's updated info.
     :type after: :class:`Member`
 
-.. function:: on_member_screening_decline(member)
+.. function:: on_member_screening_reject(member)
 
     Called when a :class:`Member` leaves a :class:`Guild` without completing
     membership screening. This does not replace :func:`on_member_remove`;
-    both will be called.
+    both will be called, given the approriate intents are enabled.
+
+    If the member is not found in the internal member cache, this event will
+    not be called (hence the requirement for :attr:`Intents.members`).
+    Consider using :func:`on_raw_member_screening_reject` instead.
 
     This requires :attr:`Intents.members` to be enabled.
 
+    .. versionadded:: 2.3
+
     :param member: The member that left.
     :type member: :class:`Member`
+
+.. function:: on_raw_member_screening_reject(payload)
+
+    Called when a :class:`Member` leaves a :class:`Guild` without completing
+    membership screening. Unlike :func:`on_member_screening_reject`, this is
+    called regardless of the state of the internal member cache, and therefore
+    does not require :attr:`Intents.members` to be enabled.
+
+    .. versionadded:: 2.3
+
+    :param payload: The raw event payload data.
+    :type payload: :class:`RawMemberScreeningRejectEvent`
 
 .. function:: on_presence_update(before, after)
 
@@ -4145,6 +4163,14 @@ RawReactionClearEmojiEvent
 .. attributetable:: RawReactionClearEmojiEvent
 
 .. autoclass:: RawReactionClearEmojiEvent()
+    :members:
+
+RawMemberScreeningRejectEvent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: RawMemberScreeningRejectEvent
+
+.. autoclass:: RawMemberScreeningRejectEvent()
     :members:
 
 RawIntegrationDeleteEvent


### PR DESCRIPTION
## Summary

Followup to 659966ee528cf36d87b66c3cf9b4967e318063d0 and #107.

This PR adds an `on_raw_member_screening_reject` that'll always fire regardless of the `members` intent; the previously added `on_member_screening_decline` is also renamed to `on_member_screening_reject`.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
