### PR TITLE
Implement guild-specific member banners

### DIFF
--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -190,6 +190,17 @@ class Asset(AssetMixin):
         )
 
     @classmethod
+    def _from_guild_banner(cls, state, guild_id: int, member_id: int, banner: str) -> Asset:
+        animated = banner.startswith("a_")
+        format = "gif" if animated else "png"
+        return cls(
+            state,
+            url=f"{cls.BASE}/guilds/{guild_id}/users/{member_id}/banners/{banner}.{format}?size=1024",
+            key=banner,
+            animated=animated,
+        )
+
+    @classmethod
     def _from_icon(cls, state, object_id: int, icon_hash: str, path: str) -> Asset:
         return cls(
             state,

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -289,6 +289,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         "_user",
         "_state",
         "_avatar",
+        "_banner",
     )
 
     if TYPE_CHECKING:
@@ -321,6 +322,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         self.nick: Optional[str] = data.get("nick", None)
         self.pending: bool = data.get("pending", False)
         self._avatar: Optional[str] = data.get("avatar")
+        self._banner: Optional[str] = data.get("banner")
 
     def __str__(self) -> str:
         return str(self._user)
@@ -567,6 +569,29 @@ class Member(disnake.abc.Messageable, _UserTag):
         if self._avatar is None:
             return None
         return Asset._from_guild_avatar(self._state, self.guild.id, self.id, self._avatar)
+
+    @property
+    def display_banner(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns the member's display banner.
+
+        For regular members this is just their banner, but
+        if they have a guild specific banner then that
+        is returned instead.
+
+        .. versionadded:: 2.3
+        """
+        return self.guild_banner or self._user.banner
+
+    @property
+    def guild_banner(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns an :class:`Asset` for the guild banner
+        the member has. If unavailable, ``None`` is returned.
+
+        .. versionadded:: 2.3
+        """
+        if self._banner is None:
+            return None
+        return Asset._from_guild_banner(self._state, self.guild.id, self.id, self._banner)
 
     @property
     def activity(self) -> Optional[ActivityTypes]:

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -189,6 +189,16 @@ class BaseUser(_UserTag):
         return Asset._from_banner(self._state, self.id, self._banner)
 
     @property
+    def display_banner(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns the users's display banner, if available.
+
+        For regular users this is just their uploaded banner.
+
+        .. versionadded:: 2.3
+        """
+        return self.banner
+
+    @property
     def accent_colour(self) -> Optional[Colour]:
         """Optional[:class:`Colour`]: Returns the user's accent colour, if applicable.
 


### PR DESCRIPTION
## Summary

Title should be self-explanatory. The client feature is still experimental, so I'll keep this as a draft until it gets rolled out properly.

*Edit*:
Welp, looks like I was a bit too ambitious with this PR. Bots currently can't access guild-specific banners - there's a feature request for it in api-docs, I'll wait and see what happens with that.

## Checklist

- [ ] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
