### PR TITLE
Fix documentation warnings.

### DIFF
--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -113,8 +113,6 @@ class ApplicationCommandInteraction(Interaction):
         Returns an object responsible for handling responding to the interaction.
     followup: :class:`Webhook`
         Returns the follow up webhook for follow up interactions.
-    type: :class:`InteractionType`
-        The interaction type.
     token: :class:`str`
         The token to continue the interaction. These are valid
         for 15 minutes.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4262,22 +4262,6 @@ PartialMessage
 .. autoclass:: PartialMessage
     :members:
 
-Option
-~~~~~~
-
-.. attributetable:: Option
-
-.. autoclass:: Option()
-    :members:
-
-OptionChoice
-~~~~~~~~~~~~
-
-.. attributetable:: OptionChoice
-
-.. autoclass:: OptionChoice()
-    :members:
-
 SelectOption
 ~~~~~~~~~~~~~
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -11,7 +11,7 @@ Changelog
 This page keeps a detailed human friendly rendering of what's new and changed
 in specific versions.
 
-.. _vp2p2p0
+.. _vp2p2p0:
 
 v2.2.0
 -------
@@ -30,7 +30,7 @@ New Features
 - |commands| Add :meth:`Cog.cog_load <ext.commands.Cog.cog_load>`
 - |commands| Error handlers now can cancel each other by returning ``True``
 
-.. _vp2p1p5
+.. _vp2p1p5:
 
 v2.1.5
 -------
@@ -52,7 +52,7 @@ Bug Fixes
 - Command deletions on reconnections
 - Pending sync tasks on loop termination
 
-.. _vp2p1p4
+.. _vp2p1p4:
 
 v2.1.4
 -------


### PR DESCRIPTION
## Summary

I got the following warnings while building the documentation with sphinx.
```
C:\Users\...\Documents\disnake\disnake\interactions\application_command.py:docstring of disnake.interactions.application_command.ApplicationCommandInteraction:79: WARNING: duplicate object description of disnake.ApplicationCommandInteraction.type, other instance in api, use :noindex: for one of them
C:\Users\...\Documents\disnake\disnake\app_commands.py:docstring of disnake.app_commands.Option:1: WARNING: duplicate object description of disnake.Option, other instance in api, use :noindex: for one of them
C:\Users\...\Documents\disnake\disnake\app_commands.py:docstring of disnake.app_commands.Option:1: WARNING: duplicate object description of disnake.app_commands.Option, other instance in api, use :noindex: for one of them
C:\Users\...\Documents\disnake\disnake\app_commands.py:docstring of disnake.app_commands.Option.add_choice:1: WARNING: duplicate object description of disnake.Option.add_choice, other instance in api, use :noindex: for one of them
C:\Users\...\Documents\disnake\disnake\app_commands.py:docstring of disnake.app_commands.Option.add_option:1: WARNING: duplicate object description of disnake.Option.add_option, other instance in api, use :noindex: for one of them
C:\Users\...\Documents\disnake\disnake\app_commands.py:docstring of disnake.app_commands.OptionChoice:1: WARNING: duplicate object description of disnake.OptionChoice, other instance in api, use :noindex: for one of them
C:\Users\...\Documents\disnake\disnake\app_commands.py:docstring of disnake.app_commands.OptionChoice:1: WARNING: duplicate object description of disnake.app_commands.OptionChoice, other instance in api, use :noindex: for one of them
C:\Users\...\Documents\disnake\docs\whats_new.rst:14: WARNING: malformed hyperlink target.
C:\Users\...\Documents\disnake\docs\whats_new.rst:33: WARNING: malformed hyperlink target.
C:\Users\...\Documents\disnake\docs\whats_new.rst:55: WARNING: malformed hyperlink target.
```

This doesn't really change something, documentation still works good with those warnings, but just in case I decided to fix them.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
