### PR TITLE
Improve warnings, fix `DeprecationWarning` filters

### DIFF
--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -60,6 +60,7 @@ from .stage_instance import *
 from .interactions import *
 from .components import *
 from .threads import *
+from .custom_warnings import *
 
 
 class VersionInfo(NamedTuple):

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -26,8 +26,10 @@ from abc import ABC
 import re
 import math
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Union, cast
+import warnings
 
 from .abc import User
+from .custom_warnings import ConfigWarning
 from .enums import (
     ApplicationCommandType,
     ChannelType,
@@ -708,7 +710,9 @@ class UnresolvedGuildApplicationCommandPermissions:
             users = self.users or {}
             common_ids = owner_ids.keys() & users.keys()
             if any(users[id] != owner_ids[id] for id in common_ids):
-                print("[WARNING] Conflicting permissions for owner(s) provided in users")
+                warnings.warn(
+                    "Conflicting permissions for owner(s) provided in users", ConfigWarning
+                )
 
             resolved_users = {**users, **owner_ids}
         else:

--- a/disnake/custom_warnings.py
+++ b/disnake/custom_warnings.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+__all__ = (
+    "DiscordWarning",
+    "ConfigWarning",
+    "SyncWarning",
+)
+
+
+class DiscordWarning(Warning):
+    """
+    Base warning class for disnake
+    """
+
+    pass
+
+
+class ConfigWarning(DiscordWarning):
+    """
+    Warning class related to configuration issues
+    """
+
+    pass
+
+
+class SyncWarning(DiscordWarning):
+    """
+    Warning class for application command synchronization issues
+    """
+
+    pass

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -30,7 +30,7 @@ import warnings
 
 from disnake.app_commands import ApplicationCommand, UnresolvedGuildApplicationCommandPermissions
 from disnake.enums import ApplicationCommandType
-from disnake.utils import async_all, maybe_coroutine
+from disnake.utils import async_all, maybe_coroutine, warn_deprecated
 
 from .cooldowns import BucketType, CooldownMapping, MaxConcurrency
 from .errors import *
@@ -552,9 +552,9 @@ def guild_permissions(
         whether to allow/deny the bot owner(s) to use the command. Set to ``None`` to ignore.
     """
     if kwargs:
-        warnings.warn(
+        warn_deprecated(
             f"guild_permissions got unexpected deprecated keyword arguments: {', '.join(map(repr, kwargs))}",
-            DeprecationWarning,
+            stacklevel=2,
         )
         roles = roles or kwargs.get("role_ids")
         users = users or kwargs.get("user_ids")

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -41,6 +41,7 @@ from typing import (
     Union,
     cast,
 )
+import warnings
 
 import disnake
 
@@ -60,6 +61,7 @@ from disnake.app_commands import (
     ApplicationCommand,
     PartialGuildApplicationCommandPermissions,
 )
+from disnake.custom_warnings import ConfigWarning, SyncWarning
 from disnake.enums import ApplicationCommandType
 
 if TYPE_CHECKING:
@@ -689,7 +691,7 @@ class InteractionBotBase(CommonBotBase):
                 to_send.extend(diff["change_type"])
                 await self.bulk_overwrite_global_commands(to_send)
             except Exception as e:
-                print(f"[WARNING] Failed to overwrite global commands due to {e}")
+                warnings.warn(f"Failed to overwrite global commands due to {e}", SyncWarning)
         # Same process but for each specified guild individually.
         # Notice that we're not doing this for every single guild for optimisation purposes.
         # See the note in :meth:`_cache_application_commands` about guild app commands.
@@ -720,8 +722,9 @@ class InteractionBotBase(CommonBotBase):
                     to_send.extend(diff["change_type"])
                     await self.bulk_overwrite_guild_commands(guild_id, to_send)
                 except Exception as e:
-                    print(
-                        f"[WARNING] Failed to overwrite commands in <Guild id={guild_id}> due to {e}"
+                    warnings.warn(
+                        f"Failed to overwrite commands in <Guild id={guild_id}> due to {e}",
+                        SyncWarning,
                     )
         # Last debug message
         if self._sync_commands_debug:
@@ -741,9 +744,10 @@ class InteractionBotBase(CommonBotBase):
 
         if not self._sync_permissions:
             if guilds_to_cache:
-                print(
-                    "[WARNING] You're using the @commands.guild_permissions decorator, however,"
-                    f" the 'sync_permissions' kwarg of '{self.__class__.__name__}' is set to 'False'."
+                warnings.warn(
+                    "You're using the @commands.guild_permissions decorator, however, the"
+                    f" 'sync_permissions' kwarg of '{self.__class__.__name__}' is set to 'False'.",
+                    ConfigWarning,
                 )
             return
 
@@ -813,8 +817,9 @@ class InteractionBotBase(CommonBotBase):
             try:
                 await self.bulk_edit_command_permissions(guild_id, new_array)
             except Exception as err:
-                print(
-                    f"[WARNING] Failed to overwrite permissions in <Guild id={guild_id}> due to {err}"
+                warnings.warn(
+                    f"Failed to overwrite permissions in <Guild id={guild_id}> due to {err}",
+                    SyncWarning,
                 )
             finally:
                 if self._sync_commands_debug:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4511,3 +4511,22 @@ Exception Hierarchy
                 - :exc:`Forbidden`
                 - :exc:`NotFound`
                 - :exc:`DiscordServerError`
+
+
+Warnings
+----------
+
+.. autoclass:: DiscordWarning
+
+.. autoclass:: ConfigWarning
+
+.. autoclass:: SyncWarning
+
+Warning Hierarchy
+~~~~~~~~~~~~~~~~~~~
+
+.. exception_hierarchy::
+
+    - :class:`DiscordWarning`
+        - :class:`ConfigWarning`
+        - :class:`SyncWarning`


### PR DESCRIPTION
## Summary

This PR replaces calls like `print('[WARNING] ...')` with `warnings.warn(...)`, and fixes displaying deprecation warnings.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
