### PR TITLE
Change how params are detected

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -413,9 +413,11 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
     parameters = list(sig.parameters.values())
 
     # hacky I suppose
-    predicate = lambda x: x.annotation is inspect._empty and x.name != "self" or x.annotation is Interaction
+    predicate = (
+        lambda x: x.annotation is inspect._empty and x.name != "self" or x.annotation is Interaction
+    )
     inter_param = disnake.utils.find(predicate, parameters)
-    parameters = parameters[parameters.index(inter_param) + 1:]
+    parameters = parameters[parameters.index(inter_param) + 1 :]
     type_hints = get_type_hints(command.callback)
     docstring = command.docstring["params"]
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -414,7 +414,10 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
 
     # hacky I suppose
     predicate = (
-        lambda x: x.annotation is inspect._empty and x.name != "self" or x.annotation is Interaction
+        lambda x: x.annotation is inspect._empty
+        and x.name != "self"
+        or isinstance(x.annotation, type)
+        and issubclass(x.annotation, Interaction)
     )
     inter_param = disnake.utils.find(predicate, parameters)
     parameters = parameters[parameters.index(inter_param) + 1 :]

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -47,13 +47,12 @@ import disnake
 from disnake.app_commands import Option, OptionChoice
 from disnake.channel import _channel_type_factory
 from disnake.enums import ChannelType, OptionType, try_enum_to_int
+from disnake.interactions import ApplicationCommandInteraction as Interaction
 
 from . import errors
 from .converter import CONVERTER_MAPPING
 
 if TYPE_CHECKING:
-    from disnake.interactions import ApplicationCommandInteraction as Interaction
-
     from .slash_core import InvokableSlashCommand, SubCommand
 
     AnySlashCommand = Union[InvokableSlashCommand, SubCommand]
@@ -414,9 +413,9 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
     parameters = list(sig.parameters.values())
 
     # hacky I suppose
-    cog = parameters[0].name == "self" if command.cog is None else True
-    inter_param = parameters[1] if cog else parameters[0]
-    parameters = parameters[2:] if cog else parameters[1:]
+    predicate = lambda x: x.annotation is inspect._empty and x.name != "self" or x.annotation is Interaction
+    inter_param = disnake.utils.find(predicate, parameters)
+    parameters = parameters[parameters.index(inter_param) + 1:]
     type_hints = get_type_hints(command.callback)
     docstring = command.docstring["params"]
 


### PR DESCRIPTION
## Summary

Currently, we get parameters by simply indexing the first parameter if it's not within a cog and the second parameter if it is within a cog. This approach holds us back from doing some more complex things. Below is an example of that.

The example below shows an application where the config (settings) are needed within most commands. The decorator will inject a parameter, so there's easy access to the config. The config for each guild is cached, and the decorator would handle the logic for updating and retrieving this internal cache.

```py
def settings(fn):
    async def decorator(cls, interaction, *args, **kwargs):
        settings = interaction.bot.settings[interaction.guild.id]
        await disnake.utils.maybe_coroutine(fn, cls, settings, interaction, *args, **kwargs)
    return decorator


class Config(commands.Cog):
    def __init__(self, bot):
        self.bot = bot

    @settings
    @commands.slash_command(name='prefix', description='Set a custom prefix for the guild')
    async def set_prefix(
        self,
        settings,
        interaction,
        prefix: str = commands.Param(description='The prefix you want for the guild'),
    ):
        # Some cool stuff
        settings.prefix = prefix
        await settings.save()
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
