### PR TITLE
Add `InteractionBot` and `AutoShardedInteractionBot` documentation.

### DIFF
--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -949,7 +949,7 @@ class InteractionBotBase(CommonBotBase):
             The function that was used as a global check.
         call_once: :class:`bool`
             If the function should only be called once per
-            :meth:`.invoke` call.
+            :meth:`invoke` call.
         slash_commands: :class:`bool`
             If this check is for slash commands.
         user_commands: :class:`bool`
@@ -1100,7 +1100,7 @@ class InteractionBotBase(CommonBotBase):
         ----------
         call_once: :class:`bool`
             If the function should only be called once per
-            :meth:`.invoke` call.
+            :meth:`invoke` call.
         text_commands: :class:`bool`
             If this check is for text commands.
         slash_commands: :class:`bool`
@@ -1153,7 +1153,7 @@ class InteractionBotBase(CommonBotBase):
         return await disnake.utils.async_all(f(inter) for f in checks)  # type: ignore
 
     def before_slash_command_invoke(self, coro: CFT) -> CFT:
-        """Similar to :meth:`.before_invoke` but for slash commands."""
+        """Similar to :meth:`Bot.before_invoke` but for slash commands."""
 
         if not asyncio.iscoroutinefunction(coro):
             raise TypeError("The pre-invoke hook must be a coroutine.")
@@ -1162,7 +1162,7 @@ class InteractionBotBase(CommonBotBase):
         return coro
 
     def after_slash_command_invoke(self, coro: CFT) -> CFT:
-        """Similar to :meth:`.after_invoke` but for slash commands."""
+        """Similar to :meth:`Bot.after_invoke` but for slash commands."""
 
         if not asyncio.iscoroutinefunction(coro):
             raise TypeError("The post-invoke hook must be a coroutine.")
@@ -1171,7 +1171,7 @@ class InteractionBotBase(CommonBotBase):
         return coro
 
     def before_user_command_invoke(self, coro: CFT) -> CFT:
-        """Similar to :meth:`.before_invoke` but for user commands."""
+        """Similar to :meth:`Bot.before_invoke` but for user commands."""
 
         if not asyncio.iscoroutinefunction(coro):
             raise TypeError("The pre-invoke hook must be a coroutine.")
@@ -1180,7 +1180,7 @@ class InteractionBotBase(CommonBotBase):
         return coro
 
     def after_user_command_invoke(self, coro: CFT) -> CFT:
-        """Similar to :meth:`.after_invoke` but for user commands."""
+        """Similar to :meth:`Bot.after_invoke` but for user commands."""
 
         if not asyncio.iscoroutinefunction(coro):
             raise TypeError("The post-invoke hook must be a coroutine.")
@@ -1189,7 +1189,7 @@ class InteractionBotBase(CommonBotBase):
         return coro
 
     def before_message_command_invoke(self, coro: CFT) -> CFT:
-        """Similar to :meth:`.before_invoke` but for message commands."""
+        """Similar to :meth:`Bot.before_invoke` but for message commands."""
 
         if not asyncio.iscoroutinefunction(coro):
             raise TypeError("The pre-invoke hook must be a coroutine.")
@@ -1198,7 +1198,7 @@ class InteractionBotBase(CommonBotBase):
         return coro
 
     def after_message_command_invoke(self, coro: CFT) -> CFT:
-        """Similar to :meth:`.after_invoke` but for message commands."""
+        """Similar to :meth:`Bot.after_invoke` but for message commands."""
 
         if not asyncio.iscoroutinefunction(coro):
             raise TypeError("The post-invoke hook must be a coroutine.")

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -61,6 +61,78 @@ AutoShardedBot
 .. autoclass:: disnake.ext.commands.AutoShardedBot
     :members:
 
+InteractionBot
+~~~~~~~~~~~~~~~~
+
+.. attributetable:: disnake.ext.commands.InteractionBot
+
+.. autoclass:: disnake.ext.commands.InteractionBot
+    :members:
+    :inherited-members:
+    :exclude-members: after_slash_command_invoke, after_user_command_invoke, after_message_command_invoke, before_slash_command_invoke, before_user_command_invoke, before_message_command_invoke, application_command_check, slash_command_check, user_command_check, message_command_check, slash_command_check_once, user_command_check_once, message_command_check_once, event, listen, slash_command, user_command, message_command
+
+    .. automethod:: InteractionBot.after_slash_command_invoke()
+        :decorator:
+
+    .. automethod:: InteractionBot.after_user_command_invoke()
+        :decorator:
+
+    .. automethod:: InteractionBot.after_message_command_invoke()
+        :decorator:
+
+    .. automethod:: InteractionBot.before_slash_command_invoke()
+        :decorator:
+
+    .. automethod:: InteractionBot.before_user_command_invoke()
+        :decorator:
+
+    .. automethod:: InteractionBot.before_message_command_invoke()
+        :decorator:
+    
+    .. automethod:: InteractionBot.application_command_check()
+        :decorator:
+
+    .. automethod:: InteractionBot.slash_command_check()
+        :decorator:
+
+    .. automethod:: InteractionBot.user_command_check()
+        :decorator:
+
+    .. automethod:: InteractionBot.message_command_check()
+        :decorator:
+
+    .. automethod:: InteractionBot.slash_command_check_once()
+        :decorator:
+
+    .. automethod:: InteractionBot.user_command_check_once()
+        :decorator:
+
+    .. automethod:: InteractionBot.message_command_check_once()
+        :decorator:
+
+    .. automethod:: InteractionBot.slash_command(*args, **kwargs)
+        :decorator:
+
+    .. automethod:: InteractionBot.user_command(*args, **kwargs)
+        :decorator:
+
+    .. automethod:: InteractionBot.message_command(*args, **kwargs)
+        :decorator:
+
+    .. automethod:: InteractionBot.event()
+        :decorator:
+
+    .. automethod:: InteractionBot.listen(name=None)
+        :decorator:
+
+AutoShardedInteractionBot
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: disnake.ext.commands.AutoShardedInteractionBot
+
+.. autoclass:: disnake.ext.commands.AutoShardedInteractionBot
+    :members:
+
 Prefix Helpers
 ----------------
 


### PR DESCRIPTION
## Summary

I also fixed some warnings I got, here is the full trace back:
```
C:\Users\...\Documents\disnake\disnake\ext\commands\interaction_bot_base.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.after_slash_command_invoke:1: WARNING: more than one target found for cross-reference 'after_invoke': disnake.ext.commands.Bot.after_invoke, disnake.ext.commands.InvokableSlashCommand.after_invoke, disnake.ext.commands.SubCommand.after_invoke, disnake.ext.commands.SubCommandGroup.after_invoke, disnake.ext.commands.InvokableUserCommand.after_invoke, disnake.ext.commands.InvokableMessageCommand.after_invoke, disnake.ext.commands.Command.after_invoke, disnake.ext.commands.Group.after_invoke
C:\Users\...\Documents\disnake\disnake\ext\commands\interaction_bot_base.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.after_user_command_invoke:1: WARNING: more than one target found for cross-reference 'after_invoke': disnake.ext.commands.Bot.after_invoke, disnake.ext.commands.InvokableSlashCommand.after_invoke, disnake.ext.commands.SubCommand.after_invoke, disnake.ext.commands.SubCommandGroup.after_invoke, disnake.ext.commands.InvokableUserCommand.after_invoke, disnake.ext.commands.InvokableMessageCommand.after_invoke, disnake.ext.commands.Command.after_invoke, disnake.ext.commands.Group.after_invoke
C:\Users\...\Documents\disnake\disnake\ext\commands\interaction_bot_base.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.after_message_command_invoke:1: WARNING: more than one target found for cross-reference 'after_invoke': disnake.ext.commands.Bot.after_invoke, disnake.ext.commands.InvokableSlashCommand.after_invoke, disnake.ext.commands.SubCommand.after_invoke, disnake.ext.commands.SubCommandGroup.after_invoke, disnake.ext.commands.InvokableUserCommand.after_invoke, disnake.ext.commands.InvokableMessageCommand.after_invoke, disnake.ext.commands.Command.after_invoke, disnake.ext.commands.Group.after_invoke
C:\Users\...\Documents\disnake\disnake\ext\commands\interaction_bot_base.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.before_slash_command_invoke:1: WARNING: more than one target found for cross-reference 'before_invoke': disnake.ext.commands.Bot.before_invoke, disnake.ext.commands.InvokableSlashCommand.before_invoke, disnake.ext.commands.SubCommand.before_invoke, disnake.ext.commands.SubCommandGroup.before_invoke, disnake.ext.commands.InvokableUserCommand.before_invoke, disnake.ext.commands.InvokableMessageCommand.before_invoke, disnake.ext.commands.Command.before_invoke, disnake.ext.commands.Group.before_invoke
C:\Users\...\Documents\disnake\disnake\ext\commands\interaction_bot_base.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.before_user_command_invoke:1: WARNING: more than one target found for cross-reference 'before_invoke': disnake.ext.commands.Bot.before_invoke, disnake.ext.commands.InvokableSlashCommand.before_invoke, disnake.ext.commands.SubCommand.before_invoke, disnake.ext.commands.SubCommandGroup.before_invoke, disnake.ext.commands.InvokableUserCommand.before_invoke, disnake.ext.commands.InvokableMessageCommand.before_invoke, disnake.ext.commands.Command.before_invoke, disnake.ext.commands.Group.before_invoke
C:\Users\...\Documents\disnake\disnake\ext\commands\interaction_bot_base.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.before_message_command_invoke:1: WARNING: more than one target found for cross-reference 'before_invoke': disnake.ext.commands.Bot.before_invoke, disnake.ext.commands.InvokableSlashCommand.before_invoke, disnake.ext.commands.SubCommand.before_invoke, disnake.ext.commands.SubCommandGroup.before_invoke, disnake.ext.commands.InvokableUserCommand.before_invoke, disnake.ext.commands.InvokableMessageCommand.before_invoke, disnake.ext.commands.Command.before_invoke, disnake.ext.commands.Group.before_invoke
C:\Users\...\Documents\disnake\disnake\ext\commands\interaction_bot_base.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.application_command_check:23: WARNING: more than one target found for cross-reference 'invoke': disnake.ext.commands.Bot.invoke, disnake.ext.commands.InvokableSlashCommand.invoke, disnake.ext.commands.SubCommand.invoke, disnake.ext.commands.Context.invoke
C:\Users\...\Documents\disnake\disnake\ext\commands\bot.py:docstring of disnake.ext.commands.interaction_bot_base.InteractionBotBase.add_app_command_check:10: WARNING: more than one target found for cross-reference 'invoke': disnake.ext.commands.Bot.invoke, disnake.ext.commands.InvokableSlashCommand.invoke, disnake.ext.commands.SubCommand.invoke, disnake.ext.commands.Context.invoke
```

Here is an example of how it would look like: https://disnake-interaction-bot.readthedocs.io/en/latest/ext/commands/api.html#interactionbot

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
