### PR TITLE
Always close files after requests

### DIFF
--- a/disnake/message.py
+++ b/disnake/message.py
@@ -189,7 +189,12 @@ async def _edit_handler(
         else:
             payload["components"] = []
 
-    data = await msg._state.http.edit_message(msg.channel.id, msg.id, **payload, files=files)
+    try:
+        data = await msg._state.http.edit_message(msg.channel.id, msg.id, **payload, files=files)
+    finally:
+        if files:
+            for f in files:
+                f.close()
     message = Message(state=msg._state, channel=msg.channel, data=data)
 
     if view and not view.is_finished():

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1493,16 +1493,21 @@ class Webhook(BaseWebhook):
         if thread is not MISSING:
             thread_id = thread.id
 
-        data = await adapter.execute_webhook(
-            self.id,
-            self.token,
-            session=self.session,
-            payload=params.payload,
-            multipart=params.multipart,
-            files=params.files,
-            thread_id=thread_id,
-            wait=wait,
-        )
+        try:
+            data = await adapter.execute_webhook(
+                self.id,
+                self.token,
+                session=self.session,
+                payload=params.payload,
+                multipart=params.multipart,
+                files=params.files,
+                thread_id=thread_id,
+                wait=wait,
+            )
+        finally:
+            if params.files:
+                for f in params.files:
+                    f.close()
 
         msg = None
         if wait:
@@ -1679,15 +1684,20 @@ class Webhook(BaseWebhook):
             previous_allowed_mentions=previous_mentions,
         )
         adapter = async_context.get()
-        data = await adapter.edit_webhook_message(
-            self.id,
-            self.token,
-            message_id,
-            session=self.session,
-            payload=params.payload,
-            multipart=params.multipart,
-            files=params.files,
-        )
+        try:
+            data = await adapter.edit_webhook_message(
+                self.id,
+                self.token,
+                message_id,
+                session=self.session,
+                payload=params.payload,
+                multipart=params.multipart,
+                files=params.files,
+            )
+        finally:
+            if params.files:
+                for f in params.files:
+                    f.close()
 
         message = self._create_message(data)
         if view and not view.is_finished():

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -996,16 +996,21 @@ class SyncWebhook(BaseWebhook):
         if thread is not MISSING:
             thread_id = thread.id
 
-        data = adapter.execute_webhook(
-            self.id,
-            self.token,
-            session=self.session,
-            payload=params.payload,
-            multipart=params.multipart,
-            files=params.files,
-            thread_id=thread_id,
-            wait=wait,
-        )
+        try:
+            data = adapter.execute_webhook(
+                self.id,
+                self.token,
+                session=self.session,
+                payload=params.payload,
+                multipart=params.multipart,
+                files=params.files,
+                thread_id=thread_id,
+                wait=wait,
+            )
+        finally:
+            if params.files:
+                for f in params.files:
+                    f.close()
         if wait:
             return self._create_message(data)
 
@@ -1141,15 +1146,20 @@ class SyncWebhook(BaseWebhook):
             previous_allowed_mentions=previous_mentions,
         )
         adapter: WebhookAdapter = _get_webhook_adapter()
-        data = adapter.edit_webhook_message(
-            self.id,
-            self.token,
-            message_id,
-            session=self.session,
-            payload=params.payload,
-            multipart=params.multipart,
-            files=params.files,
-        )
+        try:
+            data = adapter.edit_webhook_message(
+                self.id,
+                self.token,
+                message_id,
+                session=self.session,
+                payload=params.payload,
+                multipart=params.multipart,
+                files=params.files,
+            )
+        finally:
+            if params.files:
+                for f in params.files:
+                    f.close()
         return self._create_message(data)
 
     def delete_message(self, message_id: int, /) -> None:


### PR DESCRIPTION
## Summary

This PR ensures that any files used in requests will be closed once the request finishes, instead of keeping them open until they are garbage collected.
Not closing files is technically not an issue in most cases, as CPython already closes files when they're garbage collected, usually once the ref count drops to zero. However, this behavior might be different in alternative implementations, and it's also just good practice in general.

## Checklist

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
