### PR TITLE
Check if options is None instead of if it evals false

### DIFF
--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -239,7 +239,7 @@ class SubCommand(InvokableApplicationCommand):
         self.docstring = utils.parse_docstring(func)
         description = description or self.docstring["description"]
 
-        if not options:
+        if options is None:
             options = expand_params(self)
 
         self.option = Option(
@@ -336,7 +336,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         self.docstring = utils.parse_docstring(func)
         description = description or self.docstring["description"]
 
-        if not options:
+        if options is None:
             options = expand_params(self)
 
         self.body: SlashCommand = SlashCommand(


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The expression `if not` is automatically expand the arguments of a slash command from the function signature.
However, say if a user wants to explicitly state that the slash command takes no arguments (even if the function it calls does), they can't. This is because `bool([]) == False`.
Instead it would be much more appropriate to use `is None` for the check in this situation.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
