### PR TITLE
Support setting slowmode on thread creation

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -328,8 +328,8 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             The new category for this channel. Can be ``None`` to remove the
             category.
         slowmode_delay: :class:`int`
-            Specifies the slowmode rate limit for user in this channel, in seconds.
-            A value of `0` disables slowmode. The maximum value possible is `21600`.
+            Specifies the slowmode rate limit for users in this channel, in seconds.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
         type: :class:`ChannelType`
             Change the type of this text channel. Currently, only conversion between
             :attr:`ChannelType.text` and :attr:`ChannelType.news` is supported. This

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -701,6 +701,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         message: Optional[Snowflake] = None,
         auto_archive_duration: ThreadArchiveDuration = None,
         type: Optional[ChannelType] = None,
+        invitable: bool = None,
         slowmode_delay: int = None,
         reason: Optional[str] = None,
     ) -> Thread:
@@ -728,6 +729,14 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             The type of thread to create. If a ``message`` is passed then this parameter
             is ignored, as a thread created with a message is always a public thread.
             By default this creates a private thread if this is ``None``.
+        invitable: :class:`bool`
+            Whether non-moderators can add other non-moderators to this thread.
+            Only available for private threads.
+            If a ``message`` is passed then this parameter is ignored, as a thread
+            created with a message is always a public thread.
+            Defaults to ``True``.
+
+            .. versionadded:: 2.3
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
@@ -759,6 +768,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
                 name=name,
                 auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
                 type=type.value,
+                invitable=invitable if invitable is not None else True,
                 rate_limit_per_user=slowmode_delay or 0,
                 reason=reason,
             )

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -699,8 +699,9 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         *,
         name: str,
         message: Optional[Snowflake] = None,
-        auto_archive_duration: ThreadArchiveDuration = MISSING,
+        auto_archive_duration: ThreadArchiveDuration = None,
         type: Optional[ChannelType] = None,
+        slowmode_delay: int = None,
         reason: Optional[str] = None,
     ) -> Thread:
         """|coro|
@@ -727,6 +728,12 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             The type of thread to create. If a ``message`` is passed then this parameter
             is ignored, as a thread created with a message is always a public thread.
             By default this creates a private thread if this is ``None``.
+        slowmode_delay: :class:`int`
+            Specifies the slowmode rate limit for users in this thread, in seconds.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
+            If not provided, slowmode is disabled.
+
+            .. versionadded:: 2.3
         reason: :class:`str`
             The reason for creating a new thread. Shows up on the audit log.
 
@@ -752,6 +759,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
                 name=name,
                 auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
                 type=type.value,
+                rate_limit_per_user=slowmode_delay or 0,
                 reason=reason,
             )
         else:
@@ -760,6 +768,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
                 message.id,
                 name=name,
                 auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
+                rate_limit_per_user=slowmode_delay or 0,
                 reason=reason,
             )
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1125,8 +1125,9 @@ class Guild(Hashable):
         topic: :class:`str`
             The new channel's topic.
         slowmode_delay: :class:`int`
-            Specifies the slowmode rate limit for user in this channel, in seconds.
-            The maximum value possible is `21600`.
+            Specifies the slowmode rate limit for users in this channel, in seconds.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
+            If not provided, slowmode is disabled.
         nsfw: :class:`bool`
             To mark the channel as NSFW or not.
         reason: Optional[:class:`str`]

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1018,11 +1018,13 @@ class HTTPClient:
         *,
         name: str,
         auto_archive_duration: threads.ThreadArchiveDuration,
+        rate_limit_per_user: int = 0,
         reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
         payload = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
+            "rate_limit_per_user": rate_limit_per_user,
         }
 
         route = Route(
@@ -1041,6 +1043,7 @@ class HTTPClient:
         auto_archive_duration: threads.ThreadArchiveDuration,
         type: threads.ThreadType,
         invitable: bool = True,
+        rate_limit_per_user: int = 0,
         reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
         payload = {
@@ -1048,6 +1051,7 @@ class HTTPClient:
             "auto_archive_duration": auto_archive_duration,
             "type": type,
             "invitable": invitable,
+            "rate_limit_per_user": rate_limit_per_user,
         }
 
         route = Route("POST", "/channels/{channel_id}/threads", channel_id=channel_id)

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1715,7 +1715,11 @@ class Message(Hashable):
         await self._state.http.clear_reactions(self.channel.id, self.id)
 
     async def create_thread(
-        self, *, name: str, auto_archive_duration: ThreadArchiveDuration = MISSING
+        self,
+        *,
+        name: str,
+        auto_archive_duration: ThreadArchiveDuration = None,
+        slowmode_delay: int = None,
     ) -> Thread:
         """|coro|
 
@@ -1735,6 +1739,12 @@ class Message(Hashable):
         auto_archive_duration: :class:`int`
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+        slowmode_delay: :class:`int`
+            Specifies the slowmode rate limit for users in this thread, in seconds.
+            A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
+            If not provided, slowmode is disabled.
+
+            .. versionadded:: 2.3
 
         Raises
         -------
@@ -1761,6 +1771,7 @@ class Message(Hashable):
             self.id,
             name=name,
             auto_archive_duration=auto_archive_duration or default_auto_archive_duration,
+            rate_limit_per_user=slowmode_delay or 0,
         )
         return Thread(guild=self.guild, state=self._state, data=data)
 

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -567,7 +567,7 @@ class Thread(Messageable, Hashable):
             The new duration in minutes before a thread is automatically archived for inactivity.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         slowmode_delay: :class:`int`
-            Specifies the slowmode rate limit for user in this thread, in seconds.
+            Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
 
         Raises


### PR DESCRIPTION
## Summary

This PR adds support for the `slowmode_delay` parameter on `TextChannel.create_thread` and `Message.create_thread`.
It also adds the previously missing `invitable` parameter to `TextChannel.create_thread`, which was already supported in `HTTPClient.start_thread_without_message`.

~~The slowmode parameter on channel threads (not message threads) doesn't seem to be deployed yet, sending it currently does not enable slowmode. I'll keep this PR as a draft for now because of that, and check back in a while to make sure the change is actually deployed.~~
fixed.

ref:
https://github.com/discord/discord-api-docs/commit/d56be860c5dd4c04e80337556d82eb3a04f971a2

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

---

~~update re slowmode on channel threads:~~
![image](https://user-images.githubusercontent.com/8530778/141866287-13066c70-d2ec-4fdf-a93f-16b0e98836f8.png)
