### PR TITLE
Prevent exception for unknown option parameters returned by API

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -161,6 +161,7 @@ class Option:
         autocomplete: bool = False,
         min_value: float = None,
         max_value: float = None,
+        **kwargs,
     ):
         assert name.islower(), f"Option name {name!r} must be lowercase"
 


### PR DESCRIPTION
## Summary

The API started (randomly?) returning `name_localizations` and `description_localizations` properties in response to requests on `applications/**/commands`. While this PR does not implement those properties, it ensures that no exception will be raised due to unhandled parameters being passed to `Option.__init__`.

If it fails on `GET` (doesn't seem to happen very often), all commands stop working as they're being recognized as deprecated; if it fails on `PUT` (more frequent), commands stop working as soon as a newly added command is invoked, for the same reasons.

## Checklist

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
