### PR TITLE
Updated `disable_view` example since it wasn't working.

### DIFF
--- a/examples/views/disable_view.py
+++ b/examples/views/disable_view.py
@@ -6,14 +6,7 @@ bot = commands.Bot(command_prefix=commands.when_mentioned_or("!"))
 
 class MyView(disnake.ui.View):
     def __init__(self):
-        super().__init__(timeout=30.0)
-
-    async def on_timeout(self):
-        # Once the view times out we disable the first button and remove the second button
-        self.children[0].disabled = True
-        self.remove_item(self.children[1])
-        # make sure to update the message with the new buttons
-        await self.message.edit(view=self)
+        super().__init__()
 
     @disnake.ui.button(label="Click to disable the view", style=disnake.ButtonStyle.red)
     async def disable(self, button: disnake.ui.Button, interaction: disnake.MessageInteraction):
@@ -21,22 +14,19 @@ class MyView(disnake.ui.View):
         # We disable every single component in this view
         for child in self.children:
             child.disabled = True
-        # make sure to update the message with the new buttons
-        await self.message.edit(view=self)
-
-        # Prevents on_timeout from being triggered after the buttons are disabled
-        self.stop()
+        # Make sure to update the message with the disabled buttons
+        await interaction.response.edit_message(view=self)
 
     @disnake.ui.button(label="Click to remove the view", style=disnake.ButtonStyle.red)
     async def remove(self, button: disnake.ui.Button, interaction: disnake.MessageInteraction):
         # view = None removes the view
-        await self.message.edit(view=None)
+        await interaction.response.edit_message(view=None)
 
 
 @bot.command()
 async def view(ctx):
 
-    # Defines our view so that we can use the message in on_timeout to edit it
+    # Defines our view
     view = MyView()
 
     # Sends a message with the view


### PR DESCRIPTION
## Summary

A few minutes ago, I wanted to check if it's possible to disable views in `on_timeout` callback, so I checked this example and tried it, but it doesn't work, since `ui.View` doesn't have `message` property.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
