### PR TITLE
Made "get_slash_command" work like "get_command"

### DIFF
--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -357,8 +357,7 @@ class InteractionBotBase(CommonBotBase):
         return command
 
     def get_slash_command(
-        self,
-        name: str
+        self, name: str
     ) -> Optional[Union[InvokableSlashCommand, SubCommandGroup, SubCommand]]:
         """Works like ``Bot.get_command``, but for slashes.
         Parameters

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -372,6 +372,9 @@ class InteractionBotBase(CommonBotBase):
             The slash command that was requested. If not found, returns ``None``.
         """
 
+        if not isinstance(name, str):
+            raise TypeError(f"Expected name to be str, not {name.__class__}")
+
         command = name.split()
         slash = self.all_slash_commands.get(command[0])
         if slash:

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -377,7 +377,7 @@ class InteractionBotBase(CommonBotBase):
 
         chain = name.split()
         slash = self.all_slash_commands.get(chain[0])
-        if not slash:
+        if slash is None:
             return None
 
         if len(chain) == 1:

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -383,13 +383,11 @@ class InteractionBotBase(CommonBotBase):
         if len(chain) == 1:
             return slash
         elif len(chain) == 2:
-            cmd = slash.children.get(chain[1])
-            return cmd
+            return slash.children.get(chain[1])
         elif len(chain) == 3:
             group = slash.children.get(chain[1])
             if isinstance(group, SubCommandGroup):
-                cmd = group.children.get(chain[2])
-                return cmd
+                return group.children.get(chain[2])
 
         return None
 

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -375,19 +375,21 @@ class InteractionBotBase(CommonBotBase):
         if not isinstance(name, str):
             raise TypeError(f"Expected name to be str, not {name.__class__}")
 
-        command = name.split()
-        slash = self.all_slash_commands.get(command[0])
-        if slash:
-            if len(command) == 1:
-                return slash
-            elif len(command) == 2:
-                cmd = slash.children.get(command[1])
+        chain = name.split()
+        slash = self.all_slash_commands.get(chain[0])
+        if not slash:
+            return None
+
+        if len(chain) == 1:
+            return slash
+        elif len(chain) == 2:
+            cmd = slash.children.get(chain[1])
+            return cmd
+        elif len(chain) == 3:
+            group = slash.children.get(chain[1])
+            if isinstance(group, SubCommandGroup):
+                cmd = group.children.get(chain[2])
                 return cmd
-            elif len(command) == 3:
-                group = slash.children.get(command[1])
-                if isinstance(group, SubCommandGroup):
-                    cmd = group.children.get(command[2])
-                    return cmd
 
         return None
 

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -361,6 +361,11 @@ class InteractionBotBase(CommonBotBase):
     ) -> Optional[Union[InvokableSlashCommand, SubCommandGroup, SubCommand]]:
         """Works like ``Bot.get_command``, but for slash commands.
 
+        If the name contains spaces, then it will assume that you are looking for a :class:`.SubCommand` or
+        a :class:`.SubCommandGroup`.
+        e.g: ``'foo bar'`` will get the sub command group, or the sub command ``bar`` of the top-level slash command
+        ``foo`` if found, otherwise ``None``.
+
         Parameters
         -----------
         name: :class:`str`
@@ -388,8 +393,6 @@ class InteractionBotBase(CommonBotBase):
             group = slash.children.get(chain[1])
             if isinstance(group, SubCommandGroup):
                 return group.children.get(chain[2])
-
-        return None
 
     def get_user_command(self, name: str) -> Optional[InvokableUserCommand]:
         """Get a :class:`.InvokableUserCommand` from the internal list

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -46,7 +46,7 @@ import warnings
 import disnake
 
 from .base_core import InvokableApplicationCommand
-from .slash_core import InvokableSlashCommand
+from .slash_core import InvokableSlashCommand, SubCommandGroup, SubCommand
 from .ctx_menus_core import InvokableUserCommand, InvokableMessageCommand
 from .common_bot_base import CommonBotBase
 from .context import Context
@@ -356,21 +356,36 @@ class InteractionBotBase(CommonBotBase):
             return None
         return command
 
-    def get_slash_command(self, name: str) -> Optional[InvokableSlashCommand]:
-        """Get a :class:`.InvokableSlashCommand` from the internal list
-        of commands.
-
+    def get_slash_command(
+        self,
+        name: str
+    ) -> Optional[Union[InvokableSlashCommand, SubCommandGroup, SubCommand]]:
+        """Works like ``Bot.get_command``, but for slashes.
         Parameters
         -----------
         name: :class:`str`
             The name of the slash command to get.
-
         Returns
         --------
-        Optional[:class:`InvokableSlashCommand`]
+        Optional[Union[:class:`InvokableSlashCommand`, :class:`SubCommandGroup`, :class:`SubCommand`]]
             The slash command that was requested. If not found, returns ``None``.
         """
-        return self.all_slash_commands.get(name)
+
+        command = name.split()
+        slash = self.all_slash_commands.get(command[0])
+        if slash:
+            if len(command) == 1:
+                return slash
+            elif len(command) == 2:
+                cmd = slash.children.get(command[1])
+                return cmd
+            elif len(command) == 3:
+                group = slash.children.get(command[1])
+                if isinstance(group, SubCommandGroup):
+                    cmd = group.children.get(command[2])
+                    return cmd
+
+        return None
 
     def get_user_command(self, name: str) -> Optional[InvokableUserCommand]:
         """Get a :class:`.InvokableUserCommand` from the internal list


### PR DESCRIPTION
## Summary
Improves the existing `get_slash_command` and makes it work like `get_command` 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
