### PR TITLE
Fix broken import in invite types

### DIFF
--- a/disnake/types/invite.py
+++ b/disnake/types/invite.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import Literal, Optional, TypedDict, Union
 
 from .snowflake import Snowflake
-from .guild import InviteGuild, _GuildPreviewUnique
+from .guild import InviteGuild
 from .channel import PartialChannel
 from .user import PartialUser
 from .appinfo import PartialAppInfo
@@ -41,6 +41,8 @@ class _InviteOptional(TypedDict, total=False):
     target_user: PartialUser
     target_type: InviteTargetType
     target_application: PartialAppInfo
+    approximate_member_count: int
+    approximate_presence_count: int
 
 
 class _InviteMetadata(TypedDict, total=False):
@@ -62,10 +64,6 @@ class IncompleteInvite(_InviteMetadata):
 
 
 class Invite(IncompleteInvite, _InviteOptional):
-    ...
-
-
-class InviteWithCounts(Invite, _GuildPreviewUnique):
     ...
 
 


### PR DESCRIPTION
## Summary

Fixes a broken import of `_GuildPreviewUnique`, caused by https://github.com/DisnakeDev/disnake/commit/a90bc3852f91fcb8e3f1c1a0637f972a8d18c345#diff-63bdc218be73643008bcebbf87dc59c9667f5d73adfb957e69679b876dbebc86.

Not an issue at runtime as types are only imported when type checking, but still technically broken.

## Checklist

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
