### PR TITLE
Add `start_embedded_activities` permission

### DIFF
--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -167,7 +167,7 @@ class Permissions(BaseFlags):
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
-        return cls(0b111111111111111111111111111111111111111)
+        return cls(0b1111111111111111111111111111111111111111)
 
     @classmethod
     def all_channel(cls: Type[P]) -> P:
@@ -192,8 +192,11 @@ class Permissions(BaseFlags):
            Added :attr:`create_public_threads`, :attr:`create_private_threads`, :attr:`manage_threads`,
            :attr:`use_external_stickers`, :attr:`send_messages_in_threads` and
            :attr:`request_to_speak` permissions.
+
+        .. versionchanged:: 2.3
+            Added :attr:`start_embedded_activities` permission.
         """
-        return cls(0b111110110110011111101111111111101010001)
+        return cls(0b1111110110110011111101111111111101010001)
 
     @classmethod
     def general(cls: Type[P]) -> P:
@@ -235,8 +238,12 @@ class Permissions(BaseFlags):
     @classmethod
     def voice(cls: Type[P]) -> P:
         """A factory method that creates a :class:`Permissions` with all
-        "Voice" permissions from the official Discord UI set to ``True``."""
-        return cls(0b00000011111100000000001100000000)
+        "Voice" permissions from the official Discord UI set to ``True``.
+
+        .. versionchanged:: 2.3
+            Added :attr:`start_embedded_activities` permission.
+        """
+        return cls(0b1000000000000011111100000000001100000000)
 
     @classmethod
     def stage(cls: Type[P]) -> P:
@@ -571,6 +578,15 @@ class Permissions(BaseFlags):
         """
         return 1 << 38
 
+    @flag_value
+    def start_embedded_activities(self) -> int:
+        """:class:`bool`: Returns ``True`` if a user can launch activities (applications
+        with the :attr:`embedded <ApplicationFlags.embedded>` flag) in a voice channel.
+
+        .. versionadded:: 2.3
+        """
+        return 1 << 39
+
 
 PO = TypeVar("PO", bound="PermissionOverwrite")
 
@@ -683,9 +699,10 @@ class PermissionOverwrite:
         manage_threads: Optional[bool]
         create_public_threads: Optional[bool]
         create_private_threads: Optional[bool]
-        send_messages_in_threads: Optional[bool]
         external_stickers: Optional[bool]
         use_external_stickers: Optional[bool]
+        send_messages_in_threads: Optional[bool]
+        start_embedded_activities: Optional[bool]
 
     def __init__(self, **kwargs: Optional[bool]):
         self._values: Dict[str, Optional[bool]] = {}


### PR DESCRIPTION
## Summary

This PR adds the `start_embedded_activities` (`1 << 39`) permission, added in https://github.com/discord/discord-api-docs/commit/839ef50c01069a00df53acf803d46c8d5adba034.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
