### PR TITLE
Add support for Text in Voice Channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build
 dist
 ADVANCED.rst
 secrets/
+.idea

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
     from .channel import CategoryChannel
     from .embeds import Embed
     from .message import Message, MessageReference, PartialMessage
-    from .channel import TextChannel, DMChannel, GroupChannel, PartialMessageable
+    from .channel import TextChannel, DMChannel, GroupChannel, PartialMessageable, VoiceChannel
     from .threads import Thread
     from .enums import InviteTarget
     from .guild_scheduled_event import GuildScheduledEvent
@@ -93,7 +93,7 @@ if TYPE_CHECKING:
         OverwriteType,
     )
 
-    MessageableChannel = Union[TextChannel, Thread, DMChannel, PartialMessageable]
+    MessageableChannel = Union[TextChannel, Thread, DMChannel, PartialMessageable, VoiceChannel]
     SnowflakeTime = Union["Snowflake", datetime]
 
 MISSING = utils.MISSING
@@ -1164,6 +1164,7 @@ class Messageable:
     - :class:`~disnake.Member`
     - :class:`~disnake.ext.commands.Context`
     - :class:`~disnake.Thread`
+    - :class:`~disnake.VoiceChannel`
     """
 
     __slots__ = ()

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -930,7 +930,7 @@ class VocalGuildChannel(disnake.abc.Connectable, disnake.abc.GuildChannel, Hasha
         return base
 
 
-class VoiceChannel(VocalGuildChannel):
+class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
     """Represents a Discord guild voice channel.
 
     .. container:: operations
@@ -992,6 +992,9 @@ class VoiceChannel(VocalGuildChannel):
         ]
         joined = " ".join("%s=%r" % t for t in attrs)
         return f"<{self.__class__.__name__} {joined}>"
+
+    async def _get_channel(self):
+        return self
 
     @property
     def type(self) -> ChannelType:

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
     from disnake.abc import MessageableChannel
-    from disnake.channel import TextChannel, Thread, DMChannel
+    from disnake.channel import TextChannel, Thread, DMChannel, VoiceChannel
     from disnake.guild import Guild
     from disnake.member import Member
     from disnake.state import ConnectionState
@@ -286,7 +286,7 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
         return self.message.guild
 
     @disnake.utils.cached_property
-    def channel(self) -> Union[TextChannel, Thread, DMChannel]:
+    def channel(self) -> Union[TextChannel, Thread, DMChannel, VoiceChannel]:
         """Union[:class:`.abc.Messageable`]: Returns the channel associated with this context's command.
         Shorthand for :attr:`.Message.channel`.
         """
@@ -407,6 +407,6 @@ class GuildContext(Context):
     """
 
     guild: Guild
-    channel: Union[TextChannel, Thread]
+    channel: Union[TextChannel, Thread, VoiceChannel]
     author: Member
     me: Member

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
         StoreChannel,
         Thread,
         PartialMessageable,
+        VoiceChannel,
     ]
 
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -209,7 +209,9 @@ class Interaction:
         channel = guild and guild._resolve_channel(self.channel_id)
         if channel is None:
             if self.channel_id is not None:
-                type = None if self.guild_id is not None else ChannelType.private  # could be a text, voice, or thread channel in a guild
+                type = (
+                    None if self.guild_id is not None else ChannelType.private
+                )  # could be a text, voice, or thread channel in a guild
                 return PartialMessageable(state=self._state, id=self.channel_id, type=type)  # type: ignore
             return None  # type: ignore
         return channel  # type: ignore

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -198,7 +198,7 @@ class Interaction:
         return self.guild.me
 
     @utils.cached_slot_property("_cs_channel")
-    def channel(self) -> Union[TextChannel, Thread]:
+    def channel(self) -> Union[TextChannel, Thread, VoiceChannel]:
         """Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]: The channel the interaction was sent from.
 
         Note that due to a Discord limitation, DM channels are not resolved since there is
@@ -209,7 +209,7 @@ class Interaction:
         channel = guild and guild._resolve_channel(self.channel_id)
         if channel is None:
             if self.channel_id is not None:
-                type = ChannelType.text if self.guild_id is not None else ChannelType.private
+                type = None if self.guild_id is not None else ChannelType.private  # could be a text, voice, or thread channel in a guild
                 return PartialMessageable(state=self._state, id=self.channel_id, type=type)  # type: ignore
             return None  # type: ignore
         return channel  # type: ignore

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1895,8 +1895,9 @@ class PartialMessage(Hashable):
             ChannelType.news_thread,
             ChannelType.public_thread,
             ChannelType.private_thread,
+            ChannelType.voice,
         ):
-            raise TypeError(f"Expected TextChannel, DMChannel or Thread not {type(channel)!r}")
+            raise TypeError(f"Expected TextChannel, DMChannel, VoiceChannel, or Thread not {type(channel)!r}")
 
         self.channel: MessageableChannel = channel
         self._state: ConnectionState = channel._state

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1897,7 +1897,9 @@ class PartialMessage(Hashable):
             ChannelType.private_thread,
             ChannelType.voice,
         ):
-            raise TypeError(f"Expected TextChannel, DMChannel, VoiceChannel, or Thread not {type(channel)!r}")
+            raise TypeError(
+                f"Expected TextChannel, DMChannel, VoiceChannel, or Thread not {type(channel)!r}"
+            )
 
         self.channel: MessageableChannel = channel
         self._state: ConnectionState = channel._state

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -86,7 +86,7 @@ if TYPE_CHECKING:
     from .abc import GuildChannel, MessageableChannel, MessageableChannel
     from .components import Component
     from .state import ConnectionState
-    from .channel import TextChannel, GroupChannel, DMChannel, PartialMessageable
+    from .channel import TextChannel, GroupChannel, DMChannel, PartialMessageable, VoiceChannel
     from .mentions import AllowedMentions
     from .role import Role
     from .ui.view import View
@@ -854,7 +854,7 @@ class Message(Hashable):
         self.activity: Optional[MessageActivityPayload] = data.get("activity")
         # for user experince, on_message has no bussiness getting partials
         # TODO: Subscripted message to include the channel
-        self.channel: Union[TextChannel, DMChannel, Thread] = channel  # type: ignore
+        self.channel: Union[TextChannel, DMChannel, Thread, VoiceChannel] = channel  # type: ignore
         self._edited_timestamp: Optional[datetime.datetime] = utils.parse_time(
             data["edited_timestamp"]
         )
@@ -1082,7 +1082,7 @@ class Message(Hashable):
         self.components = [_component_factory(d) for d in components]
 
     def _rebind_cached_references(
-        self, new_guild: Guild, new_channel: Union[TextChannel, Thread]
+        self, new_guild: Guild, new_channel: Union[TextChannel, Thread, VoiceChannel]
     ) -> None:
         self.guild = new_guild
         self.channel = new_channel

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1750,7 +1750,7 @@ class ConnectionState:
     def create_message(
         self,
         *,
-        channel: Union[TextChannel, Thread, DMChannel, PartialMessageable],
+        channel: Union[TextChannel, Thread, DMChannel, PartialMessageable, VoiceChannel],
         data: MessagePayload,
     ) -> Message:
         return Message(state=self, channel=channel, data=data)

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
         Message as MessagePayload,
     )
     from ..guild import Guild
-    from ..channel import TextChannel
+    from ..channel import TextChannel, VoiceChannel
     from ..abc import Snowflake
     from ..ui.view import View
     import datetime
@@ -886,8 +886,8 @@ class BaseWebhook(Hashable):
         return self._state and self._state._get_guild(self.guild_id)
 
     @property
-    def channel(self) -> Optional[TextChannel]:
-        """Optional[:class:`TextChannel`]: The text channel this webhook belongs to.
+    def channel(self) -> Optional[Union[TextChannel, VoiceChannel]]:
+        """Optional[Union[:class:`TextChannel`, :class:`VoiceChannel`]]: The messageable channel this webhook belongs to.
 
         If this is a partial webhook, then this will always return ``None``.
         """


### PR DESCRIPTION
## Summary

Text in Voice Channels is an upcoming feature in Discord that effectively grants Voice Channels a companion text channel. According to various Discord developers:

> This change should be pretty simple, since the regular text channel APIs all work the same on voice channels - the key change you'll have to accommodate is that text message content is now coming from voice channels (type GUILD_VOICE)

> we'd like to have this on stage channels at some point. but will be exclusively guild VCs for launch

Additional information:
- Text in Voice Channels can have webhooks
- Pins in Text in Voice Channels are not exposed in the UI, but the API exists (whether or not the API will be blocked in the future is TBD)
- Text in Voice Channels may be interaction sources
- Before release, trying to send text content to a channel that does not have the feature enabled raises `HTTPException: 400 Bad Request (error code: 50008): Cannot send messages in a non-text channel`

This PR makes `VoiceChannel` a subclass of `abc.Messageable` (not VocalGuildChannel because of the stage channel limitations noted above) to implement sending text content to Text in Voice Channels, updates various typings across the library to note that certain attributed may now be a VoiceChannel, and updates `PartialMessageable` to allow construction from a VoiceChannel.

I've left the PR as a draft since I'm not 100% sure I've covered all the bases - please let me know if there's anything I've missed.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
