### PR TITLE
Fix button/select decorator return types

### DIFF
--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -282,7 +282,7 @@ def button(
     def decorator(func: ItemCallbackType) -> Button:
         if not inspect.iscoroutinefunction(func):
             raise TypeError(f"<{func.__qualname__}> must be a coroutine function")
-        if hasattr(func, "__item_callback__"):
+        if hasattr(func, "__item_decorated_callback__"):
             raise TypeError("Callback is already an item")
 
         button = Button(
@@ -294,7 +294,7 @@ def button(
             emoji=emoji,
             row=row,
         )
-        button.__item_callback__ = func
+        button.__item_decorated_callback__ = func
         return button
 
     return decorator

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -285,15 +285,17 @@ def button(
         if hasattr(func, "__item_decorated_callback__"):
             raise TypeError("Callback is already an item")
 
-        button = Button(
-            style=style,
-            label=label,
-            disabled=disabled,
-            custom_id=custom_id,
-            url=None,
-            emoji=emoji,
-            row=row,
-        )
+        kwargs = {
+            "style": style,
+            "custom_id": custom_id,
+            "url": None,
+            "disabled": disabled,
+            "label": label,
+            "emoji": emoji,
+            "row": row,
+        }
+        button = Button(**kwargs)
+        button.__item_original_kwargs__ = kwargs
         button.__item_decorated_callback__ = func
         return button
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -145,6 +145,9 @@ class Item(Generic[V]):
 I_co = TypeVar("I_co", bound=Item, covariant=True)
 
 
+# while the decorators don't actually return a descriptor that matches this protocol,
+# this protocol ensures that type checkers don't complain about statements like `self.button.disabled = True`,
+# which work as `View.__init__` replaces the handler with the item
 class DecoratedItem(Protocol[I_co]):
     @overload
     def __get__(self, obj: None, objtype: Any) -> ItemCallbackType:

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -64,7 +64,7 @@ class Item(Generic[V]):
 
     __original_kwargs__: Dict[str, Any]
 
-    __item_callback__: ItemCallbackType
+    __item_decorated_callback__: ItemCallbackType
 
     __item_repr_attributes__: Tuple[str, ...] = ("row",)
 
@@ -93,7 +93,8 @@ class Item(Generic[V]):
         # this copy method is only meant for decorator-created items
         item = self.__class__(**self.__original_kwargs__)
         item.__original_kwargs__ = self.__original_kwargs__  # discard copy created by __new__
-        item.__item_callback__ = self.__item_callback__
+        if hasattr(self, "__item_decorated_callback__"):
+            item.__item_decorated_callback__ = self.__item_decorated_callback__
         return item
 
     def refresh_component(self, component: Component) -> None:

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -62,7 +62,17 @@ class Item(Generic[V]):
     .. versionadded:: 2.0
     """
 
+    __original_kwargs__: Dict[str, Any]
+
+    __item_callback__: ItemCallbackType
+
     __item_repr_attributes__: Tuple[str, ...] = ("row",)
+
+    # similar to ext.commands.Command.__new__
+    def __new__(cls: Type[I], *args: Any, **kwargs: Any) -> I:
+        self = super().__new__(cls)
+        self.__original_kwargs__ = kwargs.copy()
+        return self
 
     def __init__(self):
         self._view: Optional[V] = None
@@ -78,6 +88,13 @@ class Item(Generic[V]):
 
     def to_component_dict(self) -> Dict[str, Any]:
         raise NotImplementedError
+
+    def _copy(self: I) -> I:
+        # this copy method is only meant for decorator-created items
+        item = self.__class__(**self.__original_kwargs__)
+        item.__original_kwargs__ = self.__original_kwargs__  # discard copy created by __new__
+        item.__item_callback__ = self.__item_callback__
+        return item
 
     def refresh_component(self, component: Component) -> None:
         return None

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -346,15 +346,17 @@ def select(
         if hasattr(func, "__item_decorated_callback__"):
             raise TypeError("Callback is already an item")
 
-        select = Select(
-            custom_id=custom_id,
-            placeholder=placeholder,
-            min_values=min_values,
-            max_values=max_values,
-            options=options,
-            disabled=disabled,
-            row=row,
-        )
+        kwargs = {
+            "placeholder": placeholder,
+            "custom_id": custom_id,
+            "row": row,
+            "min_values": min_values,
+            "max_values": max_values,
+            "options": options,
+            "disabled": disabled,
+        }
+        select = Select(**kwargs)
+        select.__item_original_kwargs__ = kwargs
         select.__item_decorated_callback__ = func
         return select
 

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -301,7 +301,7 @@ def select(
     options: List[SelectOption] = MISSING,
     disabled: bool = False,
     row: Optional[int] = None,
-) -> Callable[[ItemCallbackType], ItemCallbackType]:
+) -> Callable[[ItemCallbackType], Select]:
     """A decorator that attaches a select menu to a component.
 
     The function being decorated should have three parameters, ``self`` representing
@@ -310,6 +310,10 @@ def select(
 
     In order to get the selected items that the user has chosen within the callback
     use :attr:`Select.values`.
+
+    .. versionchanged:: 2.3
+        Returns a :class:`Select` object instead of the decorated function when
+        applied to a function.
 
     Parameters
     ------------
@@ -336,20 +340,22 @@ def select(
         Whether the select is disabled or not. Defaults to ``False``.
     """
 
-    def decorator(func: ItemCallbackType) -> ItemCallbackType:
+    def decorator(func: ItemCallbackType) -> Select:
         if not inspect.iscoroutinefunction(func):
-            raise TypeError("select function must be a coroutine function")
+            raise TypeError(f"<{func.__qualname__}> must be a coroutine function")
+        if hasattr(func, "__item_callback__"):
+            raise TypeError("Callback is already an item")
 
-        func.__discord_ui_model_type__ = Select
-        func.__discord_ui_model_kwargs__ = {
-            "placeholder": placeholder,
-            "custom_id": custom_id,
-            "row": row,
-            "min_values": min_values,
-            "max_values": max_values,
-            "options": options,
-            "disabled": disabled,
-        }
-        return func
+        select = Select(
+            custom_id=custom_id,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            options=options,
+            disabled=disabled,
+            row=row,
+        )
+        select.__item_callback__ = func
+        return select
 
     return decorator

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -343,7 +343,7 @@ def select(
     def decorator(func: ItemCallbackType) -> Select:
         if not inspect.iscoroutinefunction(func):
             raise TypeError(f"<{func.__qualname__}> must be a coroutine function")
-        if hasattr(func, "__item_callback__"):
+        if hasattr(func, "__item_decorated_callback__"):
             raise TypeError("Callback is already an item")
 
         select = Select(
@@ -355,7 +355,7 @@ def select(
             disabled=disabled,
             row=row,
         )
-        select.__item_callback__ = func
+        select.__item_decorated_callback__ = func
         return select
 
     return decorator

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -152,7 +152,7 @@ class View:
         children: List[Item] = []
         for base in reversed(cls.__mro__):
             for member in base.__dict__.values():
-                if hasattr(member, "__item_callback__"):
+                if hasattr(member, "__item_decorated_callback__"):
                     children.append(member)
 
         if len(children) > 25:
@@ -165,9 +165,9 @@ class View:
         self.children: List[Item] = []
         for item in self.__view_children_items__:
             item = item._copy()
-            item.callback = partial(item.__item_callback__, self, item)
+            item.callback = partial(item.__item_decorated_callback__, self, item)
             item._view = self
-            setattr(self, item.__item_callback__.__name__, item)
+            setattr(self, item.__item_decorated_callback__.__name__, item)
             self.children.append(item)
 
         self.__weights = _ViewWeights(self.children)

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -164,10 +164,11 @@ class View:
         self.timeout = timeout
         self.children: List[Item] = []
         for item in self.__view_children_items__:
+            dec_callback = item.__item_decorated_callback__
             item = item._copy()
-            item.callback = partial(item.__item_decorated_callback__, self, item)
+            item.callback = partial(dec_callback, self, item)
             item._view = self
-            setattr(self, item.__item_decorated_callback__.__name__, item)
+            setattr(self, dec_callback.__name__, item)
             self.children.append(item)
 
         self.__weights = _ViewWeights(self.children)


### PR DESCRIPTION
## Summary

This PR updates the `ui.button`/`ui.select` decorator annotations. While the existing code works fine and types are technically correct, `View.__init__` later replaces the callback with its associated item:
https://github.com/DisnakeDev/disnake/blob/f5c8c4a8d1cc51f8068c6ffc4e018b67cd96c70d/disnake/ui/view.py#L167-L170

This results in type checkers showing errors on code like `self.button.disabled = True` (where `self.button` is a method decorated with `ui.button`), as `self.button` is considered to be the same type as the decorated callback, while it is actually the associated item at runtime.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
