### PR TITLE
Fix injections link to commit in docs

### DIFF
--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -379,4 +379,4 @@ You can implement double nesting and build commands like ``/parent group subcmd`
 Injections
 ----------
 
-We have them, look at [this example](https://github.com/DisnakeDev/disnake/blob/master/examples/slash_commands/injections.py) for more information ✨
+We have them, look at `this example <https://github.com/DisnakeDev/disnake/blob/master/examples/slash_commands/injections.py>`_ for more information ✨


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes the link found in the new section of the slash commands docs ([here](https://docs.disnake.dev/en/latest/ext/commands/slash_commands.html?highlight=injections#injections)).

EDIT: not sure why I mentioned "commit" when it's actually a file.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
