### PR TITLE
Update JP readme to match the English one

### DIFF
--- a/README.ja.rst
+++ b/README.ja.rst
@@ -1,8 +1,11 @@
+.. image:: ./assets/banner.png
+    :alt: Disnake Banner
+
 disnake
 ==========
 
-.. image:: https://discord.com/api/guilds/336642139381301249/embed.png
-   :target: https://discord.gg/nXzj3dg
+.. image:: https://discord.com/api/guilds/808030843078836254/embed.png
+   :target: https://discord.gg/gJDbCw8aQy
    :alt: Discordサーバーの招待
 .. image:: https://img.shields.io/pypi/v/disnake.svg
    :target: https://pypi.python.org/pypi/disnake
@@ -63,7 +66,7 @@ disnake は機能豊富かつモダンで使いやすい、非同期処理にも
 Linuxで音声サポートを導入するには、前述のコマンドを実行する前にお気に入りのパッケージマネージャー(例えば ``apt`` や ``dnf`` など)を使って以下のパッケージをインストールする必要があります:
 
 * libffi-dev (システムによっては ``libffi-devel``)
-* python-dev (例えばPython 3.6用の ``python3.6-dev``)
+* python-dev (例えばPython 3.8用の ``python3.8-dev``)
 
 簡単な例
 --------------
@@ -103,11 +106,45 @@ Botの例
 
     bot.run('token')
 
+Slash Commandsの例
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: py
+
+    import disnake
+    from disnake.ext import commands
+
+    bot = commands.Bot(command_prefix='>', test_guilds=[12345])
+
+    @bot.slash_command()
+    async def ping(inter):
+        await inter.response.send_message('pong')
+
+    bot.run('token')
+
+Context Menusの例
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: py
+
+    import disnake
+    from disnake.ext import commands
+
+    bot = commands.Bot(command_prefix='>', test_guilds=[12345])
+
+    @bot.user_command()
+    async def avatar(inter, user):
+        embed = disnake.Embed(title=str(user))
+        embed.set_image(url=user.display_avatar.url)
+        await inter.response.send_message(embed=embed)
+
+    bot.run('token')
+
 examplesディレクトリに更に多くのサンプルがあります。
 
 リンク
 ------
 
-- `ドキュメント <https://discordpy.readthedocs.io/ja/latest/index.html>`_
-- `公式Discordサーバー <https://discord.gg/nXzj3dg>`_
+- `ドキュメント <https://docs.disnake.dev>`_
+- `公式Discordサーバー <https://discord.gg/gJDbCw8aQy>`_
 - `Discord API <https://discord.gg/disnake-api>`_


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

- Replaced links and discord badge to point at disnake's discord
- Added slash commands and context menu examples (kept the wording in English and just added "example" in Japanese later)
- Added the disnake banner

The docs link to discord.py's Japanese docs was replaced as well, but the link points towards the default (English) disnake docs.

I've also replaced the `python3.6-dev` mention to `3.8` to reflect the new requirements (this should probably be done for the English README too). 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
