### PR TITLE
Fix dispatch of typing events in DMs

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -1860,9 +1860,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         return f"<DMChannel id={self.id} recipient={self.recipient!r}>"
 
     @classmethod
-    def _from_message(
-        cls: Type[DMC], state: ConnectionState, channel_id: int, user_id: Optional[int]
-    ) -> DMC:
+    def _from_message(cls: Type[DMC], state: ConnectionState, channel_id: int, user_id: int) -> DMC:
         self: DMC = cls.__new__(cls)
         self._state = state
         self.id = channel_id

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -1860,13 +1860,15 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         return f"<DMChannel id={self.id} recipient={self.recipient!r}>"
 
     @classmethod
-    def _from_message(cls: Type[DMC], state: ConnectionState, channel_id: int) -> DMC:
+    def _from_message(
+        cls: Type[DMC], state: ConnectionState, channel_id: int, user_id: Optional[int]
+    ) -> DMC:
         self: DMC = cls.__new__(cls)
         self._state = state
         self.id = channel_id
-        self.recipient = None
         # state.user won't be None here
         self.me = state.user  # type: ignore
+        self.recipient = state.get_user(user_id) if user_id != self.me.id else None
         return self
 
     @property

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Set, List
 
+import datetime
+
 if TYPE_CHECKING:
     from .types.raw_models import (
         MessageDeleteEvent,
@@ -36,6 +38,7 @@ if TYPE_CHECKING:
         ReactionClearEmojiEvent,
         MemberScreeningRejectEvent,
         IntegrationDeleteEvent,
+        TypingEvent,
     )
     from .message import Message
     from .partial_emoji import PartialEmoji
@@ -52,6 +55,7 @@ __all__ = (
     "RawMemberScreeningRejectEvent",
     "RawIntegrationDeleteEvent",
     "RawGuildScheduledEventUserActionEvent",
+    "RawTypingEvent",
 )
 
 
@@ -323,3 +327,33 @@ class RawGuildScheduledEventUserActionEvent(_RawReprMixin):
         self.event_id: int = int(data["guild_scheduled_event_id"])
         self.user_id: int = int(data["user_id"])
         self.guild_id: int = int(data["guild_id"])
+
+
+class RawTypingEvent(_RawReprMixin):
+    """Represents the payload for :func:`on_raw_typing` event.
+
+    Attributes
+    -----------
+    user_id: :class:`int`
+        The ID of the user who started typing.
+    channel_id: :class:`int`
+        The ID of the channel where the user started typing.
+    guild_id: Optional[:class:`int`]
+        The ID of the guild where the user started typing or ``None`` if it was in a DM.
+    member: Optional[:class:`Member`]
+        The member object of the user who started typing or ``None`` if it was in a DM.
+    timestamp: :class:`datetime.datetime`
+        The timestamp when the user started typing.
+    """
+
+    __slots__ = ("user_id", "channel_id", "guild_id", "member", "timestamp")
+
+    def __init__(self, data: TypingEvent) -> None:
+        self.user_id: int = int(data["user_id"])
+        self.channel_id: int = int(data["channel_id"])
+        try:
+            self.guild_id: Optional[int] = int(data["guild_id"])
+        except KeyError:
+            self.guild_id: Optional[int] = None
+        self.member: Optional[Member] = None
+        self.timestamp: datetime.datetime = datetime.datetime.utcfromtimestamp(data["timestamp"])

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1691,6 +1691,16 @@ class ConnectionState:
 
     def parse_typing_start(self, data: TypingEvent) -> None:
         channel, guild = self._get_guild_channel(data)
+        raw = RawTypingEvent(data)
+
+        member_data = data.get("member")
+        if member_data:
+            guild = self._get_guild(raw.guild_id)
+            if guild is not None:
+                raw.member = Member(data=member_data, guild=guild, state=self)
+
+        self.dispatch("raw_typing", raw)
+
         if channel is not None:
             member = None
             user_id = utils._get_as_snowflake(data, "user_id")

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -612,10 +612,10 @@ class ConnectionState:
             if channel is None:
                 if "author" in data:
                     # MessagePayload
-                    user_id = utils._get_as_snowflake(data["author"], "id")
+                    user_id = int(data["author"]["id"])
                 else:
                     # TypingEvent
-                    user_id = utils._get_as_snowflake(data, "user_id")
+                    user_id = int(data["user_id"])
                 channel = DMChannel._from_message(self, channel_id, user_id)
             guild = None
         else:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1712,9 +1712,6 @@ class ConnectionState:
                 # user_id won't be None
                 member = guild.get_member(user_id)  # type: ignore
 
-                if member is None and member_data:
-                    member = Member(data=member_data, state=self, guild=guild)
-
             elif isinstance(channel, GroupChannel):
                 member = utils.find(lambda x: x.id == user_id, channel.recipients)
 

--- a/disnake/types/raw_models.py
+++ b/disnake/types/raw_models.py
@@ -90,3 +90,14 @@ class _IntegrationDeleteEventOptional(TypedDict, total=False):
 class IntegrationDeleteEvent(_IntegrationDeleteEventOptional):
     id: Snowflake
     guild_id: Snowflake
+
+
+class _TypingEventOptional(TypedDict, total=False):
+    guild_id: Snowflake
+    member: Member
+
+
+class TypingEvent(_TypingEventOptional):
+    user_id: Snowflake
+    channel_id: Snowflake
+    timestamp: int

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -387,7 +387,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     Called when someone begins typing a message.
 
     This is similar to :func:`on_typing` except that it is called regardless of
-    whether :attr:`Intents.typing`, :attr:`Intents.members` and :attr:`Intents.guilds` are enabled.
+    whether :attr:`Intents.members` and :attr:`Intents.guilds` are enabled.
 
     :param data: The raw event payload data.
     :type data: :class:`RawTypingEvent`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -360,7 +360,20 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     If the ``channel`` is a :class:`TextChannel` then the ``user`` parameter
     is a :class:`Member`, otherwise it is a :class:`User`.
 
+    If the ``channel`` is a :class:`DMChannel` and the user is not found in the internal user/member cache,
+    then this event will not be called. Consider using :func:`on_raw_typing` instead.
+
     This requires :attr:`Intents.typing` to be enabled.
+
+    .. note::
+
+        This doesn't require :attr:`Intents.members` within a guild context,
+        but due to Discord not providing updated user information in a direct message
+        it's required for direct messages to receive this event, if the bot didn't explicitly
+        open the DM channel in the same session (through :func:`User.create_dm`, :func:`Client.create_dm`,
+        or indirectly by sending a message to the user).
+        Consider using :func:`on_raw_typing` if you need this and do not otherwise want
+        to enable the members intent.
 
     :param channel: The location where the typing originated from.
     :type channel: :class:`abc.Messageable`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -363,7 +363,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     If the ``channel`` is a :class:`DMChannel` and the user is not found in the internal user/member cache,
     then this event will not be called. Consider using :func:`on_raw_typing` instead.
 
-    This requires :attr:`Intents.typing` to be enabled.
+    This requires :attr:`Intents.typing` and :attr:`Intents.guilds` to be enabled.
 
     .. note::
 
@@ -381,6 +381,16 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :type user: Union[:class:`User`, :class:`Member`]
     :param when: When the typing started as an aware datetime in UTC.
     :type when: :class:`datetime.datetime`
+
+.. function:: on_raw_typing(data)
+
+    Called when someone begins typing a message.
+
+    This is similar to :func:`on_typing` except that it is called regardless of
+    whether :attr:`Intents.typing`, :attr:`Intents.members` and :attr:`Intents.guilds` are enabled.
+
+    :param data: The raw event payload data.
+    :type data: :class:`RawTypingEvent`
 
 .. function:: on_message(message)
 
@@ -4462,6 +4472,14 @@ RawGuildScheduledEventUserActionEvent
 .. attributetable:: RawGuildScheduledEventUserActionEvent
 
 .. autoclass:: RawGuildScheduledEventUserActionEvent()
+    :members:
+
+RawTypingEvent
+~~~~~~~~~~~~~~
+
+.. attributetable:: RawTypingEvent
+
+.. autoclass:: RawTypingEvent()
     :members:
 
 PartialWebhookGuild


### PR DESCRIPTION
## Summary

This PR fixes typing events for DMs in cases where the bot didn't create the DM channel in the same session (and as such it wasn't cached). Previously, `DMChannel._from_message` would always set `recipient = None`, which resulted in typing events not being dispatched.
The recipient is now taken from the cache for both `MESSAGE_CREATE` and `TYPING_START` events, which should generally fix `channel.recipient`.

Fixes #175.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
