### PR TITLE
Try to get object from cache first.

### DIFF
--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -406,7 +406,11 @@ class ApplicationCommandInteractionDataResolved:
             factory, ch_type = _threaded_channel_factory(channel["type"])
             if factory:
                 channel["position"] = 0  # type: ignore
-                self.channels[int(str_id)] = guild.get_channel(int(str_id)) or factory(guild=guild, state=state, data=channel)  # type: ignore
+                self.channels[int(str_id)] = (  # type: ignore
+                    guild
+                    and guild.get_channel(int(str_id))
+                    or factory(guild=guild, state=state, data=channel)  # type: ignore
+                )
 
         for str_id, message in messages.items():
             channel_id = int(message["channel_id"])

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -387,10 +387,14 @@ class ApplicationCommandInteractionDataResolved:
             user_id = int(str_id)
             member = members.get(str_id)
             if member is not None:
-                self.members[user_id] = guild.get_member(user_id) or Member(
-                    data={**member, "user": user},  # type: ignore
-                    guild=guild,  # type: ignore
-                    state=state,
+                self.members[user_id] = (
+                    guild
+                    and guild.get_member(user_id)
+                    or Member(
+                        data={**member, "user": user},  # type: ignore
+                        guild=guild,  # type: ignore
+                        state=state,
+                    )
                 )
             else:
                 self.users[user_id] = User(state=state, data=user)

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -387,7 +387,7 @@ class ApplicationCommandInteractionDataResolved:
             user_id = int(str_id)
             member = members.get(str_id)
             if member is not None:
-                self.members[user_id] = Member(
+                self.members[user_id] = guild.get_member(user_id) or Member(
                     data={**member, "user": user},  # type: ignore
                     guild=guild,  # type: ignore
                     state=state,
@@ -402,7 +402,7 @@ class ApplicationCommandInteractionDataResolved:
             factory, ch_type = _threaded_channel_factory(channel["type"])
             if factory:
                 channel["position"] = 0  # type: ignore
-                self.channels[int(str_id)] = factory(guild=guild, state=state, data=channel)  # type: ignore
+                self.channels[int(str_id)] = guild.get_channel(int(str_id)) or factory(guild=guild, state=state, data=channel)  # type: ignore
 
         for str_id, message in messages.items():
             channel_id = int(message["channel_id"])

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -163,10 +163,9 @@ class Interaction:
             except KeyError:
                 pass
             else:
-                author_id = int(member["user"]["id"])  # type: ignore
                 self.author = (
                     guild
-                    and guild.get_member(author_id)  # type: ignore
+                    and guild.get_member(int(member["user"]["id"]))  # type: ignore
                     or Member(state=self._state, guild=guild, data=member)  # type: ignore
                 )
                 self._permissions = int(member.get("permissions", 0))

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -163,10 +163,12 @@ class Interaction:
             except KeyError:
                 pass
             else:
-                author_id = data["member"]["user"]["id"]
-                self.author = guild.get_member(int(author_id)) or Member(
-                    state=self._state, guild=guild, data=member
-                )  # type: ignore
+                author_id = int(member["user"]["id"])  # type: ignore
+                self.author = (
+                    guild
+                    and guild.get_member(author_id)  # type: ignore
+                    or Member(state=self._state, guild=guild, data=member)  # type: ignore
+                )
                 self._permissions = int(member.get("permissions", 0))
         else:
             try:
@@ -529,8 +531,8 @@ class Interaction:
             sender = self.followup.send
         else:
             sender = self.response.send_message
-        await sender(  # type: ignore
-            content=content,
+        await sender(
+            content=content,  # type: ignore
             embed=embed,
             embeds=embeds,
             file=file,

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -163,7 +163,10 @@ class Interaction:
             except KeyError:
                 pass
             else:
-                self.author = Member(state=self._state, guild=guild, data=member)  # type: ignore
+                author_id = data["member"]["user"]["id"]
+                self.author = guild.get_member(int(author_id)) or Member(
+                    state=self._state, guild=guild, data=member
+                )  # type: ignore
                 self._permissions = int(member.get("permissions", 0))
         else:
             try:


### PR DESCRIPTION
## Summary

This PR fixes #108 and #180, and basically tries to get the object from the cache, and if it fails, it returns the partial object obtained from the API.

With this implementation, you will need to have: `members`, `guilds` and `presences` intents in order to get the member's status, as well as other things. (See #108)

And `guilds` intents to get the full channel. (See #180)

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
