### PR TITLE
Add `ThreadArchiveDuration` enum

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -77,7 +77,7 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
-    from .types.threads import ThreadArchiveDurationT
+    from .types.threads import ThreadArchiveDurationLiteral
     from .role import Role
     from .member import Member, VoiceState
     from .abc import Snowflake, SnowflakeTime
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
     from .state import ConnectionState
     from .user import ClientUser, User, BaseUser
     from .guild import Guild, GuildChannel as GuildChannelType
+    from .threads import AnyThreadArchiveDuration
     from .types.channel import (
         TextChannel as TextChannelPayload,
         VoiceChannel as VoiceChannelPayload,
@@ -203,7 +204,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         self.nsfw: bool = data.get("nsfw", False)
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)
-        self.default_auto_archive_duration: ThreadArchiveDurationT = data.get(
+        self.default_auto_archive_duration: ThreadArchiveDurationLiteral = data.get(
             "default_auto_archive_duration", 1440
         )
         self._type: int = data.get("type", self._type)
@@ -291,7 +292,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         sync_permissions: bool = ...,
         category: Optional[CategoryChannel] = ...,
         slowmode_delay: int = ...,
-        default_auto_archive_duration: ThreadArchiveDurationT = ...,
+        default_auto_archive_duration: AnyThreadArchiveDuration = ...,
         type: ChannelType = ...,
         overwrites: Mapping[Union[Role, Member, Snowflake], PermissionOverwrite] = ...,
     ) -> Optional[TextChannel]:
@@ -706,7 +707,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         *,
         name: str,
         message: Optional[Snowflake] = None,
-        auto_archive_duration: ThreadArchiveDurationT = None,
+        auto_archive_duration: AnyThreadArchiveDuration = None,
         type: Optional[ChannelType] = None,
         invitable: bool = None,
         slowmode_delay: int = None,

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -770,7 +770,10 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         if type is None:
             type = ChannelType.private_thread
 
-        auto_archive_duration = try_enum_to_int(auto_archive_duration)
+        if auto_archive_duration is not None:
+            auto_archive_duration: ThreadArchiveDurationLiteral = try_enum_to_int(
+                auto_archive_duration
+            )
 
         if message is None:
             data = await self._state.http.start_thread_without_message(

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -51,6 +51,7 @@ from .enums import (
     try_enum,
     VoiceRegion,
     VideoQualityMode,
+    ThreadArchiveDuration,
 )
 from .mixins import Hashable
 from .object import Object
@@ -75,7 +76,7 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
-    from .types.threads import ThreadArchiveDuration
+    from .types.threads import ThreadArchiveDurationT
     from .role import Role
     from .member import Member, VoiceState
     from .abc import Snowflake, SnowflakeTime
@@ -201,7 +202,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         self.nsfw: bool = data.get("nsfw", False)
         # Does this need coercion into `int`? No idea yet.
         self.slowmode_delay: int = data.get("rate_limit_per_user", 0)
-        self.default_auto_archive_duration: ThreadArchiveDuration = data.get(
+        self.default_auto_archive_duration: ThreadArchiveDurationT = data.get(
             "default_auto_archive_duration", 1440
         )
         self._type: int = data.get("type", self._type)
@@ -289,7 +290,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         sync_permissions: bool = ...,
         category: Optional[CategoryChannel] = ...,
         slowmode_delay: int = ...,
-        default_auto_archive_duration: ThreadArchiveDuration = ...,
+        default_auto_archive_duration: ThreadArchiveDurationT = ...,
         type: ChannelType = ...,
         overwrites: Mapping[Union[Role, Member, Snowflake], PermissionOverwrite] = ...,
     ) -> Optional[TextChannel]:
@@ -704,7 +705,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         *,
         name: str,
         message: Optional[Snowflake] = None,
-        auto_archive_duration: ThreadArchiveDuration = None,
+        auto_archive_duration: ThreadArchiveDurationT = None,
         type: Optional[ChannelType] = None,
         invitable: bool = None,
         slowmode_delay: int = None,
@@ -727,9 +728,10 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             A snowflake representing the message to create the thread with.
             If ``None`` is passed then a private thread is created.
             Defaults to ``None``.
-        auto_archive_duration: :class:`int`
+        auto_archive_duration: Union[:class:`int`, :class:`ThreadArchiveDuration`]
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+            Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         type: Optional[:class:`ChannelType`]
             The type of thread to create. If a ``message`` is passed then this parameter
             is ignored, as a thread created with a message is always a public thread.
@@ -766,6 +768,9 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
         if type is None:
             type = ChannelType.private_thread
+
+        if isinstance(auto_archive_duration, ThreadArchiveDuration):
+            auto_archive_duration = auto_archive_duration.value
 
         if message is None:
             data = await self._state.http.start_thread_without_message(

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -51,7 +51,6 @@ from .enums import (
     try_enum,
     VoiceRegion,
     VideoQualityMode,
-    ThreadArchiveDuration,
     try_enum_to_int,
 )
 from .mixins import Hashable
@@ -347,7 +346,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         overwrites: :class:`Mapping`
             A :class:`Mapping` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply to the channel.
-        default_auto_archive_duration: :class:`int`
+        default_auto_archive_duration: Union[:class:`int`, :class:`ThreadArchiveDuration`]
             The new default auto archive duration in minutes for threads created in this channel.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
 

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -52,6 +52,7 @@ from .enums import (
     VoiceRegion,
     VideoQualityMode,
     ThreadArchiveDuration,
+    try_enum_to_int,
 )
 from .mixins import Hashable
 from .object import Object
@@ -769,8 +770,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         if type is None:
             type = ChannelType.private_thread
 
-        if isinstance(auto_archive_duration, ThreadArchiveDuration):
-            auto_archive_duration = auto_archive_duration.value
+        auto_archive_duration = try_enum_to_int(auto_archive_duration)
 
         if message is None:
             data = await self._state.http.start_thread_without_message(

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -61,6 +61,7 @@ __all__ = (
     "GuildScheduledEventEntityType",
     "GuildScheduledEventStatus",
     "GuildScheduledEventPrivacyLevel",
+    "ThreadArchiveDuration",
 )
 
 
@@ -677,6 +678,13 @@ class GuildScheduledEventStatus(Enum):
 
 class GuildScheduledEventPrivacyLevel(Enum):
     guild_only = 2
+
+
+class ThreadArchiveDuration(Enum):
+    hour = 60
+    day = 1440
+    three_days = 4320
+    week = 10080
 
 
 T = TypeVar("T")

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1015,7 +1015,7 @@ class HTTPClient:
         message_id: Snowflake,
         *,
         name: str,
-        auto_archive_duration: threads.ThreadArchiveDuration,
+        auto_archive_duration: threads.ThreadArchiveDurationT,
         rate_limit_per_user: int = 0,
         reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
@@ -1038,7 +1038,7 @@ class HTTPClient:
         channel_id: Snowflake,
         *,
         name: str,
-        auto_archive_duration: threads.ThreadArchiveDuration,
+        auto_archive_duration: threads.ThreadArchiveDurationT,
         type: threads.ThreadType,
         invitable: bool = True,
         rate_limit_per_user: int = 0,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1015,7 +1015,7 @@ class HTTPClient:
         message_id: Snowflake,
         *,
         name: str,
-        auto_archive_duration: threads.ThreadArchiveDurationT,
+        auto_archive_duration: threads.ThreadArchiveDurationLiteral,
         rate_limit_per_user: int = 0,
         reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
@@ -1038,7 +1038,7 @@ class HTTPClient:
         channel_id: Snowflake,
         *,
         name: str,
-        auto_archive_duration: threads.ThreadArchiveDurationT,
+        auto_archive_duration: threads.ThreadArchiveDurationLiteral,
         type: threads.ThreadType,
         invitable: bool = True,
         rate_limit_per_user: int = 0,

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -54,7 +54,6 @@ from .enums import (
     ChannelType,
     InteractionType,
     try_enum,
-    ThreadArchiveDuration,
     try_enum_to_int,
 )
 from .errors import InvalidArgument, HTTPException
@@ -81,7 +80,6 @@ if TYPE_CHECKING:
     )
 
     from .types.components import Component as ComponentPayload
-    from .types.threads import ThreadArchiveDurationT
     from .types.member import (
         Member as MemberPayload,
         UserWithMember as UserWithMemberPayload,
@@ -89,6 +87,7 @@ if TYPE_CHECKING:
     from .types.user import User as UserPayload
     from .types.embed import Embed as EmbedPayload
     from .types.interactions import MessageInteraction as InteractionReferencePayload
+    from .types.threads import ThreadArchiveDurationLiteral
     from .abc import Snowflake
     from .abc import GuildChannel, MessageableChannel, MessageableChannel
     from .components import Component
@@ -96,6 +95,7 @@ if TYPE_CHECKING:
     from .channel import TextChannel, DMChannel, VoiceChannel
     from .mentions import AllowedMentions
     from .role import Role
+    from .threads import AnyThreadArchiveDuration
     from .ui.view import View
 
     MR = TypeVar("MR", bound="MessageReference")
@@ -1731,7 +1731,7 @@ class Message(Hashable):
         self,
         *,
         name: str,
-        auto_archive_duration: ThreadArchiveDurationT = None,
+        auto_archive_duration: AnyThreadArchiveDuration = None,
         slowmode_delay: int = None,
     ) -> Thread:
         """|coro|
@@ -1777,9 +1777,12 @@ class Message(Hashable):
         if self.guild is None:
             raise InvalidArgument("This message does not have guild info attached.")
 
-        auto_archive_duration = try_enum_to_int(auto_archive_duration)
+        if auto_archive_duration is not None:
+            auto_archive_duration: ThreadArchiveDurationLiteral = try_enum_to_int(
+                auto_archive_duration
+            )
 
-        default_auto_archive_duration: ThreadArchiveDurationT = getattr(
+        default_auto_archive_duration: ThreadArchiveDurationLiteral = getattr(
             self.channel, "default_auto_archive_duration", 1440
         )
         data = await self._state.http.start_thread_with_message(

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -49,7 +49,13 @@ from . import utils
 from .reaction import Reaction
 from .emoji import Emoji
 from .partial_emoji import PartialEmoji
-from .enums import MessageType, ChannelType, InteractionType, try_enum
+from .enums import (
+    MessageType,
+    ChannelType,
+    InteractionType,
+    try_enum,
+    ThreadArchiveDuration,
+)
 from .errors import InvalidArgument, HTTPException
 from .components import _component_factory
 from .embeds import Embed
@@ -74,7 +80,7 @@ if TYPE_CHECKING:
     )
 
     from .types.components import Component as ComponentPayload
-    from .types.threads import ThreadArchiveDuration
+    from .types.threads import ThreadArchiveDurationT
     from .types.member import (
         Member as MemberPayload,
         UserWithMember as UserWithMemberPayload,
@@ -1724,7 +1730,7 @@ class Message(Hashable):
         self,
         *,
         name: str,
-        auto_archive_duration: ThreadArchiveDuration = None,
+        auto_archive_duration: ThreadArchiveDurationT = None,
         slowmode_delay: int = None,
     ) -> Thread:
         """|coro|
@@ -1742,9 +1748,10 @@ class Message(Hashable):
         -----------
         name: :class:`str`
             The name of the thread.
-        auto_archive_duration: :class:`int`
+        auto_archive_duration: Union[:class:`int`, :class:`ThreadArchiveDuration`]
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
+            Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
@@ -1769,7 +1776,10 @@ class Message(Hashable):
         if self.guild is None:
             raise InvalidArgument("This message does not have guild info attached.")
 
-        default_auto_archive_duration: ThreadArchiveDuration = getattr(
+        if isinstance(auto_archive_duration, ThreadArchiveDuration):
+            auto_archive_duration = auto_archive_duration.value
+
+        default_auto_archive_duration: ThreadArchiveDurationT = getattr(
             self.channel, "default_auto_archive_duration", 1440
         )
         data = await self._state.http.start_thread_with_message(

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -55,6 +55,7 @@ from .enums import (
     InteractionType,
     try_enum,
     ThreadArchiveDuration,
+    try_enum_to_int,
 )
 from .errors import InvalidArgument, HTTPException
 from .components import _component_factory
@@ -1776,8 +1777,7 @@ class Message(Hashable):
         if self.guild is None:
             raise InvalidArgument("This message does not have guild info attached.")
 
-        if isinstance(auto_archive_duration, ThreadArchiveDuration):
-            auto_archive_duration = auto_archive_duration.value
+        auto_archive_duration = try_enum_to_int(auto_archive_duration)
 
         default_auto_archive_duration: ThreadArchiveDurationT = getattr(
             self.channel, "default_auto_archive_duration", 1440

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -30,7 +30,7 @@ import asyncio
 
 from .mixins import Hashable
 from .abc import Messageable
-from .enums import ChannelType, try_enum
+from .enums import ChannelType, try_enum, ThreadArchiveDuration
 from .errors import ClientException
 from .utils import MISSING, parse_time, snowflake_time, _get_as_snowflake
 
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
         Thread as ThreadPayload,
         ThreadMember as ThreadMemberPayload,
         ThreadMetadata,
-        ThreadArchiveDuration,
+        ThreadArchiveDurationT,
     )
     from .types.snowflake import SnowflakeList
     from .guild import Guild
@@ -545,7 +545,7 @@ class Thread(Messageable, Hashable):
         locked: bool = MISSING,
         invitable: bool = MISSING,
         slowmode_delay: int = MISSING,
-        auto_archive_duration: ThreadArchiveDuration = MISSING,
+        auto_archive_duration: ThreadArchiveDurationT = MISSING,
     ) -> Thread:
         """|coro|
 
@@ -569,7 +569,7 @@ class Thread(Messageable, Hashable):
         invitable: :class:`bool`
             Whether non-moderators can add other non-moderators to this thread.
             Only available for private threads.
-        auto_archive_duration: :class:`int`
+        auto_archive_duration: Union[:class:`int`, :class:`ThreadArchiveDuration`]
             The new duration in minutes before a thread is automatically archived for inactivity.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         slowmode_delay: :class:`int`
@@ -594,7 +594,10 @@ class Thread(Messageable, Hashable):
         if archived is not MISSING:
             payload["archived"] = archived
         if auto_archive_duration is not MISSING:
-            payload["auto_archive_duration"] = auto_archive_duration
+            if isinstance(auto_archive_duration, ThreadArchiveDuration):
+                payload["auto_archive_duration"] = auto_archive_duration.value
+            else:
+                payload["auto_archive_duration"] = auto_archive_duration
         if locked is not MISSING:
             payload["locked"] = locked
         if invitable is not MISSING:

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -30,7 +30,7 @@ import asyncio
 
 from .mixins import Hashable
 from .abc import Messageable
-from .enums import ChannelType, try_enum, ThreadArchiveDuration
+from .enums import ChannelType, try_enum, ThreadArchiveDuration, try_enum_to_int
 from .errors import ClientException
 from .utils import MISSING, parse_time, snowflake_time, _get_as_snowflake
 
@@ -594,10 +594,7 @@ class Thread(Messageable, Hashable):
         if archived is not MISSING:
             payload["archived"] = archived
         if auto_archive_duration is not MISSING:
-            if isinstance(auto_archive_duration, ThreadArchiveDuration):
-                payload["auto_archive_duration"] = auto_archive_duration.value
-            else:
-                payload["auto_archive_duration"] = auto_archive_duration
+            payload["auto_archive_duration"] = try_enum_to_int(auto_archive_duration)
         if locked is not MISSING:
             payload["locked"] = locked
         if invitable is not MISSING:

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
         Thread as ThreadPayload,
         ThreadMember as ThreadMemberPayload,
         ThreadMetadata,
-        ThreadArchiveDurationT,
+        ThreadArchiveDurationLiteral,
     )
     from .types.snowflake import SnowflakeList
     from .guild import Guild
@@ -57,6 +57,8 @@ if TYPE_CHECKING:
     from .state import ConnectionState
 
     import datetime
+
+    AnyThreadArchiveDuration = Union[ThreadArchiveDuration, ThreadArchiveDurationLiteral]
 
 
 class Thread(Messageable, Hashable):
@@ -545,7 +547,7 @@ class Thread(Messageable, Hashable):
         locked: bool = MISSING,
         invitable: bool = MISSING,
         slowmode_delay: int = MISSING,
-        auto_archive_duration: ThreadArchiveDurationT = MISSING,
+        auto_archive_duration: AnyThreadArchiveDuration = MISSING,
     ) -> Thread:
         """|coro|
 

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from typing import List, Literal, Optional, TypedDict, Union
 from .user import PartialUser
 from .snowflake import Snowflake
-from .threads import ThreadMetadata, ThreadMember, ThreadArchiveDuration
+from .threads import ThreadArchiveDurationT, ThreadMetadata, ThreadMember
 
 
 OverwriteType = Literal[0, 1]
@@ -63,7 +63,7 @@ class _TextChannelOptional(TypedDict, total=False):
     last_message_id: Optional[Snowflake]
     last_pin_timestamp: str
     rate_limit_per_user: int
-    default_auto_archive_duration: ThreadArchiveDuration
+    default_auto_archive_duration: ThreadArchiveDurationT
 
 
 class TextChannel(_BaseGuildChannel, _TextChannelOptional):

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 from typing import List, Literal, Optional, TypedDict, Union
 from .user import PartialUser
 from .snowflake import Snowflake
-from .threads import ThreadArchiveDurationT, ThreadMetadata, ThreadMember
+from .threads import ThreadArchiveDurationLiteral, ThreadMetadata, ThreadMember
 
 
 OverwriteType = Literal[0, 1]
@@ -63,7 +63,7 @@ class _TextChannelOptional(TypedDict, total=False):
     last_message_id: Optional[Snowflake]
     last_pin_timestamp: str
     rate_limit_per_user: int
-    default_auto_archive_duration: ThreadArchiveDurationT
+    default_auto_archive_duration: ThreadArchiveDurationLiteral
 
 
 class TextChannel(_BaseGuildChannel, _TextChannelOptional):

--- a/disnake/types/threads.py
+++ b/disnake/types/threads.py
@@ -23,12 +23,13 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from __future__ import annotations
-from typing import List, Literal, Optional, TypedDict
+from typing import List, Literal, Optional, TypedDict, Union
 
 from .snowflake import Snowflake
+from ..enums import ThreadArchiveDuration
 
 ThreadType = Literal[10, 11, 12]
-ThreadArchiveDuration = Literal[60, 1440, 4320, 10080]
+ThreadArchiveDurationT = Union[Literal[60, 1440, 4320, 10080], ThreadArchiveDuration]
 
 
 class ThreadMember(TypedDict):
@@ -46,7 +47,7 @@ class _ThreadMetadataOptional(TypedDict, total=False):
 
 class ThreadMetadata(_ThreadMetadataOptional):
     archived: bool
-    auto_archive_duration: ThreadArchiveDuration
+    auto_archive_duration: ThreadArchiveDurationT
     archive_timestamp: str
 
 

--- a/disnake/types/threads.py
+++ b/disnake/types/threads.py
@@ -23,13 +23,12 @@ DEALINGS IN THE SOFTWARE.
 """
 
 from __future__ import annotations
-from typing import List, Literal, Optional, TypedDict, Union
+from typing import List, Literal, Optional, TypedDict
 
 from .snowflake import Snowflake
-from ..enums import ThreadArchiveDuration
 
 ThreadType = Literal[10, 11, 12]
-ThreadArchiveDurationT = Union[Literal[60, 1440, 4320, 10080], ThreadArchiveDuration]
+ThreadArchiveDurationLiteral = Literal[60, 1440, 4320, 10080]
 
 
 class ThreadMember(TypedDict):
@@ -47,7 +46,7 @@ class _ThreadMetadataOptional(TypedDict, total=False):
 
 class ThreadMetadata(_ThreadMetadataOptional):
     archived: bool
-    auto_archive_duration: ThreadArchiveDurationT
+    auto_archive_duration: ThreadArchiveDurationLiteral
     archive_timestamp: str
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2981,6 +2981,28 @@ of :class:`enum.Enum`.
 
         The guild scheduled event is only for a specific guild.
 
+.. class:: ThreadArchiveDuration
+
+    Represents the automatic archive duration of a thread in minutes.
+
+    .. versionadded:: 2.3
+
+    .. attribute:: hour
+
+        The thread will archive after an hour.
+
+    .. attribute:: day
+
+        The thread will archive after a day.
+
+    .. attribute:: three_days
+
+        The thread will archive after three days.
+
+    .. attribute:: week
+    
+        The thread will archive after a week.
+
 
 Async Iterator
 ----------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2989,19 +2989,19 @@ of :class:`enum.Enum`.
 
     .. attribute:: hour
 
-        The thread will archive after an hour.
+        The thread will archive after an hour of inactivity.
 
     .. attribute:: day
 
-        The thread will archive after a day.
+        The thread will archive after a day of inactivity.
 
     .. attribute:: three_days
 
-        The thread will archive after three days.
+        The thread will archive after three days of inactivity.
 
     .. attribute:: week
-    
-        The thread will archive after a week.
+
+        The thread will archive after a week of inactivity.
 
 
 Async Iterator


### PR DESCRIPTION
## Summary

Building on @Victorsitou's solid base implementation, I present to you #186 v2.0, now with 50% more bells and whistles and other incredible features\*.
<sup>\* batteries not included</sup>

This PR adds a `ThreadArchiveDuration` enum with the (currently four) valid values, and renames the old `ThreadArchiveDuration` to `ThreadArchiveDurationLiteral` (there were no name conflicts, this is just to improve readability).
Resolves #181.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
    - *maybe? `disnake.types.ThreadArchiveDuration` is now `ThreadArchiveDurationLiteral`*
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
