### PR TITLE
Fixed a small command synchronization bug

### DIFF
--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -1308,7 +1308,9 @@ class InteractionBotBase(CommonBotBase):
                 try:
                     # This part is in a separate try-except because we still should respond to the interaction
                     await interaction.response.send_message(
-                        "This command was incorrectly synced. Please try again.", ephemeral=True
+                        "This command has just been synced. See also: https://docs.disnake.dev/"
+                        "en/latest/ext/commands/additional_info.html#app-command-sync.",
+                        ephemeral=True,
                     )
                 except disnake.HTTPException:
                     pass

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -1291,6 +1291,29 @@ class InteractionBotBase(CommonBotBase):
         interaction: :class:`disnake.ApplicationCommandInteraction`
             The interaction to process commands for.
         """
+        if self._sync_commands and not self._sync_queued:
+            known_command = self.get_global_command(interaction.data.id)  # type: ignore
+
+            if known_command is None:
+                known_command = self.get_guild_command(interaction.guild_id, interaction.data.id)  # type: ignore
+
+            if known_command is None:
+                # This usually comes from the blind spots of the sync algorithm.
+                # Since not all guild commands are cached, it is possible to experience such issues.
+                # In this case, the blind spot is the interaction guild, let's fix it:
+                try:
+                    await self.bulk_overwrite_guild_commands(interaction.guild_id, [])  # type: ignore
+                except disnake.HTTPException:
+                    pass
+                try:
+                    # This part is in a separate try-except because we still should respond to the interaction
+                    await interaction.response.send_message(
+                        "This command was incorrectly synced. Please try again.", ephemeral=True
+                    )
+                except disnake.HTTPException:
+                    pass
+                return
+
         interaction.bot = self  # type: ignore
         command_type = interaction.data.type
         command_name = interaction.data.name
@@ -1310,28 +1333,8 @@ class InteractionBotBase(CommonBotBase):
             event_name = "message_command"
 
         if event_name is None or app_command is None:
-            # If we got here, the command being invoked is either unknown or has an unknonw type.
+            # If we are here, the command being invoked is either unknown or has an unknonw type.
             # This usually happens if the auto sync is disabled, so let's just ignore this.
-            return
-
-        expected_command = self.get_global_command(interaction.data.id)  # type: ignore
-        if expected_command is None:
-            expected_command = self.get_guild_command(interaction.guild_id, interaction.data.id)  # type: ignore
-
-        if expected_command is None and self._sync_commands:
-            # This usually comes from the blind spots of the sync algorithm.
-            # Since not all guild commands are cached, it is possible to experience such issues.
-            # In this case, the blind spot is the interaction guild, let's fix it:
-            try:
-                await interaction.response.send_message(
-                    "This is a deprecated local command, which is now deleted.", ephemeral=True
-                )
-            except Exception:
-                pass
-            try:
-                await self.bulk_overwrite_guild_commands(interaction.guild_id, [])  # type: ignore
-            except Exception:
-                pass
             return
 
         self.dispatch(event_name, interaction)

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -874,9 +874,9 @@ class InteractionBotBase(CommonBotBase):
         # Wait a little bit, maybe other cogs are loading
         self._sync_queued = True
         await asyncio.sleep(2)
-        self._sync_queued = False
         await self._sync_application_commands()
         await self._sync_application_command_permissions()
+        self._sync_queued = False
 
     def _schedule_app_command_preparation(self) -> None:
         if not isinstance(self, disnake.Client):

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -1308,8 +1308,9 @@ class InteractionBotBase(CommonBotBase):
                 try:
                     # This part is in a separate try-except because we still should respond to the interaction
                     await interaction.response.send_message(
-                        "This command has just been synced. See also: https://docs.disnake.dev/"
-                        "en/latest/ext/commands/additional_info.html#app-command-sync.",
+                        "This command has just been synced. More information about this: "
+                        "https://docs.disnake.dev/en/latest/ext/commands/additional_info.html"
+                        "#app-command-sync.",
                         ephemeral=True,
                     )
                 except disnake.HTTPException:

--- a/docs/ext/commands/additional_info.rst
+++ b/docs/ext/commands/additional_info.rst
@@ -12,8 +12,8 @@ This section contains explanations of some library mechanics which may be useful
 App command sync
 -----------------
 
-If you're using ``ext.commands`` framework for application commands (slash commands, context menus) you should
-understand how your commands show up in Discord. If ``sync_commands`` kwarg is set to ``True`` (which is the default value)
+If you're using :ref:`discord_ext_commands` framework for application commands (slash commands, context menus) you should
+understand how your commands show up in Discord. If ``sync_commands`` kwarg of :class:`Bot <ext.commands.Bot>` (or a similar class) is set to ``True`` (which is the default value)
 the library registers / updates all commands automatically. Based on the application commands defined in your code it decides
 which commands should be registered, edited or deleted but there're some edge cases you should keep in mind.
 
@@ -26,6 +26,15 @@ it's enough to launch it at least once.
 Changing test guilds
 ++++++++++++++++++++
 
-If you remove some IDs from the ``test_guilds`` kwarg of ``commands.Bot`` (or a similar class) the commands in those guilds
-won't be deleted instantly. Instead, they'll be deleted as soon as one of the deprecated commands is invoked. Your bot will send a message
+If you remove some IDs from the ``test_guilds`` kwarg of :class:`Bot <ext.commands.Bot>` (or a similar class) or from the ``guild_ids`` kwarg of
+:func:`slash_command <ext.commands.slash_command>` (:func:`user_command <ext.commands.user_command>`, :func:`message_command <ext.commands.message_command>`)
+the commands in those guilds won't be deleted instantly. Instead, they'll be deleted as soon as one of the deprecated commands is invoked. Your bot will send a message
 like "This command has just been synced ...".
+
+Hosting the bot on multiple machines
+++++++++++++++++++++++++++++++++++++
+
+If your bot requires shard distribution across several machines, you should set ``sync_commands`` kwarg to ``False`` everywhere except 1 machine.
+This will prevent conflicts and race conditions. Discord API doesn't provide users with events related to application command updates,
+so it's impossible to keep the cache of multiple machines synced. Having only 1 machine with ``sync_commands`` set to ``True`` is enough
+because global registration of application commands doesn't depend on sharding.

--- a/docs/ext/commands/additional_info.rst
+++ b/docs/ext/commands/additional_info.rst
@@ -1,0 +1,31 @@
+.. currentmodule:: disnake
+
+.. _ext_commands_additional_info:
+
+Additional info
+===============
+
+This section contains explanations of some library mechanics which may be useful to know.
+
+.. _app_command_sync:
+
+App command sync
+-----------------
+
+If you're using ``ext.commands`` framework for application commands (slash commands, context menus) you should
+understand how your commands show up in Discord. If ``sync_commands`` kwarg is set to ``True`` (which is the default value)
+the library registers / updates all commands automatically. Based on the application commands defined in your code it decides
+which commands should be registered, edited or deleted but there're some edge cases you should keep in mind.
+
+Global registration
++++++++++++++++++++
+
+Registering commands globally may take up to 1 hour, this is an API limitation. You don't have to keep your bot online this whole time though,
+it's enough to launch it at least once.
+
+Changing test guilds
+++++++++++++++++++++
+
+If you remove some IDs from the ``test_guilds`` kwarg of ``commands.Bot`` (or a similar class) the commands in those guilds
+won't be deleted instantly. Instead, they'll be deleted as soon as one of the deprecated commands is invoked. Your bot will send a message
+like "This command was incorrectly synced ...".

--- a/docs/ext/commands/additional_info.rst
+++ b/docs/ext/commands/additional_info.rst
@@ -28,4 +28,4 @@ Changing test guilds
 
 If you remove some IDs from the ``test_guilds`` kwarg of ``commands.Bot`` (or a similar class) the commands in those guilds
 won't be deleted instantly. Instead, they'll be deleted as soon as one of the deprecated commands is invoked. Your bot will send a message
-like "This command was incorrectly synced ...".
+like "This command has just been synced ...".

--- a/docs/ext/commands/additional_info.rst
+++ b/docs/ext/commands/additional_info.rst
@@ -12,7 +12,7 @@ This section contains explanations of some library mechanics which may be useful
 App command sync
 -----------------
 
-If you're using :ref:`discord_ext_commands` framework for application commands (slash commands, context menus) you should
+If you're using :ref:`discord_ext_commands` for application commands (slash commands, context menus) you should
 understand how your commands show up in Discord. If ``sync_commands`` kwarg of :class:`Bot <ext.commands.Bot>` (or a similar class) is set to ``True`` (which is the default value)
 the library registers / updates all commands automatically. Based on the application commands defined in your code it decides
 which commands should be registered, edited or deleted but there're some edge cases you should keep in mind.

--- a/docs/ext/commands/index.rst
+++ b/docs/ext/commands/index.rst
@@ -17,3 +17,4 @@ extension library that handles this for you.
     cogs
     extensions
     api
+    additional_info


### PR DESCRIPTION
## Summary

Fixed a small sync algo bug that caused the "This is a deprecated local command which is now deleted" message if you invoke an application command before the sync finishes.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
