### PR TITLE
Add use Korean to slash_command()

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -424,8 +424,8 @@ class SlashCommand(ApplicationCommand):
         **kwargs,
     ):
         assert (
-            re.match(r"^[\w-]{1,32}$", name) is not None and name.islower()
-        ), f"Slash command name {name!r} should consist of these symbols: a-z, 0-9, -, _"
+            re.match(r"^[a-zㄱ-힣-_\d]{1,32}$", name) is not None
+        ), f"Slash command name {name!r} should consist of these symbols: a-z, ㄱ-힣, 0-9, -, _"
 
         super().__init__(
             type=ApplicationCommandType.chat_input,

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -166,9 +166,7 @@ class Option:
         min_value: float = None,
         max_value: float = None,
     ):
-        assert name.islower(), f"Option name {name!r} must be lowercase"
-
-        self.name: str = name
+        self.name: str = name.lower()
         self.description: Optional[str] = description
         self.type: OptionType = enum_if_int(OptionType, type) or OptionType.string
         self.required: bool = required
@@ -423,9 +421,10 @@ class SlashCommand(ApplicationCommand):
         default_permission: bool = True,
         **kwargs,
     ):
+        name = name.lower()
         assert (
-            re.match(r"^[a-zㄱ-힣-_\d]{1,32}$", name) is not None
-        ), f"Slash command name {name!r} should consist of these symbols: a-z, ㄱ-힣, 0-9, -, _"
+            re.fullmatch(r"[\w-]{1,32}", name)
+        ), f"Slash command name {name!r} should consist of these symbols: a-z, 0-9, -, _"
 
         super().__init__(
             type=ApplicationCommandType.chat_input,

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -422,9 +422,9 @@ class SlashCommand(ApplicationCommand):
         **kwargs,
     ):
         name = name.lower()
-        assert (
-            re.fullmatch(r"[\w-]{1,32}", name)
-        ), f"Slash command name {name!r} should consist of these symbols: a-z, 0-9, -, _"
+        assert re.fullmatch(r"[\w-]{1,32}", name), (
+            f"Slash command name {name!r} should consist of these symbols: a-z, 0-9, -, _"
+        )
 
         super().__init__(
             type=ApplicationCommandType.chat_input,

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -422,9 +422,9 @@ class SlashCommand(ApplicationCommand):
         **kwargs,
     ):
         name = name.lower()
-        assert re.fullmatch(r"[\w-]{1,32}", name), (
-            f"Slash command name {name!r} should consist of these symbols: a-z, 0-9, -, _"
-        )
+        assert re.fullmatch(
+            r"[\w-]{1,32}", name
+        ), f"Slash command name {name!r} should consist of these symbols: a-z, 0-9, -, _"
 
         super().__init__(
             type=ApplicationCommandType.chat_input,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixed an issue where the Korean slash_command name is supported in Discord but not in this module.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
