### PR TITLE
`fail_if_not_exists` in `Message.reply()` is now True by default.

### DIFF
--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1823,8 +1823,8 @@ class Message(Hashable):
         :class:`.Message`
             The message that was sent.
         """
-        if fail_if_not_exists:
-            reference = MessageReference.from_message(self, fail_if_not_exists=True)
+        if not fail_if_not_exists:
+            reference = MessageReference.from_message(self, fail_if_not_exists=False)
         else:
             reference = self
         return await self.channel.send(content, reference=reference, **kwargs)

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1805,6 +1805,9 @@ class Message(Hashable):
 
         .. versionadded:: 1.6
 
+        .. versionchanged:: 2.3
+            Added ``fail_if_not_exists`` keyword argument. Defaults to ``False``.
+
         Raises
         --------
         ~disnake.HTTPException
@@ -1822,7 +1825,7 @@ class Message(Hashable):
         """
 
         reference = MessageReference.from_message(self, fail_if_not_exists=fail_if_not_exists)
-        return await self.channel.send(content, reference=reference, **kwargs)
+        return await self.channel.send(content, reference=reference, **kwargs)  # type: ignore
 
     def to_reference(self, *, fail_if_not_exists: bool = True) -> MessageReference:
         """Creates a :class:`~disnake.MessageReference` from the current message.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1795,7 +1795,9 @@ class Message(Hashable):
         )
         return Thread(guild=self.guild, state=self._state, data=data)
 
-    async def reply(self, content: Optional[str] = None, **kwargs) -> Message:
+    async def reply(
+        self, content: Optional[str] = None, *, fail_if_not_exists: bool = False, **kwargs
+    ) -> Message:
         """|coro|
 
         A shortcut method to :meth:`.abc.Messageable.send` to reply to the
@@ -1819,7 +1821,8 @@ class Message(Hashable):
             The message that was sent.
         """
 
-        return await self.channel.send(content, reference=self, **kwargs)
+        reference = MessageReference.from_message(self, fail_if_not_exists=fail_if_not_exists)
+        return await self.channel.send(content, reference=reference, **kwargs)
 
     def to_reference(self, *, fail_if_not_exists: bool = True) -> MessageReference:
         """Creates a :class:`~disnake.MessageReference` from the current message.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1796,7 +1796,7 @@ class Message(Hashable):
         return Thread(guild=self.guild, state=self._state, data=data)
 
     async def reply(
-        self, content: Optional[str] = None, *, fail_if_not_exists: bool = False, **kwargs
+        self, content: Optional[str] = None, *, fail_if_not_exists: bool = True, **kwargs
     ) -> Message:
         """|coro|
 
@@ -1806,7 +1806,7 @@ class Message(Hashable):
         .. versionadded:: 1.6
 
         .. versionchanged:: 2.3
-            Added ``fail_if_not_exists`` keyword argument. Defaults to ``False``.
+            Added ``fail_if_not_exists`` keyword argument. Defaults to ``True``.
 
         Raises
         --------

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1823,9 +1823,11 @@ class Message(Hashable):
         :class:`.Message`
             The message that was sent.
         """
-
-        reference = MessageReference.from_message(self, fail_if_not_exists=fail_if_not_exists)
-        return await self.channel.send(content, reference=reference, **kwargs)  # type: ignore
+        if fail_if_not_exists:
+            reference = MessageReference.from_message(self, fail_if_not_exists=True)
+        else:
+            reference = self
+        return await self.channel.send(content, reference=reference, **kwargs)
 
     def to_reference(self, *, fail_if_not_exists: bool = True) -> MessageReference:
         """Creates a :class:`~disnake.MessageReference` from the current message.


### PR DESCRIPTION
## Summary

This is basically to follow the same default value in all functions that use it.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
