### PR TITLE
Add audit log target converter for scheduled events

### DIFF
--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
     from .stage_instance import StageInstance
     from .sticker import GuildSticker
     from .threads import Thread
+    from .guild_scheduled_event import GuildScheduledEvent
 
 
 def _transform_permissions(entry: AuditLogEntry, data: str) -> Permissions:
@@ -502,6 +503,7 @@ class AuditLogEntry(Hashable):
         StageInstance,
         GuildSticker,
         Thread,
+        GuildScheduledEvent,
         Object,
         None,
     ]:
@@ -583,3 +585,8 @@ class AuditLogEntry(Hashable):
 
     def _convert_target_thread(self, target_id: int) -> Union[Thread, Object]:
         return self.guild.get_thread(target_id) or Object(id=target_id)
+
+    def _convert_target_guild_scheduled_event(
+        self, target_id: int
+    ) -> Union[GuildScheduledEvent, Object]:
+        return self.guild.get_scheduled_event(target_id) or Object(id=target_id)


### PR DESCRIPTION
## Summary

This PR adds the previously missing `AuditLogEntry.target` converter for guild scheduled events, which was already documented but not implemented yet.

## Checklist

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
