### PR TITLE
Fixed GuildCommandInteraction

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -593,7 +593,7 @@ def collect_params(
                 cog_param = parameter
             else:
                 raise TypeError(
-                    f"Found two candidates for the cog parameter in {function!r}: {inter_param.name} and {parameter.name}"
+                    f"Found two candidates for the cog parameter in {function!r}: {cog_param.name} and {parameter.name}"
                 )
         else:
             paraminfo = ParamInfo.from_param(parameter, {}, doc)
@@ -683,7 +683,16 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
 
     Returns the created options
     """
-    params = collect_nested_params(command.callback)
+    sig = signature(command.callback)
+    _, inter_param, params, injections = collect_params(command.callback)
+
+    if inter_param is None:
+        raise TypeError(f"Couldn't find an interaction paramter in {command.callback}")
+
+    for injection in injections.values():
+        params += collect_nested_params(injection.function)
+
+    params = sorted(params, key=lambda param: not param.required)
 
     # update connectors and autocompleters
     for param in params:
@@ -692,7 +701,8 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
         if param.autocomplete:
             command.autocompleters[param.name] = param.autocomplete
 
-    # TODO: Apply stuff like GuildCommandInteraction
+    if issubclass_(sig.parameters[inter_param].annotation, disnake.GuildCommandInteraction):
+        command.guild_only = True
 
     return [param.to_option() for param in params]
 
@@ -819,7 +829,7 @@ class ConverterMethod(classmethod):
     A decorator to register a method as the converter method
     """
 
-    def __set_name__(self, owner: Type[Any], name: str):
+    def __set_name__(self, owner: Any, name: str):
         # this feels wrong
         function = self.__get__(None, owner)
         ParamInfo._registered_converters[owner] = function

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -687,7 +687,7 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
     _, inter_param, params, injections = collect_params(command.callback)
 
     if inter_param is None:
-        raise TypeError(f"Couldn't find an interaction paramter in {command.callback}")
+        raise TypeError(f"Couldn't find an interaction parameter in {command.callback}")
 
     for injection in injections.values():
         params += collect_nested_params(injection.function)

--- a/tests/cogs/slash_commands.py
+++ b/tests/cogs/slash_commands.py
@@ -38,6 +38,10 @@ class SlashCommands(commands.Cog):
     ):
         await inter.send(mood)
 
+    @commands.slash_command()
+    async def guild_only(self, inter: disnake.GuildCommandInteraction, option: str = None):
+        await inter.send(f"guild: {inter.guild} | option: {option!r}")
+
 
 def setup(bot):
     bot.add_cog(SlashCommands(bot))


### PR DESCRIPTION
## Summary

`GuildCommandInteraction` failed to mark the command as guild-only

## Checklist

- [ ] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
