### PR TITLE
Remove `on_member_screening_reject` event

### DIFF
--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -572,7 +572,6 @@ class Intents(BaseFlags):
         - :func:`on_member_join`
         - :func:`on_member_remove`
         - :func:`on_member_update`
-        - :func:`on_member_screening_decline`
         - :func:`on_user_update`
         - :func:`on_guild_scheduled_event_subscribe`
         - :func:`on_guild_scheduled_event_unsubscribe`

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -572,6 +572,7 @@ class Intents(BaseFlags):
         - :func:`on_member_join`
         - :func:`on_member_remove`
         - :func:`on_member_update`
+        - :func:`on_member_screening_decline`
         - :func:`on_user_update`
         - :func:`on_guild_scheduled_event_subscribe`
         - :func:`on_guild_scheduled_event_unsubscribe`
@@ -590,10 +591,6 @@ class Intents(BaseFlags):
         - :attr:`User.name`
         - :attr:`User.avatar`
         - :attr:`User.discriminator`
-
-        Note that due to an implicit relationship this also corresponds to the following events:
-
-        - :func:`on_member_screening_reject`
 
         For more information go to the :ref:`member intent documentation <need_members_intent>`.
 

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
         MessageUpdateEvent,
         ReactionClearEvent,
         ReactionClearEmojiEvent,
-        MemberScreeningRejectEvent,
         IntegrationDeleteEvent,
         TypingEvent,
     )
@@ -53,7 +52,6 @@ __all__ = (
     "RawReactionActionEvent",
     "RawReactionClearEvent",
     "RawReactionClearEmojiEvent",
-    "RawMemberScreeningRejectEvent",
     "RawIntegrationDeleteEvent",
     "RawGuildScheduledEventUserActionEvent",
     "RawTypingEvent",
@@ -256,26 +254,6 @@ class RawReactionClearEmojiEvent(_RawReprMixin):
             self.guild_id: Optional[int] = int(data["guild_id"])
         except KeyError:
             self.guild_id: Optional[int] = None
-
-
-class RawMemberScreeningRejectEvent(_RawReprMixin):
-    """Represents the payload for a :func:`on_raw_member_screening_reject` event.
-
-    .. versionadded:: 2.3
-
-    Attributes
-    -----------
-    guild_id: :class:`int`
-        The guild ID of the guild which the user left.
-    user_id: :class:`int`
-        The user ID of the user who left the guild.
-    """
-
-    __slots__ = ("guild_id", "user_id")
-
-    def __init__(self, data: MemberScreeningRejectEvent) -> None:
-        self.guild_id: int = int(data["guild_id"])
-        self.user_id: int = int(data["user_id"])
 
 
 class RawIntegrationDeleteEvent(_RawReprMixin):

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1236,8 +1236,7 @@ class ConnectionState:
             )
 
     def parse_guild_join_request_delete(self, data) -> None:
-        raw = RawMemberScreeningRejectEvent(data)
-        guild = self._get_guild(raw.guild_id)
+        guild = self._get_guild(int(data["guild_id"]))
         if guild is None:
             _log.debug(
                 "GUILD_JOIN_REQUEST_DELETE referencing an unknown guild ID: %s. Discarding.",
@@ -1245,10 +1244,9 @@ class ConnectionState:
             )
             return
 
-        self.dispatch("raw_member_screening_reject", raw)
-        member = guild.get_member(raw.user_id)
+        member = guild.get_member(int(data["user_id"]))
         if member is not None:
-            self.dispatch("member_screening_reject", member)
+            self.dispatch("member_screening_decline", member)
 
     def parse_guild_emojis_update(self, data) -> None:
         guild = self._get_guild(int(data["guild_id"]))

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1235,19 +1235,6 @@ class ConnectionState:
                 "GUILD_MEMBER_UPDATE referencing an unknown member ID: %s. Discarding.", user_id
             )
 
-    def parse_guild_join_request_delete(self, data) -> None:
-        guild = self._get_guild(int(data["guild_id"]))
-        if guild is None:
-            _log.debug(
-                "GUILD_JOIN_REQUEST_DELETE referencing an unknown guild ID: %s. Discarding.",
-                data["guild_id"],
-            )
-            return
-
-        member = guild.get_member(int(data["user_id"]))
-        if member is not None:
-            self.dispatch("member_screening_decline", member)
-
     def parse_guild_emojis_update(self, data) -> None:
         guild = self._get_guild(int(data["guild_id"]))
         if guild is None:

--- a/disnake/types/raw_models.py
+++ b/disnake/types/raw_models.py
@@ -79,11 +79,6 @@ class ReactionClearEmojiEvent(_ReactionClearEmojiEventOptional):
     emoji: PartialEmoji
 
 
-class MemberScreeningRejectEvent(TypedDict):
-    guild_id: Snowflake
-    user_id: Snowflake
-
-
 class _IntegrationDeleteEventOptional(TypedDict, total=False):
     application_id: Snowflake
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -914,37 +914,19 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param after: The updated member's updated info.
     :type after: :class:`Member`
 
-.. function:: on_member_screening_reject(member)
+.. function:: on_member_screening_decline(member)
 
     .. note::
         This is currently not officially documented or supported by the API, but has been consistently emitted for a while
 
     Called when a :class:`Member` leaves a :class:`Guild` without completing
     membership screening. This does not replace :func:`on_member_remove`;
-    both will be called, given the approriate intents are enabled.
-
-    If the member is not found in the internal member cache, this event will
-    not be called (hence the requirement for :attr:`Intents.members`).
-    Consider using :func:`on_raw_member_screening_reject` instead.
+    both will be called.
 
     This requires :attr:`Intents.members` to be enabled.
 
-    .. versionadded:: 2.3
-
     :param member: The member that left.
     :type member: :class:`Member`
-
-.. function:: on_raw_member_screening_reject(payload)
-
-    Called when a :class:`Member` leaves a :class:`Guild` without completing
-    membership screening. Unlike :func:`on_member_screening_reject`, this is
-    called regardless of the state of the internal member cache, and therefore
-    does not require :attr:`Intents.members` to be enabled.
-
-    .. versionadded:: 2.3
-
-    :param payload: The raw event payload data.
-    :type payload: :class:`RawMemberScreeningRejectEvent`
 
 .. function:: on_presence_update(before, after)
 
@@ -4483,14 +4465,6 @@ RawReactionClearEmojiEvent
 .. attributetable:: RawReactionClearEmojiEvent
 
 .. autoclass:: RawReactionClearEmojiEvent()
-    :members:
-
-RawMemberScreeningRejectEvent
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. attributetable:: RawMemberScreeningRejectEvent
-
-.. autoclass:: RawMemberScreeningRejectEvent()
     :members:
 
 RawIntegrationDeleteEvent

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -914,20 +914,6 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param after: The updated member's updated info.
     :type after: :class:`Member`
 
-.. function:: on_member_screening_decline(member)
-
-    .. note::
-        This is currently not officially documented or supported by the API, but has been consistently emitted for a while
-
-    Called when a :class:`Member` leaves a :class:`Guild` without completing
-    membership screening. This does not replace :func:`on_member_remove`;
-    both will be called.
-
-    This requires :attr:`Intents.members` to be enabled.
-
-    :param member: The member that left.
-    :type member: :class:`Member`
-
 .. function:: on_presence_update(before, after)
 
     Called when a :class:`Member` updates their presence.


### PR DESCRIPTION
## Summary

[as title]
The API is still actively changing (especially over the last few weeks) and this event isn't documented at all, so it's being removed again for now. Originally it seemed to work fine, however it looks like the event is now emitted even when completing screening, with no way to differentiate between someone leaving the server and completing membership screening.

Reverts #109 and 659966ee528cf36d87b66c3cf9b4967e318063d0.

## Checklist

- [ ] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
