### PR TITLE
Improve timeout method parameters

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3408,6 +3408,26 @@ class Guild(Hashable):
         """
         return await self._state.bulk_edit_command_permissions(self.id, permissions)
 
+    @overload
+    async def timeout(
+        self,
+        user: Snowflake,
+        *,
+        duration: Optional[Union[float, datetime.timedelta]],
+        reason: Optional[str] = None,
+    ) -> Member:
+        ...
+
+    @overload
+    async def timeout(
+        self,
+        user: Snowflake,
+        *,
+        until: Optional[datetime.datetime],
+        reason: Optional[str] = None,
+    ) -> Member:
+        ...
+
     async def timeout(
         self,
         user: Snowflake,

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3412,7 +3412,7 @@ class Guild(Hashable):
         self,
         user: Snowflake,
         *,
-        until: Optional[Union[float, datetime.datetime]],
+        duration: Optional[Union[float, datetime.timedelta, datetime.datetime]],
         reason: Optional[str] = None,
     ) -> Member:
         """|coro|
@@ -3429,7 +3429,7 @@ class Guild(Hashable):
         -----------
         user: :class:`abc.Snowflake`
             The member to timeout.
-        until: Optional[Union[:class:`float`, :class:`datetime.datetime`]]
+        duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`, :class:`datetime.datetime`]]
             The seconds or datetime to timeout the member. Set to ``None`` to remove the timeout.
             Support up to 28 days in the future.
         reason: Optional[:class:`str`]
@@ -3449,11 +3449,13 @@ class Guild(Hashable):
         """
         payload: Dict[str, Any] = {}
 
-        if until is not None:
-            if isinstance(until, datetime.datetime):
-                dt = until.astimezone(datetime.timezone.utc)
+        if duration is not None:
+            if isinstance(duration, datetime.datetime):
+                dt = duration.astimezone(datetime.timezone.utc)
+            elif isinstance(duration, datetime.timedelta):
+                dt = utils.utcnow() + duration
             else:
-                dt = utils.utcnow() + datetime.timedelta(seconds=until)
+                dt = utils.utcnow() + datetime.timedelta(seconds=duration)
             payload["communication_disabled_until"] = dt.isoformat()
         else:
             payload["communication_disabled_until"] = None

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3412,12 +3412,15 @@ class Guild(Hashable):
         self,
         user: Snowflake,
         *,
-        duration: Optional[Union[float, datetime.timedelta, datetime.datetime]],
+        duration: Optional[Union[float, datetime.timedelta]] = MISSING,
+        until: Optional[datetime.datetime] = MISSING,
         reason: Optional[str] = None,
     ) -> Member:
         """|coro|
 
         Times out the member from the guild; until then, the member will not be able to interact with the guild.
+
+        Exactly one of ``duration`` and ``until`` must be provided.
 
         The user must meet the :class:`abc.Snowflake` abc.
 
@@ -3429,9 +3432,14 @@ class Guild(Hashable):
         -----------
         user: :class:`abc.Snowflake`
             The member to timeout.
-        duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`, :class:`datetime.datetime`]]
-            The seconds or datetime to timeout the member. Set to ``None`` to remove the timeout.
-            Support up to 28 days in the future.
+        duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`]]
+            The duration of the member's timeout. Set to ``None`` to remove the timeout.
+            Supports up to 28 days in the future.
+            May not be used in combination with the ``until`` parameter.
+        until: Optional[:class:`datetime.datetime`]
+            The expiry date/time of the member's timeout. Set to ``None`` to remove the timeout.
+            Supports up to 28 days in the future.
+            May not be used in combination with the ``duration`` parameter.
         reason: Optional[:class:`str`]
             The reason for this timeout. Shows up on the audit log.
 
@@ -3447,16 +3455,24 @@ class Guild(Hashable):
         :class:`Member`
             The newly updated member.
         """
+
+        if not (duration is MISSING) ^ (until is MISSING):
+            raise ValueError("Exactly one of `duration` and `until` must be provided")
+
         payload: Dict[str, Any] = {}
 
-        if duration is not None:
-            if isinstance(duration, datetime.datetime):
-                dt = duration.astimezone(datetime.timezone.utc)
+        if duration is not MISSING:
+            if duration is None:
+                until = None
             elif isinstance(duration, datetime.timedelta):
-                dt = utils.utcnow() + duration
+                until = utils.utcnow() + duration
             else:
-                dt = utils.utcnow() + datetime.timedelta(seconds=duration)
-            payload["communication_disabled_until"] = dt.isoformat()
+                until = utils.utcnow() + datetime.timedelta(seconds=duration)
+
+        # at this point `until` cannot be `MISSING`
+        if until is not None:
+            until = until.astimezone(datetime.timezone.utc)
+            payload["communication_disabled_until"] = until.isoformat()
         else:
             payload["communication_disabled_until"] = None
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3440,7 +3440,7 @@ class Guild(Hashable):
 
         Times out the member from the guild; until then, the member will not be able to interact with the guild.
 
-        Exactly one of ``duration`` and ``until`` must be provided.
+        Exactly one of ``duration`` or ``until`` must be provided. To remove a timeout, set one of the parameters to ``None``.
 
         The user must meet the :class:`abc.Snowflake` abc.
 
@@ -3453,7 +3453,7 @@ class Guild(Hashable):
         user: :class:`abc.Snowflake`
             The member to timeout.
         duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`]]
-            The duration of the member's timeout. Set to ``None`` to remove the timeout.
+            The duration (seconds or timedelta) of the member's timeout. Set to ``None`` to remove the timeout.
             Supports up to 28 days in the future.
             May not be used in combination with the ``until`` parameter.
         until: Optional[:class:`datetime.datetime`]

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -762,8 +762,9 @@ class Member(disnake.abc.Messageable, _UserTag):
             The voice channel to move the member to.
             Pass ``None`` to kick them from voice.
         timeout: Optional[Union[:class:`float`, :class:`datetime.timedelta`, :class:`datetime.datetime`]]
-            The seconds or datetime when the timeout expires; until then, the member will not be able to interact with the guild.
-            Set to ``None`` to remove the timeout. Support up to 28 days in the future.
+            The duration (seconds or timedelta) or the expiry (datetime) of the timeout;
+            until then, the member will not be able to interact with the guild.
+            Set to ``None`` to remove the timeout. Supports up to 28 days in the future.
 
             .. versionadded:: 2.3
         reason: Optional[:class:`str`]
@@ -1035,7 +1036,7 @@ class Member(disnake.abc.Messageable, _UserTag):
 
         Times out the member from the guild; until then, the member will not be able to interact with the guild.
 
-        Exactly one of ``duration`` and ``until`` must be provided.
+        Exactly one of ``duration`` or ``until`` must be provided. To remove a timeout, set one of the parameters to ``None``.
 
         You must have the :attr:`Permissions.moderate_members` permission to do this.
 
@@ -1044,7 +1045,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         Parameters
         ----------
         duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`]]
-            The duration of the member's timeout. Set to ``None`` to remove the timeout.
+            The duration (seconds or timedelta) of the member's timeout. Set to ``None`` to remove the timeout.
             Supports up to 28 days in the future.
             May not be used in combination with the ``until`` parameter.
         until: Optional[:class:`datetime.datetime`]

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -1006,11 +1006,17 @@ class Member(disnake.abc.Messageable, _UserTag):
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None
 
     async def timeout(
-        self, *, duration: Optional[Union[float, datetime.timedelta, datetime.datetime]], reason: Optional[str] = None
+        self,
+        *,
+        duration: Optional[Union[float, datetime.timedelta]] = MISSING,
+        until: Optional[datetime.datetime] = MISSING,
+        reason: Optional[str] = None,
     ) -> Member:
         """|coro|
 
         Times out the member from the guild; until then, the member will not be able to interact with the guild.
+
+        Exactly one of ``duration`` and ``until`` must be provided.
 
         You must have the :attr:`Permissions.moderate_members` permission to do this.
 
@@ -1018,9 +1024,14 @@ class Member(disnake.abc.Messageable, _UserTag):
 
         Parameters
         ----------
-        duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`, :class:`datetime.datetime`]]
-            The seconds or datetime to timeout. Set to ``None`` to remove the timeout.
-            Support up to 28 days in the future.
+        duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`]]
+            The duration of the member's timeout. Set to ``None`` to remove the timeout.
+            Supports up to 28 days in the future.
+            May not be used in combination with the ``until`` parameter.
+        until: Optional[:class:`datetime.datetime`]
+            The expiry date/time of the member's timeout. Set to ``None`` to remove the timeout.
+            Supports up to 28 days in the future.
+            May not be used in combination with the ``duration`` parameter.
         reason: Optional[:class:`str`]
             The reason for this timeout. Appears on the audit log.
 
@@ -1036,4 +1047,4 @@ class Member(disnake.abc.Messageable, _UserTag):
         :class:`Member`
             The newly updated member.
         """
-        return await self.guild.timeout(self, duration=duration, reason=reason)
+        return await self.guild.timeout(self, duration=duration, until=until, reason=reason)

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -41,6 +41,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    overload,
 )
 
 import disnake.abc
@@ -1005,6 +1006,24 @@ class Member(disnake.abc.Messageable, _UserTag):
         """
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None
 
+    @overload
+    async def timeout(
+        self,
+        *,
+        duration: Optional[Union[float, datetime.timedelta]],
+        reason: Optional[str] = None,
+    ) -> Member:
+        ...
+
+    @overload
+    async def timeout(
+        self,
+        *,
+        until: Optional[datetime.datetime],
+        reason: Optional[str] = None,
+    ) -> Member:
+        ...
+
     async def timeout(
         self,
         *,
@@ -1047,4 +1066,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         :class:`Member`
             The newly updated member.
         """
-        return await self.guild.timeout(self, duration=duration, until=until, reason=reason)
+        if duration is not MISSING:
+            return await self.guild.timeout(self, duration=duration, reason=reason)
+        else:
+            return await self.guild.timeout(self, until=until, reason=reason)

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -710,7 +710,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         suppress: bool = MISSING,
         roles: List[disnake.abc.Snowflake] = MISSING,
         voice_channel: Optional[VocalGuildChannel] = MISSING,
-        timeout: Optional[Union[float, datetime.datetime]] = MISSING,
+        timeout: Optional[Union[float, datetime.timedelta, datetime.datetime]] = MISSING,
         reason: Optional[str] = None,
     ) -> Optional[Member]:
         """|coro|
@@ -760,7 +760,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         voice_channel: Optional[:class:`VoiceChannel`]
             The voice channel to move the member to.
             Pass ``None`` to kick them from voice.
-        timeout: Optional[Union[:class:`float`, :class:`datetime.datetime`]]
+        timeout: Optional[Union[:class:`float`, :class:`datetime.timedelta`, :class:`datetime.datetime`]]
             The seconds or datetime when the timeout expires; until then, the member will not be able to interact with the guild.
             Set to ``None`` to remove the timeout. Support up to 28 days in the future.
 
@@ -830,6 +830,8 @@ class Member(disnake.abc.Messageable, _UserTag):
             if timeout is not None:
                 if isinstance(timeout, datetime.datetime):
                     dt = timeout.astimezone(tz=datetime.timezone.utc)
+                elif isinstance(timeout, datetime.timedelta):
+                    dt = utils.utcnow() + timeout
                 else:
                     dt = utils.utcnow() + datetime.timedelta(seconds=timeout)
                 payload["communication_disabled_until"] = dt.isoformat()
@@ -1004,7 +1006,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         return self.guild.get_role(role_id) if self._roles.has(role_id) else None
 
     async def timeout(
-        self, *, until: Optional[Union[float, datetime.datetime]], reason: Optional[str] = None
+        self, *, duration: Optional[Union[float, datetime.timedelta, datetime.datetime]], reason: Optional[str] = None
     ) -> Member:
         """|coro|
 
@@ -1016,7 +1018,7 @@ class Member(disnake.abc.Messageable, _UserTag):
 
         Parameters
         ----------
-        until: Optional[Union[:class:`float`, :class:`datetime.datetime`]]
+        duration: Optional[Union[:class:`float`, :class:`datetime.timedelta`, :class:`datetime.datetime`]]
             The seconds or datetime to timeout. Set to ``None`` to remove the timeout.
             Support up to 28 days in the future.
         reason: Optional[:class:`str`]
@@ -1034,4 +1036,4 @@ class Member(disnake.abc.Messageable, _UserTag):
         :class:`Member`
             The newly updated member.
         """
-        return await self.guild.timeout(self, until=until, reason=reason)
+        return await self.guild.timeout(self, duration=duration, reason=reason)


### PR DESCRIPTION
## Summary

This PR adds support for `duration` (`float`/`timedelta`) and `until` (`datetime`) parameters to `Member.timeout` and `Guild.timeout`, as well as supporting `timedelta` parameters in `Member.edit(timeout=...)`.

## Checklist

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
