### PR TITLE
Added lower level components syntax

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1344,7 +1344,6 @@ class Messageable:
             A Discord UI View to add to the message. This can not be mixed with ``components``.
 
             .. versionadded:: 2.0
-
         components: |components_type|
             A list of components to include in the message. This can not be mixed with ``view``.
 

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -57,7 +57,7 @@ from .invite import Invite
 from .file import File
 from .voice_client import VoiceClient, VoiceProtocol
 from .sticker import GuildSticker, StickerItem
-from .ui.action_row import components_to_action_rows
+from .ui.action_row import components_to_dict
 from . import utils
 
 __all__ = (
@@ -1430,9 +1430,7 @@ class Messageable:
             components_payload = view.to_components()
 
         elif components:
-            components_payload = [
-                component.to_component_dict() for component in components_to_action_rows(components)
-            ]
+            components_payload = components_to_dict(components)
 
         else:
             components_payload = None

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1343,12 +1343,12 @@ class Messageable:
 
             .. versionadded:: 1.6
         view: :class:`disnake.ui.View`
-            A Discord UI View to add to the message. This can not be specified together with ``components``.
+            A Discord UI View to add to the message. This can not be mixed with ``components``.
 
             .. versionadded:: 2.0
 
-        components: Any
-            A list of components to include in the message. This can not be specified together with ``view``.
+        components: |components_type|
+            A list of components to include in the message. This can not be mixed with ``view``.
 
             .. versionadded:: 2.4
 

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -87,8 +87,7 @@ if TYPE_CHECKING:
     from .threads import Thread
     from .enums import InviteTarget
     from .guild_scheduled_event import GuildScheduledEvent
-    from .ui.action_row import ActionRow
-    from .ui.item import Item
+    from .ui.action_row import Components
     from .ui.view import View
     from .types.channel import (
         PermissionOverwrite as PermissionOverwritePayload,
@@ -99,7 +98,6 @@ if TYPE_CHECKING:
 
     MessageableChannel = Union[TextChannel, Thread, DMChannel, PartialMessageable, VoiceChannel]
     SnowflakeTime = Union["Snowflake", datetime]
-    Components = Union[ActionRow, Item, List[Union[ActionRow, Item, List[Item]]]]
 
 MISSING = utils.MISSING
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -65,7 +65,8 @@ if TYPE_CHECKING:
     from ..mentions import AllowedMentions
     from aiohttp import ClientSession
     from ..embeds import Embed
-    from ..ui import ActionRow, Item, View
+    from ..ui.action_row import Components
+    from ..ui.view import View
     from ..channel import (
         VoiceChannel,
         StageChannel,
@@ -86,8 +87,6 @@ if TYPE_CHECKING:
         Thread,
         PartialMessageable,
     ]
-
-    Components = Union[ActionRow, Item, List[Union[ActionRow, Item, List[Item]]]]
 
 MISSING: Any = utils.MISSING
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -357,9 +357,9 @@ class Interaction:
             .. versionadded:: 2.2
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
-            the view is removed. This can not be specified together with ``components``.
-        components: Optional[Any]
-            A list of components to update this message with. This can not be specified together with ``view``.
+            the view is removed. This can not be mixed with ``components``.
+        components: Optional[|components_type|]
+            A list of components to update this message with. This can not be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
@@ -529,9 +529,9 @@ class Interaction:
         tts: :class:`bool`
             Indicates if the message should be sent using text-to-speech.
         view: :class:`disnake.ui.View`
-            The view to send with the message. This can not be specified together with ``components``.
-        components: Any
-            A list of components to send with the message. This can not be specified together with ``view``.
+            The view to send with the message. This can not be mixed with ``components``.
+        components: |components_type|
+            A list of components to send with the message. This can not be mixed with ``view``.
 
             .. versionadded:: 2.4
         ephemeral: :class:`bool`
@@ -703,9 +703,9 @@ class InteractionResponse:
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         view: :class:`disnake.ui.View`
-            The view to send with the message. This can not be specified together with ``components``.
-        components: Any
-            A list of components to send with the message. This can not be specified together with ``view``.
+            The view to send with the message. This can not be mixed with ``components``.
+        components: |components_type|
+            A list of components to send with the message. This can not be mixed with ``view``.
 
             .. versionadded:: 2.4
         tts: :class:`bool`
@@ -877,10 +877,10 @@ class InteractionResponse:
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. This can not be specified together with ``components``.
+            The updated view to update this message with. This can not be mixed with ``components``.
             If ``None`` is passed then the view is removed.
-        components: Optional[Any]
-            A list of components to update this message with. This can not be specified together with ``view``.
+        components: Optional[|components_type|]
+            A list of components to update this message with. This can not be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
@@ -1113,10 +1113,10 @@ class InteractionMessage(Message):
 
             .. versionadded:: 2.2
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. This can not be specified together with ``components``.
+            The updated view to update this message with. This can not be mixed with ``components``.
             If ``None`` is passed then the view is removed.
-        components: Optional[Any]
-            A list of components to update this message with. This can not be specified together with ``view``.
+        components: Optional[|components_type|]
+            A list of components to update this message with. This can not be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -69,6 +69,7 @@ from .guild import Guild
 from .mixins import Hashable
 from .sticker import StickerItem
 from .threads import Thread
+from .ui.action_row import components_to_dict
 
 if TYPE_CHECKING:
     from .types.message import (
@@ -97,6 +98,7 @@ if TYPE_CHECKING:
     from .mentions import AllowedMentions
     from .role import Role
     from .threads import AnyThreadArchiveDuration
+    from .ui.action_row import Components
     from .ui.view import View
 
     MR = TypeVar("MR", bound="MessageReference")
@@ -145,11 +147,14 @@ async def _edit_handler(
     delete_after: Optional[float] = None,
     allowed_mentions: Optional[AllowedMentions] = MISSING,
     view: Optional[View] = MISSING,
+    components: Optional[Components] = MISSING,
 ) -> Message:
     if embed is not MISSING and embeds is not MISSING:
         raise InvalidArgument("Cannot mix embed and embeds keyword arguments.")
     if file is not MISSING and files is not MISSING:
         raise InvalidArgument("Cannot mix file and files keyword arguments.")
+    if view is not MISSING and components is not MISSING:
+        raise InvalidArgument("Cannot mix view and components keyword arguments.")
 
     payload: Dict[str, Any] = {}
     if content is not MISSING:
@@ -196,6 +201,9 @@ async def _edit_handler(
             payload["components"] = view.to_components()
         else:
             payload["components"] = []
+
+    if components is not MISSING:
+        payload["components"] = [] if components is None else components_to_dict(components)
 
     try:
         data = await msg._state.http.edit_message(msg.channel.id, msg.id, **payload, files=files)
@@ -1386,6 +1394,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        components: Optional[Components] = ...,
     ) -> Message:
         ...
 
@@ -1401,6 +1410,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        components: Optional[Components] = ...,
     ) -> Message:
         ...
 
@@ -1416,6 +1426,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        components: Optional[Components] = ...,
     ) -> Message:
         ...
 
@@ -1431,6 +1442,7 @@ class Message(Hashable):
         delete_after: Optional[float] = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
+        components: Optional[Components] = ...,
     ) -> Message:
         ...
 
@@ -1500,8 +1512,15 @@ class Message(Hashable):
 
             .. versionadded:: 1.4
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. If ``None`` is passed then
-            the view is removed.
+            The updated view to update this message with. This can not be mixed with ``components``.
+            If ``None`` is passed then the view is removed.
+
+            .. versionadded:: 2.0
+        components: |components_type|
+            The updated components to update this message with. This can not be mixed with ``view``.
+            If ``None`` is passed then the components are removed.
+
+            .. versionadded:: 2.4
 
         Raises
         -------
@@ -2059,10 +2078,15 @@ class PartialMessage(Hashable):
                 Unlike :meth:`Message.edit`, this does not default to
                 :attr:`Client.allowed_mentions` if no object is passed.
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. If ``None`` is passed then
-            the view is removed.
+            The updated view to update this message with. This can not be mixed with ``components``.
+            If ``None`` is passed then the view is removed.
 
             .. versionadded:: 2.0
+        components: |components_type|
+            The updated components to update this message with. This can not be mixed with ``view``.
+            If ``None`` is passed then the components are removed.
+
+            .. versionadded:: 2.4
 
         Raises
         -------

--- a/disnake/ui/__init__.py
+++ b/disnake/ui/__init__.py
@@ -9,6 +9,7 @@ Bot UI Kit helper for the Discord API
 
 """
 
+from .action_row import *
 from .view import *
 from .item import *
 from .button import *

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
 
 class ActionRow:
-    """Represents a UI action row.
+    """Represents a UI action row. Useful for lower level component manipulation.
 
     .. versionadded:: 2.4
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -221,14 +221,14 @@ class ActionRow:
         return self._underlying.to_dict()
 
 
-def components_to_action_rows(
+def components_to_dict(
     components: Union[ActionRow, Item, List[Union[ActionRow, Item, List[Item]]]]
-) -> List[ActionRow]:
+) -> List[ActionRowPayload]:
     if isinstance(components, ActionRow):
-        return [components]
+        return [components.to_component_dict()]
 
     if isinstance(components, Item):
-        return [ActionRow(components)]
+        return [ActionRow(components).to_component_dict()]
 
     if not isinstance(components, list):
         raise ValueError("components must be an Item, a list of ActionRows or a list of Items")
@@ -237,13 +237,13 @@ def components_to_action_rows(
 
     for component in components:
         if isinstance(component, ActionRow):
-            action_rows.append(component)
+            action_rows.append(component.to_component_dict())
 
         elif isinstance(component, Item):
-            action_rows.append(ActionRow(component))
+            action_rows.append(ActionRow(component).to_component_dict())
 
         elif isinstance(component, list):
-            action_rows.append(ActionRow(*component))
+            action_rows.append(ActionRow(*component).to_component_dict())
 
         else:
             raise ValueError("components must be an Item, a list of ActionRows or a list of Items")

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -1,0 +1,251 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Disnake Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, TYPE_CHECKING, Union
+
+from .item import Item
+
+from ..components import (
+    Component,
+    ActionRow as ActionRowComponent,
+    Button as ButtonComponent,
+    SelectOption,
+    SelectMenu,
+)
+from ..enums import ButtonStyle, ComponentType
+from ..utils import MISSING
+
+__all__ = ("ActionRow",)
+
+if TYPE_CHECKING:
+    from ..emoji import Emoji
+    from ..partial_emoji import PartialEmoji
+    from ..types.components import ActionRow as ActionRowPayload
+
+
+class ActionRow:
+    """Represents a UI action row.
+
+    .. versionadded:: 2.4
+
+    Parameters
+    ------------
+    *items: :class:`Item`
+        The items of this action row.
+    """
+
+    def __init__(self, *items: Item):
+        self._total_width = 0
+        components = []
+        # Validate the components
+        for item in items:
+            if not isinstance(item, Item):
+                raise ValueError("ActionRow must contain only Item instances")
+
+            self._total_width += item.width
+
+            if self._total_width > 5:
+                raise ValueError(
+                    "Too many items in 1 row. There should be not more than 5 buttons or 1 menu."
+                )
+
+            components.append(item._underlying)  # type: ignore
+
+        self._underlying = ActionRowComponent._raw_construct(
+            type=ComponentType.action_row,
+            children=components,
+        )
+
+    @property
+    def children(self) -> List[Component]:
+        """List[:class:`Component`]: The components of this row."""
+        return self._underlying.children
+
+    @children.setter
+    def children(self, value: List[Component]):
+        self._underlying.children = value
+
+    @property
+    def type(self) -> ComponentType:
+        return self._underlying.type
+
+    def append_item(self, item: Item) -> None:
+        """Appends an item to the action row.
+
+        Parameters
+        -----------
+        item: :class:`disnake.ui.Item`
+            The item to append to the action row.
+
+        Raises
+        -------
+        ValueError
+            The width of the action row exceeds 5.
+        """
+        if self._total_width + item.width > 5:
+            raise ValueError("Too many items in this row, can not appen a new one.")
+
+        self._total_width += item.width
+        self._underlying.children.append(item._underlying)  # type: ignore
+
+    def add_button(
+        self,
+        *,
+        style: ButtonStyle = ButtonStyle.secondary,
+        label: Optional[str] = None,
+        disabled: bool = False,
+        custom_id: Optional[str] = None,
+        url: Optional[str] = None,
+        emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
+    ):
+        """Adds a button to the action row.
+
+        To append a pre-existing :class:`disnake.ui.Button` use the
+        :meth:`append_item` method instead.
+
+        Parameters
+        -----------
+        style: :class:`disnake.ButtonStyle`
+            The style of the button.
+        custom_id: Optional[:class:`str`]
+            The ID of the button that gets received during an interaction.
+            If this button is for a URL, it does not have a custom ID.
+        url: Optional[:class:`str`]
+            The URL this button sends you to.
+        disabled: :class:`bool`
+            Whether the button is disabled or not.
+        label: Optional[:class:`str`]
+            The label of the button, if any.
+        emoji: Optional[Union[:class:`.PartialEmoji`, :class:`.Emoji`, :class:`str`]]
+            The emoji of the button, if available.
+
+        Raises
+        -------
+        ValueError
+            The width of the action row exceeds 5.
+        """
+        if self._total_width >= 5:
+            raise ValueError("Too many items in this row, can not add a button.")
+
+        self._total_width += 1
+        self._underlying.children.append(
+            ButtonComponent._raw_construct(
+                type=ComponentType.button,
+                custom_id=custom_id,
+                url=url,
+                disabled=disabled,
+                label=label,
+                style=style,
+                emoji=emoji,
+            )
+        )
+
+    def add_select(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        options: List[SelectOption] = MISSING,
+        disabled: bool = False,
+    ):
+        """Adds a select menu to the action row.
+
+        To append a pre-existing :class:`disnake.ui.Select` use the
+        :meth:`append_item` method instead.
+
+        Parameters
+        -----------
+        custom_id: :class:`str`
+            The ID of the select menu that gets received during an interaction.
+            If not given then one is generated for you.
+        placeholder: Optional[:class:`str`]
+            The placeholder text that is shown if nothing is selected, if any.
+        min_values: :class:`int`
+            The minimum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        max_values: :class:`int`
+            The maximum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        options: List[:class:`disnake.SelectOption`]
+            A list of options that can be selected in this menu.
+        disabled: :class:`bool`
+            Whether the select is disabled or not.
+
+        Raises
+        -------
+        ValueError
+            The width of the action row exceeds 5.
+        """
+        if self._total_width >= 5:
+            raise ValueError("Too many items in this row, can not add a select menu.")
+
+        self._total_width += 5
+        self._underlying.children.append(
+            SelectMenu._raw_construct(
+                custom_id=custom_id,
+                type=ComponentType.select,
+                placeholder=placeholder,
+                min_values=min_values,
+                max_values=max_values,
+                options=options,
+                disabled=disabled,
+            )
+        )
+
+    def to_component_dict(self) -> ActionRowPayload:
+        return self._underlying.to_dict()
+
+
+def components_to_action_rows(
+    components: Union[ActionRow, Item, List[Union[ActionRow, Item, List[Item]]]]
+) -> List[ActionRow]:
+    if isinstance(components, ActionRow):
+        return [components]
+
+    if isinstance(components, Item):
+        return [ActionRow(components)]
+
+    if not isinstance(components, list):
+        raise ValueError("components must be an Item, a list of ActionRows or a list of Items")
+
+    action_rows = []
+
+    for component in components:
+        if isinstance(component, ActionRow):
+            action_rows.append(component)
+
+        elif isinstance(component, Item):
+            action_rows.append(ActionRow(component))
+
+        elif isinstance(component, list):
+            action_rows.append(ActionRow(*component))
+
+        else:
+            raise ValueError("components must be an Item, a list of ActionRows or a list of Items")
+
+    return action_rows

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import List, Optional, TYPE_CHECKING, Union
+from typing import List, Optional, TYPE_CHECKING, TypeVar, Union
 
 from .button import Button
 from .item import Item
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
     from ..emoji import Emoji
     from ..partial_emoji import PartialEmoji
     from ..types.components import ActionRow as ActionRowPayload
+
+    ActionRowT = TypeVar("ActionRowT", bound="ActionRow")
+    Components = Union[ActionRowT, Item, List[Union[ActionRowT, Item, List[Item]]]]
 
 
 class ActionRow:
@@ -211,9 +214,7 @@ class ActionRow:
         return self._underlying.to_dict()
 
 
-def components_to_dict(
-    components: Union[ActionRow, Item, List[Union[ActionRow, Item, List[Item]]]]
-) -> List[ActionRowPayload]:
+def components_to_dict(components: Components) -> List[ActionRowPayload]:
     if not isinstance(components, list):
         components = [components]
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -26,14 +26,14 @@ from __future__ import annotations
 
 from typing import List, Optional, TYPE_CHECKING, Union
 
+from .button import Button
 from .item import Item
+from .select import Select
 
 from ..components import (
     Component,
     ActionRow as ActionRowComponent,
-    Button as ButtonComponent,
     SelectOption,
-    SelectMenu,
 )
 from ..enums import ButtonStyle, ComponentType
 from ..utils import MISSING
@@ -147,18 +147,13 @@ class ActionRow:
         ValueError
             The width of the action row exceeds 5.
         """
-        if self._total_width >= 5:
-            raise ValueError("Too many items in this row, can not add a button.")
-
-        self._total_width += 1
-        self._underlying.children.append(
-            ButtonComponent._raw_construct(
-                type=ComponentType.button,
+        self.append_item(
+            Button(
+                style=style,
+                label=label,
+                disabled=disabled,
                 custom_id=custom_id,
                 url=url,
-                disabled=disabled,
-                label=label,
-                style=style,
                 emoji=emoji,
             )
         )
@@ -201,14 +196,9 @@ class ActionRow:
         ValueError
             The width of the action row exceeds 5.
         """
-        if self._total_width >= 5:
-            raise ValueError("Too many items in this row, can not add a select menu.")
-
-        self._total_width += 5
-        self._underlying.children.append(
-            SelectMenu._raw_construct(
+        self.append_item(
+            Select(
                 custom_id=custom_id,
-                type=ComponentType.select,
                 placeholder=placeholder,
                 min_values=min_values,
                 max_values=max_values,
@@ -224,14 +214,8 @@ class ActionRow:
 def components_to_dict(
     components: Union[ActionRow, Item, List[Union[ActionRow, Item, List[Item]]]]
 ) -> List[ActionRowPayload]:
-    if isinstance(components, ActionRow):
-        return [components.to_component_dict()]
-
-    if isinstance(components, Item):
-        return [ActionRow(components).to_component_dict()]
-
     if not isinstance(components, list):
-        raise ValueError("components must be an Item, a list of ActionRows or a list of Items")
+        components = [components]
 
     action_rows = []
 

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -30,7 +30,7 @@ import inspect
 import os
 
 
-from .item import Item, ItemCallbackType, DecoratedItem
+from .item import Item, DecoratedItem
 from ..enums import ButtonStyle, ComponentType
 from ..partial_emoji import PartialEmoji, _EmojiTag
 from ..components import Button as ButtonComponent
@@ -41,6 +41,7 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from .item import ItemCallbackType
     from .view import View
     from ..emoji import Emoji
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -40,18 +40,17 @@ from typing import (
     overload,
 )
 
-from ..interactions import MessageInteraction
-
 __all__ = ("Item",)
+
+I = TypeVar("I", bound="Item")
+V = TypeVar("V", bound="View", covariant=True)
 
 if TYPE_CHECKING:
     from ..enums import ComponentType
     from .view import View
     from ..components import Component
-
-I = TypeVar("I", bound="Item")
-V = TypeVar("V", bound="View", covariant=True)
-ItemCallbackType = Callable[[Any, I, MessageInteraction], Coroutine[Any, Any, Any]]
+    from ..interactions import MessageInteraction
+    ItemCallbackType = Callable[[Any, I, MessageInteraction], Coroutine[Any, Any, Any]]
 
 
 class Item(Generic[V]):

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from .view import View
     from ..components import Component
     from ..interactions import MessageInteraction
+
     ItemCallbackType = Callable[[Any, I, MessageInteraction], Coroutine[Any, Any, Any]]
 
 

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -28,11 +28,9 @@ from typing import List, Optional, TYPE_CHECKING, Tuple, TypeVar, Type, Callable
 import inspect
 import os
 
-from .item import Item, ItemCallbackType, DecoratedItem
+from .item import Item, DecoratedItem
 from ..enums import ComponentType
 from ..partial_emoji import PartialEmoji
-from ..emoji import Emoji
-from ..interactions import MessageInteraction
 from ..utils import MISSING
 from ..components import (
     SelectOption,
@@ -45,7 +43,10 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from .item import ItemCallbackType
     from .view import View
+    from ..emoji import Emoji
+    from ..interactions import MessageInteraction
     from ..types.components import SelectMenu as SelectMenuPayload
 
 S = TypeVar("S", bound="Select")

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -44,7 +44,7 @@ import asyncio
 import sys
 import time
 import os
-from .item import Item, ItemCallbackType
+from .item import Item
 from ..enums import try_enum_to_int
 from ..components import (
     Component,
@@ -58,6 +58,7 @@ __all__ = ("View",)
 
 
 if TYPE_CHECKING:
+    from .item import ItemCallbackType
     from ..interactions import MessageInteraction
     from ..message import Message
     from ..types.components import Component as ComponentPayload

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -82,10 +82,9 @@ if TYPE_CHECKING:
     from ..guild import Guild
     from ..channel import TextChannel, VoiceChannel
     from ..abc import Snowflake
-    from ..ui import ActionRow, Item, View
+    from ..ui.action_row import Components
+    from ..ui.view import View
     import datetime
-
-    Components = Union[ActionRow, Item, List[Union[ActionRow, Item, List[Item]]]]
 
 MISSING = utils.MISSING
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -55,7 +55,7 @@ from ..asset import Asset
 from ..http import Route, to_multipart
 from ..mixins import Hashable
 from ..channel import PartialMessageable
-from ..ui.action_row import components_to_action_rows
+from ..ui.action_row import components_to_dict
 
 __all__ = (
     "Webhook",
@@ -521,12 +521,7 @@ def handle_message_parameters(
     if view is not MISSING:
         payload["components"] = view.to_components() if view is not None else []
     if components is not MISSING:
-        if components is None:
-            payload["components"] = None
-        else:
-            payload["components"] = [
-                comp.to_component_dict() for comp in components_to_action_rows(components)
-            ]
+        payload["components"] = [] if components is None else components_to_dict(components)
 
     if attachments is not MISSING:
         payload["attachments"] = [a.to_dict() for a in attachments]
@@ -749,7 +744,7 @@ class WebhookMessage(Message):
 
             .. versionadded:: 2.0
         components: Optional[Any]
-            A list of components to include in the message. This can not be specified together with ``view``.
+            A list of components to update the message with. This can not be specified together with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -740,11 +740,11 @@ class WebhookMessage(Message):
             .. versionadded:: 2.2
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
-            the view is removed. This can not be specified together with ``components``.
+            the view is removed. This can not be mixed with ``components``.
 
             .. versionadded:: 2.0
-        components: Optional[Any]
-            A list of components to update the message with. This can not be specified together with ``view``.
+        components: Optional[|components_type|]
+            A list of components to update the message with. This can not be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
@@ -1434,11 +1434,11 @@ class Webhook(BaseWebhook):
             The view to send with the message. You can only send a view
             if this webhook is not partial and has state attached. A
             webhook has state attached if the webhook is managed by the
-            library. This can not be specified together with ``components``.
+            library. This can not be mixed with ``components``.
 
             .. versionadded:: 2.0
-        components: Any
-            A list of components to include in the message. This can not be specified together with ``view``.
+        components: |components_type|
+            A list of components to include in the message. This can not be mixed with ``view``.
 
             .. versionadded:: 2.4
         thread: :class:`~disnake.abc.Snowflake`
@@ -1661,11 +1661,11 @@ class Webhook(BaseWebhook):
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed. The webhook must have state attached, similar to
-            :meth:`send`. This can not be specified together with ``components``.
+            :meth:`send`. This can not be mixed with ``components``.
 
             .. versionadded:: 2.0
-        components: Any
-            A list of components to update this message with. This can not be specified together with ``view``.
+        components: |components_type|
+            A list of components to update this message with. This can not be mixed with ``view``.
 
             .. versionadded:: 2.4
         allowed_mentions: :class:`AllowedMentions`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4709,6 +4709,14 @@ View
 .. autoclass:: disnake.ui.View
     :members:
 
+ActionRow
+~~~~~~~~~~
+
+.. attributetable:: disnake.ui.ActionRow
+
+.. autoclass:: disnake.ui.ActionRow
+    :members:
+
 Item
 ~~~~~~~
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ rst_prolog = """
 .. |coro| replace:: This function is a |coroutine_link|_.
 .. |maybecoro| replace:: This function *could be a* |coroutine_link|_.
 .. |coroutine_link| replace:: *coroutine*
+.. |components_type| replace:: Union[:class:`disnake.ui.ActionRow`, :class:`disnake.ui.Item`, List[Union[:class:`disnake.ui.ActionRow`, :class:`disnake.ui.Item`, List[:class:`disnake.ui.Item`]]]]
 .. _coroutine_link: https://docs.python.org/3/library/asyncio-task.html#coroutine
 """
 
@@ -190,7 +191,7 @@ def linkcode_resolve(domain, info):
         if isinstance(obj, property):
             obj = inspect.unwrap(obj.fget)  # type: ignore
 
-        path = os.path.relpath(inspect.getsourcefile(obj), start=_disnake_module_path)
+        path = os.path.relpath(inspect.getsourcefile(obj), start=_disnake_module_path)  # type: ignore
         src, lineno = inspect.getsourcelines(obj)
     except Exception:
         return None


### PR DESCRIPTION
## Summary

This PR adds 2 things:
1) `ui.ActionRow` object for grouping components
2) `components` kwarg in all send methods

## Checklist

- [x] If code changes were made then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
