### PR TITLE
Add `locale` and `guild_locale` properties to interactions.

### DIFF
--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -175,6 +175,7 @@ class GuildCommandInteraction(ApplicationCommandInteraction):
 
     guild: Guild
     me: Member
+    guild_locale: str
 
 
 class UserCommandInteraction(ApplicationCommandInteraction):

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -110,8 +110,17 @@ class ApplicationCommandInteraction(Interaction):
         The interaction's bot. There is an alias for this named ``client``.
     author: Optional[Union[:class:`User`, :class:`Member`]]
         The user or member that sent the interaction.
+    locale: Optional[:class:`str`]
+        The selected language of the interaction's author.
+
+        .. versionadded:: 2.4
     guild: Optional[:class:`Guild`]
         The guild the interaction was sent from.
+    guild_locale: Optional[:class:`str`]
+        The selected language of the interaction's guild. Only available if the guild has ``COMMUNITY`` feature,
+        if not, then this is always en-US.
+
+        .. versionadded:: 2.4
     channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]
         The channel the interaction was sent from.
     me: Union[:class:`.Member`, :class:`.ClientUser`]

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -117,8 +117,8 @@ class ApplicationCommandInteraction(Interaction):
     guild: Optional[:class:`Guild`]
         The guild the interaction was sent from.
     guild_locale: Optional[:class:`str`]
-        The selected language of the interaction's guild. Only available if the guild has ``COMMUNITY`` feature,
-        if not, then this is always en-US.
+        The selected language of the interaction's guild.
+        This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
 
         .. versionadded:: 2.4
     channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -185,9 +185,7 @@ class UserCommandInteraction(ApplicationCommandInteraction):
     to seem like the interaction is specifically a user command.
     """
 
-    target: Member
-    guild: Guild
-    me: Member
+    target: Union[User, Member]
 
 
 class MessageCommandInteraction(ApplicationCommandInteraction):

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -119,6 +119,7 @@ class ApplicationCommandInteraction(Interaction):
     guild_locale: Optional[:class:`str`]
         The selected language of the interaction's guild.
         This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
+        If the interaction was in a DM, then this value is ``None``.
 
         .. versionadded:: 2.4
     channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -110,7 +110,7 @@ class ApplicationCommandInteraction(Interaction):
         The interaction's bot. There is an alias for this named ``client``.
     author: Optional[Union[:class:`User`, :class:`Member`]]
         The user or member that sent the interaction.
-    locale: Optional[:class:`str`]
+    locale: :class:`str`
         The selected language of the interaction's author.
 
         .. versionadded:: 2.4

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -105,12 +105,21 @@ class Interaction:
         The interaction type.
     guild_id: Optional[:class:`int`]
         The guild ID the interaction was sent from.
+    guild_locale: Optional[:class:`str`]
+        The selected language of the interaction's guild. Only available if the guild has ``COMMUNITY`` feature,
+        if not, then this is always en-US.
+
+        .. versionadded:: 2.4
     channel_id: Optional[:class:`int`]
         The channel ID the interaction was sent from.
     application_id: :class:`int`
         The application ID that the interaction was for.
     author: Optional[Union[:class:`User`, :class:`Member`]]
         The user or member that sent the interaction.
+    locale: Optional[:class:`str`]
+        The selected language of the interaction's author.
+
+        .. versionadded:: 2.4
     token: :class:`str`
         The token to continue the interaction. These are valid
         for 15 minutes.
@@ -126,6 +135,8 @@ class Interaction:
         "token",
         "version",
         "bot",
+        "locale",
+        "guild_locale",
         "_permissions",
         "_state",
         "_session",
@@ -152,6 +163,8 @@ class Interaction:
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, "channel_id")
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, "guild_id")
         self.application_id: int = int(data["application_id"])
+        self.locale: Optional[str] = data.get("locale")
+        self.guild_locale: Optional[str] = data.get("guild_locale")
         # think about the user's experience
         self.author: Union[User, Member] = None  # type: ignore
         self._permissions: int = 0

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -116,7 +116,7 @@ class Interaction:
         The application ID that the interaction was for.
     author: Optional[Union[:class:`User`, :class:`Member`]]
         The user or member that sent the interaction.
-    locale: Optional[:class:`str`]
+    locale: :class:`str`
         The selected language of the interaction's author.
 
         .. versionadded:: 2.4
@@ -163,7 +163,7 @@ class Interaction:
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, "channel_id")
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, "guild_id")
         self.application_id: int = int(data["application_id"])
-        self.locale: Optional[str] = data.get("locale")
+        self.locale: str = data.get("locale")
         self.guild_locale: Optional[str] = data.get("guild_locale")
         # think about the user's experience
         self.author: Union[User, Member] = None  # type: ignore

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -108,6 +108,7 @@ class Interaction:
     guild_locale: Optional[:class:`str`]
         The selected language of the interaction's guild.
         This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
+        If the interaction was in a DM, then this value is ``None``.
 
         .. versionadded:: 2.4
     channel_id: Optional[:class:`int`]

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -163,7 +163,7 @@ class Interaction:
         self.channel_id: Optional[int] = utils._get_as_snowflake(data, "channel_id")
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, "guild_id")
         self.application_id: int = int(data["application_id"])
-        self.locale: str = data.get("locale")
+        self.locale: str = data["locale"]
         self.guild_locale: Optional[str] = data.get("guild_locale")
         # think about the user's experience
         self.author: Union[User, Member] = None  # type: ignore

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -106,8 +106,8 @@ class Interaction:
     guild_id: Optional[:class:`int`]
         The guild ID the interaction was sent from.
     guild_locale: Optional[:class:`str`]
-        The selected language of the interaction's guild. Only available if the guild has ``COMMUNITY`` feature,
-        if not, then this is always en-US.
+        The selected language of the interaction's guild.
+        This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
 
         .. versionadded:: 2.4
     channel_id: Optional[:class:`int`]

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -71,6 +71,7 @@ class MessageInteraction(Interaction):
     guild_locale: Optional[:class:`str`]
         The selected language of the interaction's guild.
         This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
+        If the interaction was in a DM, then this value is ``None``.
 
         .. versionadded:: 2.4
     channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -62,8 +62,17 @@ class MessageInteraction(Interaction):
         The application ID that the interaction was for.
     author: Optional[Union[:class:`User`, :class:`Member`]]
         The user or member that sent the interaction.
+    locale: :class:`str`
+        The selected language of the interaction's author.
+
+        .. versionadded:: 2.4
     guild: Optional[:class:`Guild`]
         The guild the interaction was sent from.
+    guild_locale: Optional[:class:`str`]
+        The selected language of the interaction's guild. Only available if the guild has ``COMMUNITY`` feature,
+        if not, then this is always en-US.
+
+        .. versionadded:: 2.4
     channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]
         The channel the interaction was sent from.
     message: Optional[:class:`Message`]

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -69,8 +69,8 @@ class MessageInteraction(Interaction):
     guild: Optional[:class:`Guild`]
         The guild the interaction was sent from.
     guild_locale: Optional[:class:`str`]
-        The selected language of the interaction's guild. Only available if the guild has ``COMMUNITY`` feature,
-        if not, then this is always en-US.
+        The selected language of the interaction's guild.
+        This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
 
         .. versionadded:: 2.4
     channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -188,7 +188,6 @@ class _InteractionOptional(TypedDict, total=False):
     member: Member
     user: User
     message: Message
-    locale: str
     guild_locale: str
 
 
@@ -198,6 +197,7 @@ class Interaction(_InteractionOptional):
     type: InteractionType
     token: str
     version: int
+    locale: str
 
 
 class InteractionApplicationCommandCallbackData(TypedDict, total=False):

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -188,6 +188,8 @@ class _InteractionOptional(TypedDict, total=False):
     member: Member
     user: User
     message: Message
+    locale: str
+    guild_locale: str
 
 
 class Interaction(_InteractionOptional):


### PR DESCRIPTION
## Summary

The API is already providing those values.

ref:
https://github.com/discord/discord-api-docs/pull/4265

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `black .`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
