### PR TITLE
Use logger for application command sync debug

### DIFF
--- a/disnake/client.py
+++ b/disnake/client.py
@@ -234,15 +234,15 @@ class Client:
 
         .. versionadded:: 2.1
     sync_commands_debug: :class:`bool`
-        Whether to change the log level of log messages in the synchronization process to ``INFO``,
-        instead of the default ``DEBUG`` which isn't shown unless the log level is changed manually.
+        Whether to always show sync debug logs (uses ``INFO`` log level if it's enabled, prints otherwise).
+        If disabled, uses the default ``DEBUG`` log level which isn't shown unless the log level is changed manually.
         Useful for tracking the commands being registered in the API.
 
         .. versionadded:: 2.1
 
         .. versionchanged:: 2.4
-            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO``, instead of
-            controlling whether they are enabled at all.
+            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO`` or ``print``\\s them,
+            instead of controlling whether they are enabled at all.
 
     Attributes
     -----------

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -234,10 +234,15 @@ class Client:
 
         .. versionadded:: 2.1
     sync_commands_debug: :class:`bool`
-        Whether to enable messages logging the synchronization process.
+        Whether to change the log level of log messages in the synchronization process to ``INFO``,
+        instead of the default ``DEBUG`` which isn't shown unless the log level is changed manually.
         Useful for tracking the commands being registered in the API.
 
         .. versionadded:: 2.1
+
+        .. versionchanged:: 2.4
+            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO``, instead of
+            controlling whether they are enabled at all.
 
     Attributes
     -----------

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -152,11 +152,16 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
 
         .. versionadded:: 2.1
     sync_commands_debug: :class:`bool`
-        Whether to enable messages logging the synchronization process.
+        Whether to change the log level of log messages in the synchronization process to ``INFO``,
+        instead of the default ``DEBUG`` which isn't shown unless the log level is changed manually.
         Useful for tracking the commands being registered in the API.
         Defaults to ``False``.
 
         .. versionadded:: 2.1
+
+        .. versionchanged:: 2.4
+            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO``, instead of
+            controlling whether they are enabled at all.
     sync_permissions: :class:`bool`
         Whether to enable automatic synchronization of app command permissions in your code.
         Defaults to ``False``.
@@ -218,11 +223,16 @@ class InteractionBot(InteractionBotBase, disnake.Client):
 
         .. versionadded:: 2.1
     sync_commands_debug: :class:`bool`
-        Whether to enable messages logging the synchronization process.
+        Whether to change the log level of log messages in the synchronization process to ``INFO``,
+        instead of the default ``DEBUG`` which isn't shown unless the log level is changed manually.
         Useful for tracking the commands being registered in the API.
         Defaults to ``False``.
 
         .. versionadded:: 2.1
+
+        .. versionchanged:: 2.4
+            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO``, instead of
+            controlling whether they are enabled at all.
     sync_permissions: :class:`bool`
         Whether to enable automatic synchronization of app command permissions in your code.
         Defaults to ``False``.

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -152,16 +152,16 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
 
         .. versionadded:: 2.1
     sync_commands_debug: :class:`bool`
-        Whether to change the log level of log messages in the synchronization process to ``INFO``,
-        instead of the default ``DEBUG`` which isn't shown unless the log level is changed manually.
+        Whether to always show sync debug logs (uses ``INFO`` log level if it's enabled, prints otherwise).
+        If disabled, uses the default ``DEBUG`` log level which isn't shown unless the log level is changed manually.
         Useful for tracking the commands being registered in the API.
         Defaults to ``False``.
 
         .. versionadded:: 2.1
 
         .. versionchanged:: 2.4
-            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO``, instead of
-            controlling whether they are enabled at all.
+            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO`` or ``print``\\s them,
+            instead of controlling whether they are enabled at all.
     sync_permissions: :class:`bool`
         Whether to enable automatic synchronization of app command permissions in your code.
         Defaults to ``False``.
@@ -223,16 +223,16 @@ class InteractionBot(InteractionBotBase, disnake.Client):
 
         .. versionadded:: 2.1
     sync_commands_debug: :class:`bool`
-        Whether to change the log level of log messages in the synchronization process to ``INFO``,
-        instead of the default ``DEBUG`` which isn't shown unless the log level is changed manually.
+        Whether to always show sync debug logs (uses ``INFO`` log level if it's enabled, prints otherwise).
+        If disabled, uses the default ``DEBUG`` log level which isn't shown unless the log level is changed manually.
         Useful for tracking the commands being registered in the API.
         Defaults to ``False``.
 
         .. versionadded:: 2.1
 
         .. versionchanged:: 2.4
-            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO``, instead of
-            controlling whether they are enabled at all.
+            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO`` or ``print``\\s them,
+            instead of controlling whether they are enabled at all.
     sync_permissions: :class:`bool`
         Whether to enable automatic synchronization of app command permissions in your code.
         Defaults to ``False``.

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -39,7 +39,8 @@ This code sample shows how to set the registration to be local:
 For global registration, don't specify this parameter.
 
 Another useful parameter is ``sync_commands_debug``. If set to ``True``, you receive debug messages related to the
-app command registration. This is useful if you want to figure out some registration details:
+app command registration by default, without having to change the log level of any loggers.
+This is useful if you want to figure out some registration details:
 
 .. code-block:: python3
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -39,7 +39,8 @@ This code sample shows how to set the registration to be local:
 For global registration, don't specify this parameter.
 
 Another useful parameter is ``sync_commands_debug``. If set to ``True``, you receive debug messages related to the
-app command registration by default, without having to change the log level of any loggers.
+app command registration by default, without having to change the log level of any loggers
+(see :class:`Bot.sync_commands_debug <ext.commands.Bot.sync_commands_debug>` for more info).
 This is useful if you want to figure out some registration details:
 
 .. code-block:: python3


### PR DESCRIPTION
## Summary

Fixes #157.

The output is pretty much unchanged:
<details>
<summary>Example log output</summary>

```py
2021-12-25 20:10:35,670: [INFO] (MainThread) disnake.ext.commands.interaction_bot_base: Application command synchronization:
GLOBAL COMMANDS
===============
| NOTE: global commands can take up to 1 hour to show up after registration.
|
| Update is required: False
| To upsert:
|     -
| To edit:
|     -
| To delete:
|     -
| Type migration:
|     -
| No changes:
|     -
2021-12-25 20:10:35,672: [INFO] (MainThread) disnake.ext.commands.interaction_bot_base: Application command synchronization:
COMMANDS IN 521292111455453194
===============================
| Update is required: True
| To upsert:
|     <SlashCommand name='shutdown'>
| To edit:
|     -
| To delete:
|     -
| Type migration:
|     -
| No changes:
|     <SlashCommand name='say'>
|     <SlashCommand name='snowflaketime'>
|     <UserCommand name='test'>
|     <MessageCommand name='msg'>
|     <SlashCommand name='info'>
```
</details>

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
