### PR TITLE
python 3.10 union type alias fix

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -104,7 +104,7 @@ def remove_optionals(annotation: Any) -> Any:
     if get_origin(annotation) in (Union, UnionType):
         annotation = cast(Any, annotation)
 
-        args = [i for i in annotation.__args__ if i not in (None, type(None))]
+        args = tuple(i for i in annotation.__args__ if i not in (None, type(None)))
         if len(args) == 1:
             annotation = args[0]
         else:

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -108,7 +108,7 @@ def remove_optionals(annotation: Any) -> Any:
         if len(args) == 1:
             annotation = args[0]
         else:
-            annotation.__args__ = args
+            annotation = Union[tuple(args)]  # type: ignore
 
     return annotation
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -108,7 +108,7 @@ def remove_optionals(annotation: Any) -> Any:
         if len(args) == 1:
             annotation = args[0]
         else:
-            annotation = Union[tuple(args)]  # type: ignore
+            annotation = Union[args]  # type: ignore
 
     return annotation
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -70,6 +70,10 @@ if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
     Annotated = object()
+if sys.version_info >= (3, 10):
+    from types import UnionType
+else:
+    UnionType = object()
 
 T = TypeVar("T", bound=Any)
 TypeT = TypeVar("TypeT", bound=Type[Any])
@@ -97,7 +101,7 @@ def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[Type
 
 def remove_optionals(annotation: Any) -> Any:
     """remove unwanted optionals from an annotation"""
-    if get_origin(annotation) is Union:
+    if get_origin(annotation) in (Union, UnionType):
         annotation = cast(Any, annotation)
 
         args = [i for i in annotation.__args__ if i not in (None, type(None))]
@@ -402,7 +406,7 @@ class ParamInfo:
             or get_origin(annotation) is Literal
         ):
             self._parse_enum(annotation)
-        elif get_origin(annotation) is Union:
+        elif get_origin(annotation) in (Union, UnionType):
             args = annotation.__args__
             if all(issubclass_(channel, disnake.abc.GuildChannel) for channel in args):
                 self._parse_guild_channel(*args)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fix for python3.10 union type aliasing syntax (`type | type`) for `Param`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
