### PR TITLE
add taskipy for local dev

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,9 +33,9 @@ If the bug report is missing this information then it'll take us longer to fix t
 
 Submitting a pull request is fairly simple, just make sure it focuses on a single aspect and doesn't manage to have scope creep and it's probably good to go. It would be incredibly lovely if the style is consistent to that found in the project. This project follows PEP-8 guidelines (mostly) with a column limit of 100 characters.
 
-Before submitting a pull request, ensure that the code is formatted properly by installing the required tooling (`pip install -r requirements_dev.txt`) and running `pre-commit run` once your files are staged, or `pre-commit run --all-files` to check and fix all files.  
+Before submitting a pull request, ensure that the code is formatted properly by installing the required tooling (`pip install -r requirements_dev.txt`) and running `pre-commit run` once your files are staged, or `task lint` to check and fix all files.  
 
-Alternatively, run `pre-commit install` to install hooks that will automatically run all the checks when you commit changes (check out the [pre-commit docs](https://pre-commit.com/#quick-start) for more info).
+Alternatively, run `task precommit` to install hooks that will automatically run all the checks when you commit changes (check out the [pre-commit docs](https://pre-commit.com/#quick-start) for more info).
 
 **Note**: If the code is formatted incorrectly, `pre-commit` will apply fixes and exit without committing the changes - just stage and commit again.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 - [ ] If code changes were made, then they have been tested
     - [ ] I have updated the documentation to reflect the changes
-    - [ ] I have formatted the code properly by running `pre-commit run --all-files`
+    - [ ] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
 - [ ] This PR fixes an issue
 - [ ] This PR adds something new (e.g. new method or parameters)
 - [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,9 @@ py_version = 38
 line_length = 100
 combine_as_imports = true
 filter_files = true
+
+[tool.taskipy.tasks]
+black = { cmd = 'task lint black', help = 'Run black' }
+isort = { cmd = 'task lint isort', help = 'Run isort' }
+lint = { cmd = 'pre-commit run --all-files', help = 'Checks all files for linting errors' }
+precommit = { cmd = 'pre-commit install --install-hooks', help = 'Installs the precommit hook' }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ combine_as_imports = true
 filter_files = true
 
 [tool.taskipy.tasks]
-black = { cmd = 'task lint black', help = 'Run black' }
-isort = { cmd = 'task lint isort', help = 'Run isort' }
-lint = { cmd = 'pre-commit run --all-files', help = 'Checks all files for linting errors' }
-precommit = { cmd = 'pre-commit install --install-hooks', help = 'Installs the precommit hook' }
+black = { cmd = "task lint black", help = "Run black" }
+isort = { cmd = "task lint isort", help = "Run isort" }
+lint = { cmd = "pre-commit run --all-files", help = "Checks all files for linting errors" }
+precommit = { cmd = "pre-commit install --install-hooks", help = "Installs the precommit hook" }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,2 @@
 pre-commit~=2.16.0
+taskipy>=1.9.0


### PR DESCRIPTION
- feat: use taskipy for development
- chore: update references to pre-commit to use the linting tasks

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds taskipy for development. Means we don't have to remember long commands, or type them over and over.

If you have other commands that have to be typed over and over, please share them!


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
