### PR TITLE
Fix missing dropdown icon in docs

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -315,7 +315,7 @@ header > nav > a:hover {
   border-bottom: 1px solid var(--search-border);
 
   appearance: none;
-  background-image: url('/_images/drop_down_icon.svg');
+  background-image: url('../_images/drop_down_icon.svg');
   background-repeat: no-repeat;
   background-position-x: 100%;
   background-position-y: 50%;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,12 @@ nitpick_ignore_files = [
 ]
 
 
+# unreferenced static images to copy
+copy_static_images = [
+    "images/drop_down_icon.svg",
+]
+
+
 _disnake_module_path = os.path.dirname(importlib.util.find_spec("disnake").origin)  # type: ignore
 
 

--- a/docs/extensions/builder.py
+++ b/docs/extensions/builder.py
@@ -46,6 +46,12 @@ class DPYStandaloneHTMLBuilder(StandaloneHTMLBuilder):
         else:
             self.handle_page("genindex", genindexcontext, "genindex.html")
 
+    def post_process_images(self, doctree) -> None:
+        super().post_process_images(doctree)
+
+        for path in self.app.config.copy_static_images:
+            self.images[path] = path.split("/")[-1]
+
 
 def add_custom_jinja2(app):
     env = app.builder.templates.environment
@@ -73,5 +79,7 @@ def add_builders(app):
 
 
 def setup(app):
+    app.add_config_value("copy_static_images", [], "env")
+
     add_builders(app)
     app.connect("builder-inited", add_custom_jinja2)


### PR DESCRIPTION
## Summary

The `drop_down_icon.svg` file wasn't being copied by Sphinx since it wasn't referenced in any rst files. This PR adds a new option for specifying a list of images that should always be copied to the build directory.

<sup>Disclaimer: I have no idea if this is a good implementation (spoiler: it probably isn't), but it works™</sup>

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
