### PR TITLE
Show tooltips when hovering over links in docs

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1329,3 +1329,23 @@ div.code-block-caption {
     margin-right: auto;
   }
 }
+
+
+/* hoverxref stuff */
+
+.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-box {
+  background: rgba(10, 10, 10, 0.95);
+}
+
+.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-content {
+  font-size: 80%;
+  padding: 18px;
+}
+
+.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-content p {
+  font-size: 100% !important;
+}
+
+.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-content .headerlink {
+  visibility: hidden;
+}

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -107,6 +107,7 @@ Historically however, thanks to:
   --attribute-table-entry-hover-text: var(--blue-2);
   --attribute-table-badge: var(--grey-7);
   --highlighted-text: rgb(252, 233, 103);
+  --tooltip-background: #f8f8f8;
 }
 
 :root[data-font="serif"] {
@@ -167,6 +168,7 @@ Historically however, thanks to:
   --attribute-table-entry-hover-text: var(--blue-1);
   --attribute-table-badge: var(--grey-4);
   --highlighted-text: rgba(250, 166, 26, 0.2);
+  --tooltip-background: rgba(10, 10, 10, 0.95);
 }
 
 img[src$="snake_dark.svg"]  {
@@ -1332,20 +1334,104 @@ div.code-block-caption {
 
 
 /* hoverxref stuff */
+/* (this is mostly just a merge of the 'shadow' and 'borderless' themes) */
 
-.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-box {
-  background: rgba(10, 10, 10, 0.95);
+.tooltipster-sidetip.tooltipster-custom .tooltipster-content {
+  color: inherit;
 }
 
-.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-content {
+.tooltipster-sidetip.tooltipster-custom .tooltipster-box {
+	border: none;
+	background: var(--tooltip-background);
+}
+
+:root[data-theme="light"] .tooltipster-sidetip.tooltipster-custom .tooltipster-box {
+  box-shadow: 0px 0px 10px 6px rgba(0,0,0,0.1);
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-bottom .tooltipster-box {
+	margin-top: 8px;
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-left .tooltipster-box {
+	margin-right: 8px;
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-box {
+	margin-left: 8px;
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-top .tooltipster-box {
+	margin-bottom: 8px;
+}
+
+.tooltipster-sidetip.tooltipster-custom .tooltipster-arrow {
+	height: 8px;
+	margin-left: -8px;
+	width: 16px;
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-left .tooltipster-arrow,
+.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-arrow {
+	height: 16px;
+	margin-left: 0;
+	margin-top: -8px;
+	width: 8px;
+}
+
+.tooltipster-sidetip.tooltipster-custom .tooltipster-arrow-background {
+	display: none;
+}
+
+.tooltipster-sidetip.tooltipster-custom .tooltipster-arrow-border {
+	border: 8px solid transparent;
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-bottom .tooltipster-arrow-border {
+	border-bottom-color: var(--tooltip-background);
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-left .tooltipster-arrow-border {
+	border-left-color: var(--tooltip-background);
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-arrow-border {
+	border-right-color: var(--tooltip-background);
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-top .tooltipster-arrow-border {
+	border-top-color: var(--tooltip-background);
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-bottom .tooltipster-arrow-uncropped {
+	top: -8px;
+}
+
+.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-arrow-uncropped {
+	left: -8px;
+}
+
+
+/* hoverxref stuff (hoverxref custom additions) */
+
+.hoverxref {
+  border-bottom: 1px dotted;
+  border-color: gray;
+}
+
+.tooltipster-box {
+  max-height: 600px;
+}
+
+.tooltipster-sidetip.tooltipster-custom .tooltipster-content {
   font-size: 80%;
   padding: 18px;
 }
 
-.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-content p {
+.tooltipster-sidetip.tooltipster-custom .tooltipster-content p {
   font-size: 100% !important;
 }
 
-.tooltipster-sidetip.tooltipster-borderless.tooltipster-borderless-custom .tooltipster-content .headerlink {
+.tooltipster-sidetip.tooltipster-custom .tooltipster-content .headerlink {
   visibility: hidden;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,7 +208,6 @@ hoverxref_role_types = dict.fromkeys(
     "tooltip",
 )
 hoverxref_tooltip_theme = ["tooltipster-custom"]
-hoverxref_api_host = "https://rtd-cors.hmmmm.workers.dev/disnake"
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.linkcode",
     "sphinxcontrib_trio",
+    "hoverxref.extension",
     "details",
     "exception_hierarchy",
     "attributetable",
@@ -198,6 +199,16 @@ def linkcode_resolve(domain, info):
 
     path = f"{path}#L{lineno}-L{lineno + len(src) - 1}"
     return f"{github_repo}/blob/{git_ref}/disnake/{path}"
+
+
+hoverx_default_type = "tooltip"
+hoverxref_auto_ref = True
+hoverxref_domains = ["py"]
+hoverxref_role_types = dict.fromkeys(
+    ["ref", "class", "func", "meth", "attr", "exc", "data"],
+    "tooltip",
+)
+hoverxref_tooltip_theme = ["tooltipster-borderless", "tooltipster-borderless-custom"]
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,13 +202,13 @@ def linkcode_resolve(domain, info):
 
 
 hoverx_default_type = "tooltip"
-hoverxref_auto_ref = True
 hoverxref_domains = ["py"]
 hoverxref_role_types = dict.fromkeys(
     ["ref", "class", "func", "meth", "attr", "exc", "data"],
     "tooltip",
 )
-hoverxref_tooltip_theme = ["tooltipster-borderless", "tooltipster-borderless-custom"]
+hoverxref_tooltip_theme = ["tooltipster-custom"]
+hoverxref_api_host = "https://rtd-cors.hmmmm.workers.dev/disnake"
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require = {
     "docs": [
         "sphinx==4.0.2",
         "sphinxcontrib_trio==1.1.2",
-        "sphinxcontrib-websupport",
+        "sphinx-hoverxref~=1.0.0",
     ],
     "speed": [
         "orjson>=3.5.4",


### PR DESCRIPTION
## Summary

This PR adds `sphinx-hoverxref`, which shows a preview tooltip of a linked page when hovering over the link. It unfortunately only works on readthedocs, since it uses rtd's API and using their API locally is a bit wacky due to CORS.

The API is unfortunately not incredibly fast (this is also noted in the [API docs](https://docs.readthedocs.io/en/stable/development/design/embed-api.html#current-implementation)), the first few requests sometimes take ~600-700ms; for some reason it seems to get faster after a few requests, not sure what's up with that. Still, I feel like this could be a useful feature, even if the loading times aren't incredible they're still reasonably fast.

`sphinxcontrib-websupport` was removed as it was only used as a workaround in a time where readthedocs was having issues after the module was split from sphinx' core, afaict.

example: https://disnake--236.org.readthedocs.build/en/236/intents.html#member-cache

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
