### PR TITLE
Implement Range in slash commands

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -401,6 +401,17 @@ class ParamInfo:
 
         return default
 
+    async def verify_type(self, inter: CommandInteraction, argument: Any) -> Any:
+        """Check if a type of an argument is correct and possibly fix it"""
+        if issubclass(self.type, disnake.Member):
+            if isinstance(argument, disnake.Member):
+                return argument
+
+            raise errors.MemberNotFound(str(argument.id))
+
+        # unexpected types may just be ignored
+        return argument
+
     async def convert_argument(self, inter: CommandInteraction, argument: Any) -> Any:
         """Convert a value if a converter is given"""
         if self.large:
@@ -411,7 +422,7 @@ class ParamInfo:
 
         if self.converter is None:
             # TODO: Custom validators
-            return argument
+            return await self.verify_type(inter, argument)
 
         try:
             argument = self.converter(inter, argument)

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -177,6 +177,7 @@ class Injection:
 
 class RangeMeta(type):
     """Custom Generic implementation for Range"""
+
     @overload
     def __getitem__(self, args: Tuple[Union[int, ellipsis], Union[int, ellipsis]]) -> Type[int]:
         ...
@@ -231,14 +232,16 @@ class Range(type, metaclass=RangeMeta):
         cls,
         min_value: float = None,
         max_value: float = None,
-        **kwargs: Optional[float],
+        *,
+        le: float = None,
+        lt: float = None,
+        ge: float = None,
+        gt: float = None,
     ) -> Any:
         """Construct a new range with any possible constraints"""
         self = cls(cls.__name__, (), {})
-        ge = kwargs.get("ge", min_value)
-        le = kwargs.get("le", max_value)
-        self.min_value = _xt_to_xe(ge, kwargs.get("gt"), 1)
-        self.max_value = _xt_to_xe(le, kwargs.get("lt"), -1)
+        self.min_value = min_value if min_value is not None else _xt_to_xe(le, lt, -1)
+        self.max_value = max_value if max_value is not None else _xt_to_xe(ge, gt, 1)
         return self
 
     @property
@@ -381,7 +384,7 @@ class ParamInfo:
         return converter
 
     def __repr__(self) -> str:
-        args = ", ".join(f"{k}={'...' if v is Ellipsis else repr(v)}" for k, v in vars(self).items())
+        args = ", ".join(f"{k}={'...' if v is ... else repr(v)}" for k, v in vars(self).items())
         return f"{type(self).__name__}({args})"
 
     async def get_default(self, inter: CommandInteraction) -> Any:

--- a/examples/slash_commands/autocomplete.py
+++ b/examples/slash_commands/autocomplete.py
@@ -19,7 +19,7 @@ async def autocomplete_langs(inter, string: str) -> List[str]:
 
 @bot.slash_command()
 async def autocomplete(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     language: str = commands.Param(autocomplete=autocomplete_langs),
 ):
     ...
@@ -28,11 +28,11 @@ async def autocomplete(
 # In case you need don't want to use Param or need to use self in a cog you you may
 # create autocomplete options with the decorator @slash_command.autocomplete()
 @bot.slash_command()
-async def languages(inter: disnake.ApplicationCommandInteraction, language: str):
+async def languages(inter: disnake.CommandInteraction, language: str):
     ...
 
 
 @languages.autocomplete("language")
-async def language_autocomp(inter: disnake.ApplicationCommandInteraction, string: str):
+async def language_autocomp(inter: disnake.CommandInteraction, string: str):
     string = string.lower()
     return [lang for lang in LANGUAGES if string in lang.lower()]

--- a/examples/slash_commands/converters.py
+++ b/examples/slash_commands/converters.py
@@ -7,7 +7,7 @@ bot = commands.Bot("!")
 # These can be set using a parameter of Param
 @bot.slash_command()
 async def clean_content_converter(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     text: str = commands.Param(converter=lambda inter, text: text.replace("@", "\\@")),
 ):
     ...
@@ -15,13 +15,13 @@ async def clean_content_converter(
 
 # Converters may also set the type of the option using annotations
 # here the converter is actually using a user option despite the actual command being annotated as str
-def avatar_converter(inter: disnake.ApplicationCommandInteraction, user: disnake.User) -> str:
+def avatar_converter(inter: disnake.CommandInteraction, user: disnake.User) -> str:
     return user.display_avatar.url
 
 
 @bot.slash_command()
 async def command_with_avatar(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     avatar: str = commands.Param(converter=avatar_converter),
 ):
     ...
@@ -34,13 +34,13 @@ class SomeCustomClass:
         self.discriminator = discriminator
 
     @classmethod
-    async def from_option(cls, inter: disnake.ApplicationCommandInteraction, user: disnake.User):
+    async def from_option(cls, inter: disnake.CommandInteraction, user: disnake.User):
         return cls(user.name, user.discriminator)
 
 
 @bot.slash_command()
 async def command_with_clsmethod(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     some: SomeCustomClass = commands.Param(converter=SomeCustomClass.from_option),
 ):
     ...
@@ -54,13 +54,13 @@ class OtherCustomClass:
         self.discriminator = discriminator
 
     @commands.converter_method
-    async def convert(cls, inter: disnake.ApplicationCommandInteraction, user: disnake.User):
+    async def convert(cls, inter: disnake.CommandInteraction, user: disnake.User):
         return cls(user.name, user.discriminator)
 
 
 @bot.slash_command()
 async def command_with_convmethod(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     other: OtherCustomClass,
 ):
     ...

--- a/examples/slash_commands/injections.py
+++ b/examples/slash_commands/injections.py
@@ -22,7 +22,7 @@ class Config:
 
 
 async def get_config(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     locale: Optional[str] = None,
     timezone: str = "UTC",
     theme: Literal["light", "dark", "amoled"] = "dark",
@@ -53,7 +53,7 @@ async def get_config(
 # `config` will be whatever `get_config()` returns.
 @bot.slash_command()
 async def injected1(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     number: int,
     config: Config = commands.inject(get_config),
 ):
@@ -67,7 +67,7 @@ async def injected1(
 
 @bot.slash_command()
 async def injected2(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     string: str,
     config: Config = commands.inject(get_config),
 ):
@@ -92,7 +92,7 @@ conn: Any = ...  # a placeholder for an actual database connection
 
 @commands.register_injection
 async def get_game_user(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     user: str = None,
     server: Literal["eu", "us", "cn"] = None,
 ) -> GameUser:
@@ -114,5 +114,5 @@ async def get_game_user(
 
 
 @bot.slash_command()
-async def implicit_injection(inter: disnake.ApplicationCommandInteraction, user: GameUser):
+async def implicit_injection(inter: disnake.CommandInteraction, user: GameUser):
     """A command which uses an implicit injection"""

--- a/examples/slash_commands/param.py
+++ b/examples/slash_commands/param.py
@@ -1,3 +1,4 @@
+from typing import Type
 import disnake
 from disnake.ext import commands
 
@@ -15,7 +16,7 @@ bot = commands.Bot("!")
 # disnake takes care of parsing the annotation and adding a description for it.
 @bot.slash_command()
 async def simple(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     required: str,
     optional: int = 0,
 ):
@@ -26,7 +27,7 @@ async def simple(
 # You can also use various other types like User, Member, Role, TextChannel, Emoji, ...
 @bot.slash_command()
 async def other_types(
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     user: disnake.User,
     emoji: disnake.Emoji,
 ):
@@ -35,14 +36,16 @@ async def other_types(
 
 # Adding descriptions is very simple, just use the docstring
 @bot.slash_command()
-async def description(inter: disnake.ApplicationCommandInteraction, user: disnake.User):
+async def description(inter: disnake.CommandInteraction, user: disnake.User):
     """A random command"""
 
 
 # Options can also be added into the docstring
 @bot.slash_command()
 async def full_description(
-    inter: disnake.ApplicationCommandInteraction, user: disnake.User, channel: disnake.TextChannel
+    inter: disnake.CommandInteraction,
+    user: disnake.User,
+    channel: disnake.TextChannel,
 ):
     """A random command
 
@@ -58,22 +61,48 @@ async def full_description(
 # This is so the annotation actually stays correct.
 @bot.slash_command()
 async def defaults(
-    self,
-    inter: disnake.ApplicationCommandInteraction,
+    inter: disnake.CommandInteraction,
     string: str = None,
     user: disnake.User = commands.Param(lambda inter: inter.author),
 ):
     ...
 
 
-# You may limit numbers into a certain range using gt, ge, lt, le (greater than, greater or equal, less than, less or equal)
-# Alternatively you may use min_value instead of ge and max_value instead of le
+# You may limit numbers into a certain range using commands.Range
+# ... implictly means infinity. Range[0, ...] therefore means any integer from 0 to infinity and Range[..., 0] means from -inf to 0
+# The 1.0 in fraction is very important, the usage of a float says that the argument may be any float in that range.
+#
+# If your linter complains about wrong types you may use IntRange or FloatRange
+# They are however completely optional and only there to improve user experience.
 @bot.slash_command()
 async def ranges(
-    self,
-    inter: disnake.ApplicationCommandInteraction,
-    ranking: int = commands.Param(gt=0, le=10),
-    negative: float = commands.Param(lt=0),
-    fraction: float = commands.Param(ge=0, lt=1),
+    inter: disnake.CommandInteraction,
+    ranking: commands.Range[1, 10],
+    negative: commands.IntRange[..., 0],
+    fraction: commands.FloatRange[0, 1.0],
+):
+    """Command with limited ranges
+
+    Parameters
+    ----------
+    ranking: An integer between 1 and 10
+    negative: An integer lower than 0
+    fraction: A floating point number between 0 and 1
+    """
+    ...
+
+
+# All of these may also be created separately if you so choose
+Ranking: Type = commands.Range[1, 10]
+Negative: Type = commands.Range.create(lt=0)
+Fraction: Type = commands.Range.create(min_value=0, max_value=1)
+
+
+@bot.slash_command()
+async def seprate_ranges(
+    inter: disnake.CommandInteraction,
+    ranking: Ranking,
+    negative: Negative,
+    fraction: Fraction,
 ):
     ...

--- a/examples/slash_commands/param.py
+++ b/examples/slash_commands/param.py
@@ -68,7 +68,7 @@ async def defaults(
 
 
 # You may limit numbers into a certain range using commands.Range
-# "..." is impicitlyinfinity. Range[0, ...] therefore means any integer from 0 to infinity and Range[..., 0] means from -inf to 0
+# "..." is impicitly infinity. Range[0, ...] therefore means any integer from 0 to infinity and Range[..., 0] means from -inf to 0
 # The 1.0 in fraction is very important, the usage of a float says that the argument may be any float in that range.
 @bot.slash_command()
 async def ranges(

--- a/examples/slash_commands/param.py
+++ b/examples/slash_commands/param.py
@@ -1,4 +1,3 @@
-from typing import Type
 import disnake
 from disnake.ext import commands
 
@@ -69,17 +68,14 @@ async def defaults(
 
 
 # You may limit numbers into a certain range using commands.Range
-# ... implictly means infinity. Range[0, ...] therefore means any integer from 0 to infinity and Range[..., 0] means from -inf to 0
+# "..." is impicitlyinfinity. Range[0, ...] therefore means any integer from 0 to infinity and Range[..., 0] means from -inf to 0
 # The 1.0 in fraction is very important, the usage of a float says that the argument may be any float in that range.
-#
-# If your linter complains about wrong types you may use IntRange or FloatRange
-# They are however completely optional and only there to improve user experience.
 @bot.slash_command()
 async def ranges(
     inter: disnake.CommandInteraction,
     ranking: commands.Range[1, 10],
-    negative: commands.IntRange[..., 0],
-    fraction: commands.FloatRange[0, 1.0],
+    negative: commands.Range[..., 0],
+    fraction: commands.Range[0, 1.0],
 ):
     """Command with limited ranges
 
@@ -89,20 +85,3 @@ async def ranges(
     negative: An integer lower than 0
     fraction: A floating point number between 0 and 1
     """
-    ...
-
-
-# All of these may also be created separately if you so choose
-Ranking: Type = commands.Range[1, 10]
-Negative: Type = commands.Range.create(lt=0)
-Fraction: Type = commands.Range.create(min_value=0, max_value=1)
-
-
-@bot.slash_command()
-async def seprate_ranges(
-    inter: disnake.CommandInteraction,
-    ranking: Ranking,
-    negative: Negative,
-    fraction: Fraction,
-):
-    ...

--- a/test_bot/cogs/injections.py
+++ b/test_bot/cogs/injections.py
@@ -27,7 +27,7 @@ class PrefixConverter:
         self.prefix = prefix
         self.suffix = suffix
 
-    def __call__(self, inter: disnake.ApplicationCommandInteraction, a: str = "init"):
+    def __call__(self, inter: disnake.CommandInteraction, a: str = "init"):
         return self.prefix + a + self.suffix
 
 
@@ -37,7 +37,7 @@ class HopeToGod:
         self.discriminator = discriminator
 
     @commands.converter_method
-    async def convert(cls, inter: disnake.ApplicationCommandInteraction, user: disnake.User):
+    async def convert(cls, inter: disnake.CommandInteraction, user: disnake.User):
         return cls(user.name, user.discriminator)
 
     def __repr__(self) -> str:
@@ -85,7 +85,7 @@ class InjectionSlashCommands(commands.Cog):
     @commands.slash_command()
     async def injection_command(
         self,
-        inter: disnake.ApplicationCommandInteraction,
+        inter: disnake.CommandInteraction,
         sqrt: Optional[float] = commands.Param(None, converter=lambda i, x: x ** 0.5),
         prefixed: str = commands.Param(converter=PrefixConverter("__", "__")),
         other: Tuple[int, str] = commands.inject(injected),
@@ -105,7 +105,7 @@ class InjectionSlashCommands(commands.Cog):
     @commands.slash_command()
     async def discerned_injections(
         self,
-        inter: disnake.ApplicationCommandInteraction,
+        inter: disnake.CommandInteraction,
         perhaps: PerhapsThis,
         god: HopeToGod = None,
     ):

--- a/test_bot/cogs/slash_commands.py
+++ b/test_bot/cogs/slash_commands.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import disnake
 from disnake.ext import commands
 
@@ -11,11 +13,11 @@ class SlashCommands(commands.Cog):
         self.bot: commands.Bot = bot
 
     @commands.slash_command()
-    async def hello(self, inter: disnake.AppCmdInter):
+    async def hello(self, inter: disnake.CommandInteraction):
         await inter.response.send_message("Hello world!")
 
     @commands.slash_command()
-    async def auto(self, inter: disnake.AppCmdInter, mood: str):
+    async def auto(self, inter: disnake.CommandInteraction, mood: str):
         """
         Has an autocomplete option.
 
@@ -26,7 +28,7 @@ class SlashCommands(commands.Cog):
         await inter.send(mood)
 
     @auto.autocomplete("mood")
-    async def test_autocomp(self, inter: disnake.AppCmdInter, string: str):
+    async def test_autocomp(self, inter: disnake.CommandInteraction, string: str):
         return ["XD", ":D", ":)", ":|", ":("]
 
     @commands.slash_command()
@@ -41,6 +43,28 @@ class SlashCommands(commands.Cog):
     @commands.slash_command()
     async def guild_only(self, inter: disnake.GuildCommandInteraction, option: str = None):
         await inter.send(f"guild: {inter.guild} | option: {option!r}")
+
+    @commands.slash_command()
+    async def ranges(
+        self,
+        inter: disnake.CommandInteraction,
+        a: int = commands.Param(None, lt=0),
+        b: commands.Range[1, ...] = None,
+        c: commands.Range[0, 10] = None,
+        d: commands.Range[0.0, 10] = None,
+    ):
+        """limit slash command options to a range of values
+
+        Parameters
+        ----------
+        a: Negative
+        b: Positive
+        c: 0 - 10 integer
+        d: 0 - 10 float
+        """
+        await inter.send(f"{inter.options}")
+
+    print(ranges.options)
 
 
 def setup(bot):

--- a/test_bot/cogs/slash_commands.py
+++ b/test_bot/cogs/slash_commands.py
@@ -51,7 +51,7 @@ class SlashCommands(commands.Cog):
         a: int = commands.Param(None, lt=0),
         b: commands.Range[1, ...] = None,
         c: commands.Range[0, 10] = None,
-        d: commands.Range[0.0, 10] = None,
+        d: commands.Range[0, 10.0] = None,
     ):
         """limit slash command options to a range of values
 
@@ -63,8 +63,6 @@ class SlashCommands(commands.Cog):
         d: 0 - 10 float
         """
         await inter.send(f"{inter.options}")
-
-    print(ranges.options)
 
 
 def setup(bot):


### PR DESCRIPTION
## Summary

Use `x: Range[1, 2]` instead of `x: int = Param(ge=1, le=2)` in slash commands

## Example
```py
# You may limit numbers into a certain range using commands.Range
# "..." is impicitly infinity. Range[0, ...] therefore means any integer from 0 to infinity and Range[..., 0] means from -inf to 0
# The 1.0 in fraction is very important, the usage of a float says that the argument may be any float in that range.
@bot.slash_command()
async def ranges(
    inter: disnake.CommandInteraction,
    ranking: commands.Range[1, 10],
    negative: commands.Range[..., 0],
    fraction: commands.Range[0, 1.0],
):
    """Command with limited ranges

    Parameters
    ----------
    ranking: An integer between 1 and 10
    negative: An integer lower than 0
    fraction: A floating point number between 0 and 1
    """
```
```py
# All of these may also be created separately if you so choose
Ranking: Type[int] = commands.Range[1, 10]
Negative: Type[int] = commands.Range.create(lt=0)
Fraction: Type[float] = commands.Range.create(min_value=0, max_value=1.0)


@bot.slash_command()
async def seprate_ranges(
    inter: disnake.CommandInteraction,
    ranking: Ranking,
    negative: Negative,
    fraction: Fraction,
):
    ...
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
