### PR TITLE
feat(MessageFlags): Add `failed_to_mention_roles_in_thread` flag (1 << 8).

### DIFF
--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -327,7 +327,7 @@ class MessageFlags(BaseFlags):
         return 128
 
     @flag_value
-    def failed_to_mention_roles(self):
+    def failed_to_mention_roles_in_thread(self):
         """:class:`bool`: Returns ``True`` if the source message failed to
         mention some roles and add their members to the thread.
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -326,6 +326,15 @@ class MessageFlags(BaseFlags):
         """
         return 128
 
+    @flag_value
+    def failed_to_mention_roles(self):
+        """:class:`bool`: Returns ``True`` if the source message failed to
+        mention some roles and add their members to the thread.
+
+        .. versionadded:: 2.4
+        """
+        return 256
+
 
 @fill_with_flags()
 class PublicUserFlags(BaseFlags):


### PR DESCRIPTION
## Summary

I failed to test this flag, so if anyone could test this, I appreciate it. Also, I didn't want to make the flag name long, `failed_to_mention_roles_in_thread` might be good to avoid confusions, but it's too long :/

ref:
https://github.com/discord/discord-api-docs/pull/4282

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
