### PR TITLE
Use proxied readthedocs API for hoverxref

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,6 +215,10 @@ hoverxref_role_types = dict.fromkeys(
 )
 hoverxref_tooltip_theme = ["tooltipster-custom"]
 
+# use proxied API endpoint on rtd to avoid CORS issues
+if os.environ.get("READTHEDOCS"):
+    hoverxref_api_host = "/_"
+
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
## Summary

see title
Fixes CORS issues which sometimes occurred (or rather, sometimes *didn't* occur even though they should've) due to a race condition with `beforeSend` on readthedocs.

also see https://github.com/readthedocs/sphinx-hoverxref/issues/165

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
