### PR TITLE
fix: allow deferring messages on component interactions

### DIFF
--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -623,7 +623,7 @@ class InteractionResponse:
         Parameters
         -----------
         show_message: :class:`bool`
-            Indicates whether or not the respond will be a message. Shows a loading screen to the user.
+            Indicates whether the response will be a message with thinking state (bot is thinking...)
             This only applies for interactions of type :attr:`InteractionType.component`.
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -627,7 +627,6 @@ class InteractionResponse:
             This only applies for interactions of type :attr:`InteractionType.component`, and is ``True`` otherwise.
 
             .. versionadded:: 2.4
-
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
             This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -627,7 +627,8 @@ class InteractionResponse:
             This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True
         with_message: :class:`bool`
             Indicates whether the response will be a message with thinking state (bot is thinking...).
-            This only applies for interactions of type :attr:`InteractionType.component`, and is ``True`` otherwise.
+            This is always True for interactions of type :attr:`InteractionType.application_command`.
+            For interactions of type :attr:`InteractionType.component` this defaults to False.
 
             .. versionadded:: 2.4
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -612,7 +612,7 @@ class InteractionResponse:
         """
         return self._responded
 
-    async def defer(self, *, show_message: bool = False, ephemeral: bool = False) -> None:
+    async def defer(self, *, with_message: bool = False, ephemeral: bool = False) -> None:
         """|coro|
 
         Defers the interaction response.
@@ -622,9 +622,9 @@ class InteractionResponse:
 
         Parameters
         -----------
-        show_message: :class:`bool`
+        with_message: :class:`bool`
             Indicates whether the response will be a message with thinking state (bot is thinking...)
-            This only applies for interactions of type :attr:`InteractionType.component`.
+            This only applies for interactions of type :attr:`InteractionType.component`, and is `True` otherwise.
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
             This only applies for interactions of type :attr:`InteractionType.application_command` or when :attr:`show_message` is True.
@@ -642,7 +642,7 @@ class InteractionResponse:
         defer_type: int = 0
         data: Optional[Dict[str, Any]] = None
         parent = self._parent
-        if parent.type is InteractionType.application_command or show_message:
+        if parent.type is InteractionType.application_command or with_message:
             defer_type = InteractionResponseType.deferred_channel_message.value
             if ephemeral:
                 data = {"flags": 64}

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -612,7 +612,7 @@ class InteractionResponse:
         """
         return self._responded
 
-    async def defer(self, *, with_message: bool = False, ephemeral: bool = False) -> None:
+    async def defer(self, *, ephemeral: bool = False, with_message: bool = False) -> None:
         """|coro|
 
         Defers the interaction response.
@@ -622,14 +622,14 @@ class InteractionResponse:
 
         Parameters
         -----------
+        ephemeral: :class:`bool`
+            Indicates whether the deferred message will eventually be ephemeral.
+            This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True
         with_message: :class:`bool`
             Indicates whether the response will be a message with thinking state (bot is thinking...).
             This only applies for interactions of type :attr:`InteractionType.component`, and is ``True`` otherwise.
 
             .. versionadded:: 2.4
-        ephemeral: :class:`bool`
-            Indicates whether the deferred message will eventually be ephemeral.
-            This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True
 
         Raises
         -------

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -612,7 +612,7 @@ class InteractionResponse:
         """
         return self._responded
 
-    async def defer(self, *, ephemeral: bool = False) -> None:
+    async def defer(self, *, show_message: bool = False, ephemeral: bool = False) -> None:
         """|coro|
 
         Defers the interaction response.
@@ -622,9 +622,12 @@ class InteractionResponse:
 
         Parameters
         -----------
+        show_message: :class:`bool`
+            Indicates whether or not the respond will be a message. Shows a loading screen to the user.
+            This only applies for interactions of type :attr:`InteractionType.component`.
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
-            This only applies for interactions of type :attr:`InteractionType.application_command`.
+            This only applies for interactions of type :attr:`InteractionType.application_command` or when :attr:`show_message` is True.
 
         Raises
         -------
@@ -639,12 +642,12 @@ class InteractionResponse:
         defer_type: int = 0
         data: Optional[Dict[str, Any]] = None
         parent = self._parent
-        if parent.type is InteractionType.component:
-            defer_type = InteractionResponseType.deferred_message_update.value
-        elif parent.type is InteractionType.application_command:
+        if parent.type is InteractionType.application_command or show_message:
             defer_type = InteractionResponseType.deferred_channel_message.value
             if ephemeral:
                 data = {"flags": 64}
+        elif parent.type is InteractionType.component:
+            defer_type = InteractionResponseType.deferred_message_update.value
 
         if defer_type:
             adapter = async_context.get()

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -623,11 +623,11 @@ class InteractionResponse:
         Parameters
         -----------
         with_message: :class:`bool`
-            Indicates whether the response will be a message with thinking state (bot is thinking...)
-            This only applies for interactions of type :attr:`InteractionType.component`, and is `True` otherwise.
+            Indicates whether the response will be a message with thinking state (bot is thinking...).
+            This only applies for interactions of type :attr:`InteractionType.component`, and is ``True`` otherwise.
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
-            This only applies for interactions of type :attr:`InteractionType.application_command` or when :attr:`show_message` is True.
+            This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True
 
         Raises
         -------

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -625,6 +625,9 @@ class InteractionResponse:
         with_message: :class:`bool`
             Indicates whether the response will be a message with thinking state (bot is thinking...).
             This only applies for interactions of type :attr:`InteractionType.component`, and is ``True`` otherwise.
+
+            .. versionadded:: 2.4
+
         ephemeral: :class:`bool`
             Indicates whether the deferred message will eventually be ephemeral.
             This only applies for interactions of type :attr:`InteractionType.application_command` or when ``with_message`` is True


### PR DESCRIPTION
## Summary
added show_message to defer, which for component interactions sends a type 5 response instead of 6.
![image](https://user-images.githubusercontent.com/71233171/148002003-95a0e555-7b79-4d74-9203-0f77f63e71b4.png)

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
