### PR TITLE
Improve `app_commands.py` typing

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -53,6 +53,12 @@ if TYPE_CHECKING:
         GuildApplicationCommandPermissions as GuildApplicationCommandPermissionsPayload,
     )
 
+    Choices = Union[
+        List["OptionChoice"],
+        List[ApplicationCommandOptionChoiceValue],
+        Dict[str, ApplicationCommandOptionChoiceValue],
+    ]
+
 __all__ = (
     "application_command_factory",
     "ApplicationCommand",
@@ -109,13 +115,6 @@ class OptionChoice:
     @classmethod
     def from_dict(cls, data: ApplicationCommandOptionChoicePayload):
         return OptionChoice(name=data["name"], value=data["value"])
-
-
-Choices = Union[
-    List[OptionChoice],
-    List[ApplicationCommandOptionChoiceValue],
-    Dict[str, ApplicationCommandOptionChoiceValue],
-]
 
 
 class Option:

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -320,6 +320,17 @@ class ApplicationCommand(ABC):
     The base class for application commands
     """
 
+    __slots__ = (
+        "type",
+        "name",
+        "default_permission",
+        "id",
+        "application_id",
+        "guild_id",
+        "version",
+        "_always_synced",
+    )
+
     def __init__(self, type: ApplicationCommandType, name: str, default_permission: bool = True):
         self.type: ApplicationCommandType = enum_if_int(ApplicationCommandType, type)
         self.name: str = name
@@ -359,6 +370,8 @@ class ApplicationCommand(ABC):
 
 
 class UserCommand(ApplicationCommand):
+    __slots__ = ()
+
     def __init__(self, name: str, default_permission: bool = True):
         super().__init__(
             type=ApplicationCommandType.user,
@@ -384,6 +397,8 @@ class UserCommand(ApplicationCommand):
 
 
 class MessageCommand(ApplicationCommand):
+    __slots__ = ()
+
     def __init__(self, name: str, default_permission: bool = True):
         super().__init__(
             type=ApplicationCommandType.message,
@@ -423,6 +438,8 @@ class SlashCommand(ApplicationCommand):
     default_permission : :class:`bool`
         Whether the command is enabled by default when the app is added to a guild
     """
+
+    __slots__ = ("description", "options")
 
     def __init__(
         self,

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -174,7 +174,7 @@ class Option:
         max_value: float = None,
     ):
         self.name: str = name.lower()
-        self.description: Optional[str] = description
+        self.description: str = description or "\u200b"
         self.type: OptionType = enum_if_int(OptionType, type) or OptionType.string
         self.required: bool = required
         self.options: List[Option] = options or []

--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -88,7 +88,7 @@ class GatewayNotFound(DiscordException):
     """An exception that is raised when the gateway for Discord could not be found"""
 
     def __init__(self):
-        message = "The gateway to connect to disnake was not found."
+        message = "The gateway to connect to Discord was not found."
         super().__init__(message)
 
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2323,7 +2323,7 @@ class HTTPClient:
         application_id: Snowflake,
         guild_id: Snowflake,
         payload: List[interactions.PartialGuildApplicationCommandPermissions],
-    ) -> Response[List[interactions.ApplicationCommandPermissions]]:
+    ) -> Response[List[interactions.GuildApplicationCommandPermissions]]:
         r = Route(
             "PUT",
             "/applications/{application_id}/guilds/{guild_id}/commands/permissions",

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -360,7 +360,7 @@ class BotIntegration(Integration):
 
 
 def _integration_factory(value: str) -> Tuple[Type[Integration], str]:
-    if value == "disnake":
+    if value == "discord":
         return BotIntegration, value
     elif value in ("twitch", "youtube"):
         return StreamIntegration, value

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -43,8 +43,10 @@ ApplicationCommandType = Literal[1, 2, 3]
 
 
 class _ApplicationCommandOptional(TypedDict, total=False):
-    options: List[ApplicationCommandOption]
     type: ApplicationCommandType
+    guild_id: Snowflake
+    options: List[ApplicationCommandOption]
+    default_permission: bool
 
 
 class ApplicationCommand(_ApplicationCommandOptional):
@@ -52,11 +54,17 @@ class ApplicationCommand(_ApplicationCommandOptional):
     application_id: Snowflake
     name: str
     description: str
+    version: Snowflake
 
 
 class _ApplicationCommandOptionOptional(TypedDict, total=False):
+    required: bool
     choices: List[ApplicationCommandOptionChoice]
     options: List[ApplicationCommandOption]
+    channel_types: List[ChannelType]
+    min_value: float
+    max_value: float
+    autocomplete: bool
 
 
 ApplicationCommandOptionType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -66,12 +74,14 @@ class ApplicationCommandOption(_ApplicationCommandOptionOptional):
     type: ApplicationCommandOptionType
     name: str
     description: str
-    required: bool
+
+
+ApplicationCommandOptionChoiceValue = Union[str, int, float]
 
 
 class ApplicationCommandOptionChoice(TypedDict):
     name: str
-    value: Union[str, int]
+    value: ApplicationCommandOptionChoiceValue
 
 
 ApplicationCommandPermissionType = Literal[1, 2]

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -241,9 +241,9 @@ class MessageInteraction(TypedDict):
 class _EditApplicationCommandOptional(TypedDict, total=False):
     description: str
     options: Optional[List[ApplicationCommandOption]]
+    default_permission: bool
     type: ApplicationCommandType
 
 
 class EditApplicationCommand(_EditApplicationCommandOptional):
     name: str
-    default_permission: bool

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -141,6 +141,7 @@ else:
 
 
 T = TypeVar("T")
+V = TypeVar("V")
 T_co = TypeVar("T_co", covariant=True)
 _Iter = Union[Iterator[T], AsyncIterator[T]]
 
@@ -496,11 +497,10 @@ def _get_as_snowflake(data: Any, key: str) -> Optional[int]:
         return value and int(value)
 
 
-def _get_and_cast(data: dict, key: Any, converter: Callable, default: Any = None) -> Any:
-    try:
-        return converter(data[key])
-    except KeyError:
+def _maybe_cast(value: V, converter: Callable[[V], T], default: T = None) -> Optional[T]:
+    if value is MISSING:
         return default
+    return converter(value)
 
 
 def _get_mime_type_for_image(data: bytes):


### PR DESCRIPTION
## Summary

This PR updates the typings for application commands, and makes `app_commands.py` fully typed (no more `Dict[str, Any]` or `Any` \o/ ).
Changes in no particular order:
- `ApplicationCommand` and subtypes are now slotted
- `ApplicationCommand.__init__` and its subtypes no longer take `**kwargs`, common parameters in application command payloads are now handled by `_update_common` which is called by `from_dict`. I tried a few different solutions and this was the one that worked best, since calling `__init__` from a `classmethod` is tricky with inheritance
  The `**kwargs` were never meant to be set by the user and were only populated from API response payloads, so this change should be fine.
- `_get_and_cast` is `_maybe_cast` now and works a bit differently, while it unfortunately doesn't look as nice as before it's type-safe now
- The `description` value for `Option` is no longer optional (the API doesn't allow that anyway) and defaults to `'\u200b'` if the parameter is `None`/empty
- Some leftover incorrect strings are now fixed
- None of the methods return `Any` or `Dict[str, Any]` anymore, and instead use types defined in `disnake.types`

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
    - *idk, `**kwargs` on `ApplicationCommand` and subtypes were never documented and not supposed to be used anyway, so not really*
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
