### PR TITLE
use http version 9

### DIFF
--- a/disnake/http.py
+++ b/disnake/http.py
@@ -141,7 +141,7 @@ def to_multipart(payload: Dict[str, Any], files: Iterable[File]) -> List[Dict[st
 
 
 class Route:
-    BASE: ClassVar[str] = "https://discord.com/api/v8"
+    BASE: ClassVar[str] = "https://discord.com/api/v9"
 
     def __init__(self, method: str, path: str, **parameters: Any) -> None:
         self.path: str = path


### PR DESCRIPTION
## Summary

Bump to http api version 9
the only change from v8 to v9 were adding thread channels to gateway events
and there's no http api differences between v8 to v9


<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
