### PR TITLE
fix: bugs with link buttons

### DIFF
--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -52,7 +52,7 @@ from ..components import (
     SelectMenu as SelectComponent,
     _component_factory,
 )
-from ..enums import try_enum_to_int, ComponentType
+from ..enums import ComponentType, try_enum_to_int
 from .item import Item
 
 __all__ = ("View",)

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -52,7 +52,7 @@ from ..components import (
     SelectMenu as SelectComponent,
     _component_factory,
 )
-from ..enums import try_enum_to_int
+from ..enums import try_enum_to_int, ComponentType
 from .item import Item
 
 __all__ = ("View",)
@@ -412,7 +412,7 @@ class View:
             except (KeyError, AttributeError):
                 for child in self.children:
                     if (
-                        child.type.value == 2  # Button
+                        child.type is ComponentType.button
                         and child.label == component.label  # type: ignore
                         and child.url == component.url  # type: ignore
                     ):

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -410,7 +410,17 @@ class View:
             try:
                 older = old_state[(component.type.value, component.custom_id)]  # type: ignore
             except (KeyError, AttributeError):
-                children.append(_component_to_item(component))
+                for child in self.children:
+                    if (
+                        child.type.value == 2  # Button
+                        and child.label == component.label  # type: ignore
+                        and child.url == component.url  # type: ignore
+                    ):
+                        child.refresh_component(component)
+                        children.append(child)
+                        break
+                else:
+                    children.append(_component_to_item(component))
             else:
                 older.refresh_component(component)
                 children.append(older)

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -397,14 +397,12 @@ class View:
         )
 
     def refresh(self, components: List[Component]):
-        # This is pretty hacky at the moment
-        # fmt: off
+        # TODO: this is pretty hacky at the moment
         old_state: Dict[Tuple[int, str], Item] = {
             (item.type.value, item.custom_id): item  # type: ignore
             for item in self.children
             if item.is_dispatchable()
         }
-        # fmt: on
         children: List[Item] = []
         for component in _walk_all_components(components):
             older: Optional[Item] = None


### PR DESCRIPTION
## Summary

<sup>First bug</sup>
This PR fixes a bug for when a view is refreshed, and it has a link button, since they aren't dispatchable, they won't be in this dict,
![image](https://user-images.githubusercontent.com/67214928/148285588-a554cde2-f0a3-4c1b-a356-164fcf0363cb.png)
so it tries to get the link button from it,
https://github.com/DisnakeDev/disnake/blob/2e5488572cc25432101da3328f44ae638d05dae6/disnake/ui/view.py#L409-L413
and since it isn't there, it'll raise a `KeyError` error, and then it tries to create a new item (`_component_to_item`)
https://github.com/DisnakeDev/disnake/blob/2e5488572cc25432101da3328f44ae638d05dae6/disnake/ui/view.py#L77-L81
which calls `Button.from_component` which defines `row` to `None`
https://github.com/DisnakeDev/disnake/blob/2e5488572cc25432101da3328f44ae638d05dae6/disnake/ui/button.py#L203-L213

There is also another related bug, but I really don't understand why it happens :/

Closes #251 bug
Yes, views really need a refactor.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
