### PR TITLE
Add support for modals and input text.

### DIFF
--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -52,6 +52,7 @@ __all__ = (
     "VideoQualityMode",
     "ComponentType",
     "ButtonStyle",
+    "InputTextStyle",
     "StagePrivacyLevel",
     "InteractionType",
     "InteractionResponseType",
@@ -583,6 +584,7 @@ class InteractionType(Enum):
     application_command = 2
     component = 3
     application_command_autocomplete = 4
+    modal_submit = 5
 
 
 class InteractionResponseType(Enum):
@@ -594,6 +596,7 @@ class InteractionResponseType(Enum):
     deferred_message_update = 6  # for components
     message_update = 7  # for components
     application_command_autocomplete_result = 8  # for autocomplete
+    modal_submit = 9  # for modals
 
 
 class VideoQualityMode(Enum):
@@ -608,6 +611,7 @@ class ComponentType(Enum):
     action_row = 1
     button = 2
     select = 3
+    input_text = 4
 
     def __int__(self):
         return self.value
@@ -629,6 +633,19 @@ class ButtonStyle(Enum):
     url = 5
 
     def __int__(self):
+        return self.value
+
+
+class InputTextStyle(Enum):
+    short = 1
+    paragraph = 2
+
+    # Aliases
+    singleline = 1
+    long = 2
+    multiline = 2
+
+    def __int__(self) -> int:
         return self.value
 
 

--- a/disnake/interactions/__init__.py
+++ b/disnake/interactions/__init__.py
@@ -1,3 +1,4 @@
 from .application_command import *
 from .base import *
 from .message import *
+from .modal import *

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -1,0 +1,90 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present Disnake Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List
+
+from .base import Interaction
+
+if TYPE_CHECKING:
+    from ..state import ConnectionState
+    from ..types.components import ActionRow as ActionRowPayload
+    from ..types.interactions import (
+        Interaction as InteractionPayload,
+        ModalInteractionData as ModalInteractionDataPayload,
+    )
+
+__all__ = ("ModalInteraction", "ModalInteractionData")
+
+
+class ModalInteraction(Interaction):
+    """Represents an Interaction with a modal.
+
+    .. versionadded:: 2.4
+
+    Attributes
+    ----------
+    data: :class:`ModalInteractionData`
+        The wrapped interaction data.
+    """
+
+    def __init__(self, *, data: InteractionPayload, state: ConnectionState):
+        super().__init__(data=data, state=state)
+        self.data = ModalInteractionData(data=data.get("data", {}))  # type: ignore
+
+    @property
+    def values(self) -> Dict[str, str]:
+        """Dict[str, str]: Returns the values the user has entered in the modal.
+        This is a dict of the form ``{custom_id: value}``."""
+        values: Dict[str, str] = {}
+        for action_row in self.data.components:
+            component = action_row["components"][0]
+            values[component["custom_id"]] = component["value"]  # type: ignore
+        return values
+
+    @property
+    def custom_id(self) -> str:
+        """:class:`str`: The custom ID of the modal."""
+        return self.data.custom_id
+
+
+class ModalInteractionData:
+    """Represents the data of an interaction with a modal.
+
+    .. versionadded:: 2.4
+
+    Attributes
+    ----------
+    custom_id: str
+        The custom ID of the modal.
+    components: List[:class:`ActionRow`]
+        A list with the components of the modal.
+    """
+
+    __slots__ = ("custom_id", "components")
+
+    def __init__(self, *, data: ModalInteractionDataPayload):
+        self.custom_id: str = data.get("custom_id")  # type: ignore # Is the custom ID always present?
+        self.components: List[ActionRowPayload] = data.get("components", [])

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -63,7 +63,12 @@ from .flags import ApplicationFlags, Intents, MemberCacheFlags
 from .guild import Guild
 from .guild_scheduled_event import GuildScheduledEvent
 from .integrations import _integration_factory
-from .interactions import ApplicationCommandInteraction, Interaction, MessageInteraction
+from .interactions import (
+    ApplicationCommandInteraction,
+    Interaction,
+    MessageInteraction,
+    ModalInteraction,
+)
 from .invite import Invite
 from .member import Member
 from .mentions import AllowedMentions
@@ -75,6 +80,7 @@ from .role import Role
 from .stage_instance import StageInstance
 from .sticker import GuildSticker
 from .threads import Thread, ThreadMember
+from .ui.modal import Modal, ModalStore
 from .ui.view import View, ViewStore
 from .user import ClientUser, User
 from .utils import MISSING
@@ -263,7 +269,9 @@ class ConnectionState:
 
         self.clear()
 
-    def clear(self, *, views: bool = True, application_commands: bool = True) -> None:
+    def clear(
+        self, *, views: bool = True, application_commands: bool = True, modals: bool = True
+    ) -> None:
         self.user: ClientUser = MISSING
         # Originally, this code used WeakValueDictionary to maintain references to the
         # global user mapping.
@@ -291,6 +299,9 @@ class ConnectionState:
 
         if views:
             self._view_store: ViewStore = ViewStore(self)
+
+        if modals:
+            self._modal_store: ModalStore = ModalStore(self)
 
         self._voice_clients: Dict[int, VoiceProtocol] = {}
 
@@ -399,6 +410,9 @@ class ConnectionState:
 
     def store_view(self, view: View, message_id: Optional[int] = None) -> None:
         self._view_store.add_view(view, message_id)
+
+    def store_modal(self, user_id: int, modal: Modal) -> None:
+        self._modal_store.add_modal(user_id, modal)
 
     def prevent_view_updates_for(self, message_id: int) -> Optional[View]:
         return self._view_store.remove_message_tracking(message_id)
@@ -730,7 +744,7 @@ class ConnectionState:
             self._ready_task.cancel()
 
         self._ready_state = asyncio.Queue()
-        self.clear(views=False, application_commands=False)
+        self.clear(views=False, application_commands=False, modals=False)
         self.user = ClientUser(state=self, data=data["user"])
         self.store_user(data["user"])
 
@@ -900,6 +914,10 @@ class ConnectionState:
         elif data["type"] == 4:
             interaction = ApplicationCommandInteraction(data=data, state=self)
             self.dispatch("application_command_autocomplete", interaction)
+        elif data["type"] == 5:
+            interaction = ModalInteraction(data=data, state=self)
+            self._modal_store.dispatch(interaction)
+            self.dispatch("modal_submit", interaction)
         else:
             return
 

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -31,6 +31,7 @@ from .emoji import PartialEmoji
 
 ComponentType = Literal[1, 2, 3]
 ButtonStyle = Literal[1, 2, 3, 4, 5]
+InputTextStyle = Literal[1, 2]
 
 
 class ActionRow(TypedDict):
@@ -75,4 +76,25 @@ class SelectMenu(_SelectMenuOptional):
     options: List[SelectOption]
 
 
-Component = Union[ActionRow, ButtonComponent, SelectMenu]
+class Modal(TypedDict):
+    title: str
+    custom_id: str
+    components: List[InputText]
+
+
+class _InputTextOptional(TypedDict, total=False):
+    value: str
+    required: bool
+    placeholder: str
+    min_length: int
+    max_length: int
+
+
+class InputText(_InputTextOptional):
+    type: Literal[4]
+    custom_id: str
+    style: InputTextStyle
+    label: str
+
+
+Component = Union[ActionRow, ButtonComponent, SelectMenu, InputText]

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, TypedDict, Union
 
 from .channel import ChannelType
-from .components import Component, ComponentType
+from .components import ActionRow, Component, ComponentType
 from .embed import Embed
 from .member import Member
 from .role import Role
@@ -179,7 +179,14 @@ class ComponentInteractionData(_ComponentInteractionDataOptional):
     component_type: ComponentType
 
 
-InteractionData = Union[ApplicationCommandInteractionData, ComponentInteractionData]
+class ModalInteractionData(TypedDict):
+    custom_id: str
+    components: List[ActionRow]
+
+
+InteractionData = Union[
+    ApplicationCommandInteractionData, ComponentInteractionData, ModalInteractionData
+]
 
 
 class _InteractionOptional(TypedDict, total=False):

--- a/disnake/ui/__init__.py
+++ b/disnake/ui/__init__.py
@@ -11,6 +11,8 @@ Bot UI Kit helper for the Discord API
 
 from .action_row import *
 from .button import *
+from .input_text import *
 from .item import *
+from .modal import *
 from .select import *
 from .view import *

--- a/disnake/ui/input_text.py
+++ b/disnake/ui/input_text.py
@@ -1,0 +1,158 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present DisnakeDev
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Type, TypeVar
+
+from ..components import InputText as InputTextComponent
+from ..enums import ComponentType
+
+if TYPE_CHECKING:
+    from ..enums import InputTextStyle
+    from ..types.components import InputText as InputTextPayload
+
+IT = TypeVar("IT", bound="InputText")
+
+
+class InputText:
+    def __init__(
+        self,
+        *,
+        style: InputTextStyle,  # Default to InputTextStyle.short?
+        label: str,
+        custom_id: str,
+        placeholder: Optional[str] = None,
+        value: Optional[str] = None,
+        required: bool = True,
+        min_length: int = 0,
+        max_length: Optional[int] = None,
+    ) -> None:
+        self._underlying = InputTextComponent._raw_construct(
+            type=ComponentType.input_text,
+            style=style,
+            label=label,
+            custom_id=custom_id,
+            placeholder=placeholder,
+            value=value,
+            required=required,
+            min_length=min_length,
+            max_length=max_length,
+        )
+
+    @property
+    def width(self) -> int:
+        return 5
+
+    @property
+    def type(self) -> ComponentType:
+        """:class:`ComponentType`: The type of the input text. This is always ``ComponentType.input_text``."""
+        return self._underlying.type
+
+    @property
+    def style(self) -> InputTextStyle:
+        """:class:`InputTextStyle`: The style of the input text."""
+        return self._underlying.style
+
+    @style.setter
+    def style(self, value: InputTextStyle) -> None:
+        self._underlying.style = value
+
+    @property
+    def label(self) -> str:
+        """:class:`str`: The label of the input text."""
+        return self._underlying.label
+
+    @label.setter
+    def label(self, value: str) -> None:
+        self._underlying.label = value
+
+    @property
+    def custom_id(self) -> str:
+        """:class:`str`: The ID of the input text that gets received during an interaction."""
+        return self._underlying.custom_id
+
+    @custom_id.setter
+    def custom_id(self, value: str) -> None:
+        self._underlying.custom_id = value
+
+    @property
+    def placeholder(self) -> Optional[str]:
+        """:class:`str`: The placeholder text that is shown if nothing is entered."""
+        return self._underlying.placeholder
+
+    @placeholder.setter
+    def placeholder(self, value: Optional[str]) -> None:
+        self._underlying.placeholder = value
+
+    @property
+    def value(self) -> Optional[str]:
+        """:class:`str`: The pre-filled text of the input text."""
+        return self._underlying.value
+
+    @value.setter
+    def value(self, value: Optional[str]) -> None:
+        self._underlying.value = value
+
+    @property
+    def required(self) -> bool:
+        """:class:`bool`: Whether the input text is required."""
+        return self._underlying.required
+
+    @required.setter
+    def required(self, value: bool) -> None:
+        self._underlying.required = value
+
+    @property
+    def min_length(self) -> int:
+        """:class:`int`: The minimum length of the input text."""
+        return self._underlying.min_length
+
+    @min_length.setter
+    def min_length(self, value: int) -> None:
+        self._underlying.min_length = value
+
+    @property
+    def max_length(self) -> Optional[int]:
+        """:class:`int`: The maximum length of the input text."""
+        return self._underlying.max_length
+
+    @max_length.setter
+    def max_length(self, value: Optional[int]) -> None:
+        self._underlying.max_length = value
+
+    def to_component_dict(self) -> InputTextPayload:
+        return self._underlying.to_dict()
+
+    @classmethod
+    def from_dict(cls: Type[IT], data: InputTextPayload) -> IT:
+        return cls(
+            style=data["style"],  # type: ignore
+            label=data["label"],
+            custom_id=data["custom_id"],
+            placeholder=data.get("placeholder"),
+            value=data.get("value"),
+            required=data.get("required", True),
+            min_length=data.get("min_length", 0),
+            max_length=data.get("max_length"),
+        )

--- a/disnake/ui/modal.py
+++ b/disnake/ui/modal.py
@@ -1,0 +1,228 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2021-present DisnakeDev
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import traceback
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union, overload
+
+from ..components import Modal as ModalComponent
+from .input_text import InputText
+
+if TYPE_CHECKING:
+    from ..interactions.modal import ModalInteraction
+    from ..state import ConnectionState
+
+__all__ = ["Modal"]
+
+
+class Modal:
+    """Represents a UI Modal.
+
+    .. versionadded:: 2.4
+
+    Parameters
+    ----------
+    title: str
+        The title of the modal
+    custom_id: str
+        The custom ID of the modal.
+    components: List[:class:`.ui.InputText`]
+        A list of components to display in the modal. Maximum of 5.
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        custom_id: str,
+        components: List[InputText],  # Discord will support other components as well.
+    ) -> None:
+        if len(components) > 5:
+            raise ValueError("maximum of components is 5.")
+
+        for component in components:
+            if not isinstance(component, InputText):
+                raise TypeError(
+                    f"components must be a list of InputTexts, but {component.__class__.__name__} was given."
+                )
+
+        self._underlying = ModalComponent._raw_construct(
+            title=title, custom_id=custom_id, components=components
+        )
+
+    def __repr__(self) -> str:
+        return f"<Modal {self.title}, custom_id={self.custom_id}, components={self.components}>"
+
+    @property
+    def title(self) -> str:
+        """:class:`str`: The title of the modal."""
+        return self._underlying.title
+
+    @title.setter
+    def title(self, title: str) -> None:
+        self._underlying.title = title
+
+    @property
+    def custom_id(self) -> str:
+        """:class:`str`: The ID of the modal that gets received during an interaction."""
+        return self._underlying.custom_id
+
+    @custom_id.setter
+    def custom_id(self, custom_id: str) -> None:
+        self._underlying.custom_id = custom_id
+
+    @property
+    def components(self) -> List[InputText]:
+        """List[:class:`.ui.InputText`]: A list of components the modal contains."""
+        return self._underlying.components
+
+    @overload
+    def add_component(self, component: List[InputText]) -> None:
+        ...
+
+    @overload
+    def add_component(self, component: InputText) -> None:
+        ...
+
+    def add_component(self, component: Union[InputText, List[InputText]]) -> None:
+        """Adds a component to the modal.
+
+        Parameters
+        ----------
+        component: Union[:class:`.ui.InputText`, List[:class:`.ui.InputText`]]
+            The component to add to the modal.
+
+        Raises
+        ------
+        ValueError
+            Maximum of components exceeded. (5)
+        TypeError
+            An :class:`InputText` object was not passed.
+        """
+        if len(self.components) == 5:
+            raise ValueError("maximum of components exceeded.")
+
+        if not isinstance(component, list):
+            component = [component]
+
+        for c in component:
+            if not isinstance(c, InputText):
+                raise TypeError(
+                    f"component must be of type InputText or a list of InputText, not {c.__class__.__name__}."
+                )
+            self._underlying.components.append(c)
+
+    async def callback(self, interaction: ModalInteraction) -> None:
+        """|coro|
+
+        The callback associated with this modal.
+
+        This can be overriden by subclasses.
+
+        Parameters
+        ----------
+        interaction: :class:`ModalInteraction`
+            The interaction that triggered this modal.
+        """
+        pass
+
+    async def on_error(self, error: Exception, interaction: ModalInteraction) -> None:
+        """|coro|
+
+        A callback that is called when an error occurs.
+
+        The default implementation prints the traceback to stderr.
+
+        Parameters
+        ----------
+        error: :class:`Exception`
+            The exception that was raised.
+        interaction: :class:`ModalInteraction`
+            The interaction that triggered this modal.
+        """
+        traceback.print_exception(error.__class__, error, error.__traceback__, file=sys.stderr)
+
+    def to_components(self) -> Dict[str, Any]:
+        components: Dict[str, Any] = {
+            "title": self._underlying.title,
+            "custom_id": self._underlying.custom_id,
+            "components": [],
+        }
+
+        for component in self._underlying.components:
+            components["components"].append(
+                {"type": 1, "components": [component.to_component_dict()]}
+            )
+
+        return components
+
+    async def _scheduled_task(self, interaction: ModalInteraction) -> None:
+        try:
+            await self.callback(interaction)
+        except Exception as e:
+            await self.on_error(e, interaction)
+        else:
+            interaction._state._modal_store.remove_modal(
+                interaction.author.id, interaction.custom_id
+            )
+
+    def dispatch(self, interaction: ModalInteraction) -> None:
+        asyncio.create_task(
+            self._scheduled_task(interaction), name=f"disnake-ui-modal-dispatch-{self.custom_id}"
+        )
+
+
+class ModalStore:
+    def __init__(self, state: ConnectionState) -> None:
+        self._state = state
+        # (user_id, Modal.custom_id): Modal
+        self._modals: Dict[Tuple[int, str], Modal] = {}
+
+    def add_modal(self, user_id: int, modal: Modal) -> None:
+        loop = asyncio.get_event_loop()
+        self._modals[(user_id, modal.custom_id)] = modal
+        loop.create_task(self.handle_timeout(user_id, modal.custom_id))
+
+    def remove_modal(self, user_id: int, modal_custom_id: str) -> None:
+        self._modals.pop((user_id, modal_custom_id))
+
+    async def handle_timeout(self, user_id: int, modal_custom_id: str) -> None:
+        # Waits 10 minutes and then removes the modal from cache, this is done just in case the user closed the modal,
+        # as there isn't an event for that.
+
+        # TODO: on_modal_timeout event?
+        await asyncio.sleep(600)
+        try:
+            self.remove_modal(user_id, modal_custom_id)
+        except KeyError:
+            # The modal has already been removed.
+            pass
+
+    def dispatch(self, interaction: ModalInteraction) -> None:
+        key = (interaction.author.id, interaction.custom_id)
+        modal = self._modals.get(key)
+        if modal is not None:
+            modal.dispatch(interaction)


### PR DESCRIPTION
## Summary

Bored of using `wait_for("message")` to get user input? I present you **Modals**, a new way to asking for user input, along with ``InputText``, a component to write text (These can only be used in modals).

<details><summary>Examples</summary>

```py
from disnake.ui.input_text import InputText
from typing import List

# High-level implementation.

class Tag(disnake.ui.Modal):
    def __init__(self) -> None:

        components: List[InputText] = [
            disnake.ui.InputText(
                style=disnake.InputTextStyle.short,
                label="Name",
                placeholder="The name of the tag.",
                custom_id="name",
                max_length=50,
            ),
            disnake.ui.InputText(
                style=disnake.InputTextStyle.long,
                label="Content",
                placeholder="The content of the tag.",
                custom_id="content",
            ),
        ]

        super().__init__(title="Tag creation", custom_id="tag_creation", components=components)

    async def callback(self, inter: disnake.ModalInteraction) -> None:
        embed = disnake.Embed(title="Tag Creation")
        for key, value in inter.values.items():
            embed.add_field(name=key.capitalize(), value=value, inline=False)
        await inter.response.send_message(embed=embed)

    async def on_error(self, error: Exception, inter: disnake.ModalInteraction) -> None:
        await inter.response.send_message("Oops, something went wrong.", ephemeral=True)

@bot.slash_command()
async def create_tag(inter: disnake.AppCmdInter) -> None:
    await inter.response.send_modal(Tag())


# Same example but with low-level implementation.

@bot.slash_command()
async def create_tag_low(inter: disnake.AppCmdInter) -> None:
    await inter.response.send_modal(
        title="Tag creation",
        custom_id="tag_creation",
        components=[
            disnake.ui.InputText(
                style=disnake.InputTextStyle.short,
                label="Name",
                placeholder="The name of the tag.",
                custom_id="name",
                max_length=50,
            ),
            disnake.ui.InputText(
                style=disnake.InputTextStyle.long,
                label="Content",
                placeholder="The content of the tag.",
                custom_id="content",
            ),
        ],
    )
    modal_inter: disnake.ModalInteraction = await bot.wait_for(
        "modal_submit",
        check=lambda i: i.author == inter.author and i.custom_id == "tag_creation",
    )
    embed = disnake.Embed(title="Tag Creation")
    for key, value in modal_inter.values.items():
        embed.add_field(name=key.capitalize(), value=value, inline=False)
    await modal_inter.response.send_message(embed=embed)
```
</details>

### TODO list

 - [x] Add modals.
 - [x] Add input text.
 - [x] Add `ModalInteraction`.
 - [x] Add `InteractionRespone.send_modal`
 - [ ] New `ModalInteractionResponded` error?
 - [ ] `on_modal_timeout` event? (This is not dispatched by Discord)
 - [ ] Add documentation.

At the moment only `InputText` is supported in modals, with a maximum of 5 action rows; 1 component per row.

And to finish I want to thanks zhu for helping me to test this when we didn't have access to the modals beta.

<sup>Closes #212</sup>

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
