### PR TITLE
Fixed a rare command sync bug

### DIFF
--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -686,11 +686,7 @@ class InteractionBotBase(CommonBotBase):
         diff = _app_commands_diff(
             global_cmds, self._connection._global_application_commands.values()
         )
-        update_required = (
-            bool(diff["upsert"])
-            or bool(diff["edit"])
-            or bool(diff["delete"])
-        )
+        update_required = bool(diff["upsert"]) or bool(diff["edit"]) or bool(diff["delete"])
 
         # Show the difference
         self._log_sync_debug(
@@ -715,11 +711,7 @@ class InteractionBotBase(CommonBotBase):
         for guild_id, cmds in guild_cmds.items():
             current_guild_cmds = self._connection._guild_application_commands.get(guild_id, {})
             diff = _app_commands_diff(cmds, current_guild_cmds.values())
-            update_required = (
-                bool(diff["upsert"])
-                or bool(diff["edit"])
-                or bool(diff["delete"])
-            )
+            update_required = bool(diff["upsert"]) or bool(diff["edit"]) or bool(diff["delete"])
             # Show diff
             self._log_sync_debug(
                 "Application command synchronization:\n"

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -99,8 +99,8 @@ def _app_commands_diff(
     new_commands: Iterable[ApplicationCommand],
     old_commands: Iterable[ApplicationCommand],
 ) -> Dict[str, List[ApplicationCommand]]:
-    new_cmds = {cmd.name: cmd for cmd in new_commands}
-    old_cmds = {cmd.name: cmd for cmd in old_commands}
+    new_cmds = {(cmd.name, cmd.type): cmd for cmd in new_commands}
+    old_cmds = {(cmd.name, cmd.type): cmd for cmd in old_commands}
 
     diff = {
         "no_changes": [],
@@ -110,8 +110,8 @@ def _app_commands_diff(
         "change_type": [],
     }
 
-    for name, new_cmd in new_cmds.items():
-        old_cmd = old_cmds.get(name)
+    for name_and_type, new_cmd in new_cmds.items():
+        old_cmd = old_cmds.get(name_and_type)
         if old_cmd is None:
             diff["upsert"].append(new_cmd)
         elif old_cmd.type != new_cmd.type:
@@ -124,8 +124,8 @@ def _app_commands_diff(
         else:
             diff["no_changes"].append(new_cmd)
 
-    for name, old_cmd in old_cmds.items():
-        if name not in new_cmds:
+    for name_and_type, old_cmd in old_cmds.items():
+        if name_and_type not in new_cmds:
             diff["delete"].append(old_cmd)
 
     return diff


### PR DESCRIPTION
It was impossible to register commands of different types with the same name. The reason was one of the internal functions that compares old and new commands. It mapped them like `{name: cmd}` instead of `{(name, type): cmd}`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
