### PR TITLE
Implement `LargeInt` in slash commands.

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -38,7 +38,6 @@ from typing import (
     Dict,
     List,
     Literal,
-    NewType,
     Optional,
     Tuple,
     Type,

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -72,7 +72,6 @@ if TYPE_CHECKING:
 
     TChoice = TypeVar("TChoice", bound=ApplicationCommandOptionChoiceValue)
 
-
 if sys.version_info >= (3, 10):
     from types import UnionType
 else:

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -71,13 +71,6 @@ if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
     TChoice = TypeVar("TChoice", bound=ApplicationCommandOptionChoiceValue)
-    LargeInt = int
-else:
-
-    class LargeInt(type):
-        """Type for large integers."""
-
-        pass
 
 
 if sys.version_info >= (3, 10):
@@ -266,6 +259,12 @@ class Range(type, metaclass=RangeMeta):
         a = "..." if self.min_value is None else self.min_value
         b = "..." if self.max_value is None else self.max_value
         return f"{type(self).__name__}[{a}, {b}]"
+
+
+class LargeInt(int):
+    """Type for large integers"""
+
+    pass
 
 
 class ParamInfo:

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -262,9 +262,7 @@ class Range(type, metaclass=RangeMeta):
 
 
 class LargeInt(int):
-    """Type for large integers"""
-
-    pass
+    """Type for large integers in slash commands."""
 
 
 class ParamInfo:

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -38,6 +38,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    NewType,
     Optional,
     Tuple,
     Type,
@@ -71,6 +72,14 @@ if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
     TChoice = TypeVar("TChoice", bound=ApplicationCommandOptionChoiceValue)
+    LargeInt = int
+else:
+
+    class LargeInt(type):
+        """Type for large integers."""
+
+        pass
+
 
 if sys.version_info >= (3, 10):
     from types import UnionType
@@ -83,6 +92,7 @@ CallableT = TypeVar("CallableT", bound=Callable[..., Any])
 
 __all__ = (
     "Range",
+    "LargeInt",
     "ParamInfo",
     "Param",
     "param",
@@ -475,11 +485,14 @@ class ParamInfo:
             self.min_value = annotation.min_value
             self.max_value = annotation.max_value
             annotation = annotation.underlying_type
+        if issubclass(annotation, LargeInt):
+            self.large = True
+            annotation = int
 
         if self.large:
             self.type = str
             if annotation is not int:
-                raise TypeError("Large integers must be annotated with int")
+                raise TypeError("Large integers must be annotated with int or LargeInt")
         elif annotation in self.TYPES:
             self.type = annotation
         elif (

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -503,7 +503,7 @@ GroupMixin
 LargeInt
 ~~~~~~~~
 
-This is a type alias of :class:`int` to allow large numbers in slash commands, meant to be used only for annotations.
+This is a class which inherits from :class:`int` to allow large numbers in slash commands, meant to be used only for annotations.
 
 .. _ext_commands_api_cogs:
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -500,6 +500,11 @@ GroupMixin
     .. automethod:: GroupMixin.group(*args, **kwargs)
         :decorator:
 
+LargeInt
+~~~~~~~~
+
+This is a type alias of :class:`int` to allow large numbers in slash commands, meant to be used only for annotations.
+
 .. _ext_commands_api_cogs:
 
 Cogs

--- a/examples/slash_commands/param.py
+++ b/examples/slash_commands/param.py
@@ -85,3 +85,10 @@ async def ranges(
     negative: An integer lower than 0
     fraction: A floating point number between 0 and 1
     """
+
+
+# You can also allow large numbers with commands.LargeInt.
+# Since Discord only allows numbers between -2^53 and 2^53, this allows you to use larger numbers.
+@bot.slash_command()
+async def large(inter: disnake.CommandInteraction, largenumber: commands.LargeInt):
+    ...

--- a/test_bot/cogs/slash_commands.py
+++ b/test_bot/cogs/slash_commands.py
@@ -64,6 +64,10 @@ class SlashCommands(commands.Cog):
         """
         await inter.send(f"{inter.options}")
 
+    @commands.slash_command()
+    async def largenumber(self, inter: disnake.CommandInteraction, largenum: commands.LargeInt):
+        await inter.send(f"Is int: {isinstance(largenum, int)}")
+
 
 def setup(bot):
     bot.add_cog(SlashCommands(bot))


### PR DESCRIPTION
## Summary

Use  `x: LargeInt` instead of `x: int = Param(large=True)`

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
