### PR TITLE
Add missing support for reason in `http.py`.

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2503,7 +2503,7 @@ class Guild(Hashable):
 
         payload["tags"] = emoji
 
-        data = await self._state.http.create_guild_sticker(self.id, payload, file, reason)
+        data = await self._state.http.create_guild_sticker(self.id, payload, file, reason=reason)
         return self._state.store_sticker(self, data)
 
     async def delete_sticker(self, sticker: Snowflake, *, reason: Optional[str] = None) -> None:
@@ -2530,7 +2530,7 @@ class Guild(Hashable):
         HTTPException
             An error occurred deleting the sticker.
         """
-        await self._state.http.delete_guild_sticker(self.id, sticker.id, reason)
+        await self._state.http.delete_guild_sticker(self.id, sticker.id, reason=reason)
 
     async def fetch_emojis(self) -> List[Emoji]:
         r"""|coro|

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3158,7 +3158,11 @@ class Guild(Hashable):
         return Widget(state=self._state, data=data)
 
     async def edit_widget(
-        self, *, enabled: bool = MISSING, channel: Optional[Snowflake] = MISSING
+        self,
+        *,
+        enabled: bool = MISSING,
+        channel: Optional[Snowflake] = MISSING,
+        reason: Optional[str] = None,
     ) -> None:
         """|coro|
 
@@ -3175,6 +3179,10 @@ class Guild(Hashable):
             Whether to enable the widget for the guild.
         channel: Optional[:class:`~disnake.abc.Snowflake`]
             The new widget channel. ``None`` removes the widget channel.
+        reason: Optional[:class:`str`]
+            The reason for editing the widget. Shows up on the audit log.
+
+            .. versionadded:: 2.4
 
         Raises
         -------
@@ -3189,7 +3197,7 @@ class Guild(Hashable):
         if enabled is not MISSING:
             payload["enabled"] = enabled
 
-        await self._state.http.edit_widget(self.id, payload=payload)
+        await self._state.http.edit_widget(self.id, payload=payload, reason=reason)
 
     async def chunk(self, *, cache: bool = True) -> None:
         """|coro|

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -451,6 +451,8 @@ class HTTPClient:
         max_age: int,
         max_uses: int,
         target_application_id: Snowflake,
+        *,
+        reason: Optional[str] = None,
     ):
         payload = {
             "max_age": max_age,
@@ -461,7 +463,9 @@ class HTTPClient:
             "validate": None,
         }
         return self.request(
-            Route("POST", "/channels/{channel_id}/invites", channel_id=channel_id), json=payload
+            Route("POST", "/channels/{channel_id}/invites", channel_id=channel_id),
+            json=payload,
+            reason=reason,
         )
 
     def logout(self) -> Response[None]:
@@ -813,11 +817,8 @@ class HTTPClient:
         r = Route(
             "DELETE", "/guilds/{guild_id}/members/{user_id}", guild_id=guild_id, user_id=user_id
         )
-        if reason:
-            # thanks aiohttp
-            r.url = f"{r.url}?reason={_uriquote(reason)}"
 
-        return self.request(r)
+        return self.request(r, reason=reason)
 
     def ban(
         self,
@@ -1410,7 +1411,7 @@ class HTTPClient:
         guild_id: Snowflake,
         payload: sticker.CreateGuildSticker,
         file: File,
-        reason: Optional[str],
+        reason: Optional[str] = None,
     ) -> Response[sticker.GuildSticker]:
         initial_bytes = file.fp.read(16)
 
@@ -1453,7 +1454,7 @@ class HTTPClient:
         guild_id: Snowflake,
         sticker_id: Snowflake,
         payload: sticker.EditGuildSticker,
-        reason: Optional[str],
+        reason: Optional[str] = None,
     ) -> Response[sticker.GuildSticker]:
         return self.request(
             Route(
@@ -1467,7 +1468,7 @@ class HTTPClient:
         )
 
     def delete_guild_sticker(
-        self, guild_id: Snowflake, sticker_id: Snowflake, reason: Optional[str]
+        self, guild_id: Snowflake, sticker_id: Snowflake, reason: Optional[str] = None
     ) -> Response[None]:
         return self.request(
             Route(
@@ -1607,9 +1608,13 @@ class HTTPClient:
     def get_widget(self, guild_id: Snowflake) -> Response[widget.Widget]:
         return self.request(Route("GET", "/guilds/{guild_id}/widget.json", guild_id=guild_id))
 
-    def edit_widget(self, guild_id: Snowflake, payload) -> Response[widget.WidgetSettings]:
+    def edit_widget(
+        self, guild_id: Snowflake, payload, *, reason: Optional[str] = None
+    ) -> Response[widget.WidgetSettings]:
         return self.request(
-            Route("PATCH", "/guilds/{guild_id}/widget", guild_id=guild_id), json=payload
+            Route("PATCH", "/guilds/{guild_id}/widget", guild_id=guild_id),
+            json=payload,
+            reason=reason,
         )
 
     # Invite management
@@ -1812,7 +1817,7 @@ class HTTPClient:
         return self.request(Route("GET", "/stage-instances/{channel_id}", channel_id=channel_id))
 
     def create_stage_instance(
-        self, *, reason: Optional[str], **payload: Any
+        self, *, reason: Optional[str] = None, **payload: Any
     ) -> Response[channel.StageInstance]:
         valid_keys = (
             "channel_id",

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1411,6 +1411,7 @@ class HTTPClient:
         guild_id: Snowflake,
         payload: sticker.CreateGuildSticker,
         file: File,
+        *,
         reason: Optional[str] = None,
     ) -> Response[sticker.GuildSticker]:
         initial_bytes = file.fp.read(16)
@@ -1454,6 +1455,7 @@ class HTTPClient:
         guild_id: Snowflake,
         sticker_id: Snowflake,
         payload: sticker.EditGuildSticker,
+        *,
         reason: Optional[str] = None,
     ) -> Response[sticker.GuildSticker]:
         return self.request(
@@ -1468,7 +1470,7 @@ class HTTPClient:
         )
 
     def delete_guild_sticker(
-        self, guild_id: Snowflake, sticker_id: Snowflake, reason: Optional[str] = None
+        self, guild_id: Snowflake, sticker_id: Snowflake, *, reason: Optional[str] = None
     ) -> Response[None]:
         return self.request(
             Route(

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -493,7 +493,7 @@ class GuildSticker(Sticker):
             payload["tags"] = emoji
 
         data: GuildStickerPayload = await self._state.http.modify_guild_sticker(
-            self.guild_id, self.id, payload, reason
+            self.guild_id, self.id, payload, reason=reason
         )
         return GuildSticker(state=self._state, data=data)
 
@@ -517,7 +517,7 @@ class GuildSticker(Sticker):
         HTTPException
             An error occurred deleting the sticker.
         """
-        await self._state.http.delete_guild_sticker(self.guild_id, self.id, reason)
+        await self._state.http.delete_guild_sticker(self.guild_id, self.id, reason=reason)
 
 
 def _sticker_factory(

--- a/disnake/types/template.py
+++ b/disnake/types/template.py
@@ -34,7 +34,7 @@ from .user import User
 
 class CreateTemplate(TypedDict):
     name: str
-    icon: Optional[bytes]
+    description: Optional[str]
 
 
 class Template(TypedDict):


### PR DESCRIPTION
## Summary

Went through all the endpoints which support reason and added the missing ones (well, only one heh).

#### Check List
1. Add support for reason in `edit_widget` (`PATCH /guilds/{guild_id}/widget`) and updated `Guild.edit_widget`.
2. Added `Widget.edit`, probably unnecessary.
3. Changed `CreateTemplate` type as the old one was pointing to a different [endpoint](https://discord.com/developers/docs/resources/guild-template#create-guild-from-guild-template).
4. Add support for reason in `create_party`, which is unused by the library.
5. `reason` is now a kwarg in create/edit/delete sticker endpoints.

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
      - _Kind of, since `CreateTemplate` type was changed, but I doubt it's used._
      - `reason` is now a kwarg in create/edit/delete sticker endpoints.
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
