### PR TITLE
Improve validation of slash command/option names

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -90,6 +90,17 @@ def application_command_factory(data: ApplicationCommandPayload) -> ApplicationC
     raise TypeError(f"Application command of type {cmd_type} is not valid")
 
 
+def _validate_name(name: str) -> None:
+    # used for slash command names and option names
+    # see https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-naming
+
+    assert name == name.lower() and re.fullmatch(r"[\w-]{1,32}", name), (
+        f"Slash command or option name '{name}' should be lowercase, "
+        "between 1 and 32 characters long, and only consist of "
+        "these symbols: a-z, 0-9, -, _, and other languages'/scripts' symbols"
+    )
+
+
 class OptionChoice:
     """
     Represents an option choice.
@@ -177,6 +188,7 @@ class Option:
         max_value: float = None,
     ):
         self.name: str = name.lower()
+        _validate_name(self.name)
         self.description: str = description or "\u200b"
         self.type: OptionType = enum_if_int(OptionType, type) or OptionType.string
         self.required: bool = required
@@ -449,9 +461,7 @@ class SlashCommand(ApplicationCommand):
         default_permission: bool = True,
     ):
         name = name.lower()
-        assert re.fullmatch(
-            r"[\w-]{1,32}", name
-        ), f"Slash command name {name!r} should consist of these symbols: a-z, 0-9, -, _"
+        _validate_name(name)
 
         super().__init__(
             type=ApplicationCommandType.chat_input,


### PR DESCRIPTION
## Summary

This PR improves the error message for invalid command names, and adds validation for option names.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
