### PR TITLE
Add mypy plugin for `commands.Range` annotations

### DIFF
--- a/disnake/ext/mypy_plugin.py
+++ b/disnake/ext/mypy_plugin.py
@@ -24,7 +24,6 @@ def range_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
         if isinstance(arg, EllipsisType):
             continue
         if not isinstance(arg, RawExpressionType):
-            # not sure when/how/if this actually happens, but handled just in case
             ctx.api.fail('invalid usage of "Range"', ctx.context)
             return AnyType(TypeOfAny.from_error)
 

--- a/disnake/mypy_plugin.py
+++ b/disnake/mypy_plugin.py
@@ -1,0 +1,44 @@
+import typing as t
+
+from mypy.plugin import AnalyzeTypeContext, Plugin
+from mypy.types import AnyType, EllipsisType, RawExpressionType, Type, TypeOfAny
+
+
+class DisnakePlugin(Plugin):
+    def get_type_analyze_hook(
+        self, fullname: str
+    ) -> t.Optional[t.Callable[[AnalyzeTypeContext], Type]]:
+        if fullname == "disnake.ext.commands.params.Range":
+            return range_type_analyze_callback
+        return None
+
+
+def range_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
+    args = ctx.type.args
+
+    if len(args) != 2:
+        ctx.api.fail(f'"Range" expected 2 parameters, got {len(args)}', ctx.context)
+        return AnyType(TypeOfAny.from_error)
+
+    for arg in args:
+        if isinstance(arg, EllipsisType):
+            continue
+        if not isinstance(arg, RawExpressionType):
+            # not sure when/how/if this actually happens, but handled just in case
+            ctx.api.fail('invalid usage of "Range"', ctx.context)
+            return AnyType(TypeOfAny.from_error)
+
+        name = arg.simple_name()
+        # if one is a float, `Range.underlying_type` returns `float`
+        if name == "float":
+            return ctx.api.named_type("builtins.float", [])
+        # otherwise it should be an int; fail if it isn't
+        elif name != "int":
+            ctx.api.fail(f'"Range" parameters must be int or float, not {name}', ctx.context)
+            return AnyType(TypeOfAny.from_error)
+
+    return ctx.api.named_type("builtins.int", [])
+
+
+def plugin(version: str) -> t.Type[Plugin]:
+    return DisnakePlugin

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -164,18 +164,18 @@ For instance, you could restrict an option to only accept positive integers:
 
 
 Instead of using :func:`Param <ext.commands.Param>`, you can also use a :class:`Range` annotation.
-The range bounds are both inclusive; the type of the option is determined by the range bounds,
-with the option being a :class:`float` if at least one of the bounds is a :class:`float`, and :class:`int` otherwise.
+The range bounds are both inclusive; using ``...`` as a bound indicates that this end of the range is unbounded.
+The type of the option is determined by the range bounds, with the option being a
+:class:`float` if at least one of the bounds is a :class:`float`, and :class:`int` otherwise.
 
 .. code-block:: python3
 
     @bot.slash_command()
     async def ranges(
         inter: disnake.ApplicationCommandInteraction,
-        a: int = commands.Param(lt=0),  # negative int
-        b: commands.Range[1, ...],      # positive int
-        c: commands.Range[0, 10],       # 0 - 10 int
-        d: commands.Range[0, 10.0],     # 0 - 10 float
+        a: commands.Range[0, 10],       # 0 - 10 int
+        b: commands.Range[0, 10.0],     # 0 - 10 float
+        c: commands.Range[1, ...],      # positive int
     ):
         ...
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -146,6 +146,58 @@ All the other types may be converted implicitly, similarly to :ref:`ext_commands
   \*\* Role and Member may be used together to create a "mentionable" (:class:`Union[Role, Member]`)
 
 
+Number Ranges
++++++++++++++
+
+:class:`int` and :class:`float` parameters support minimum and maximum allowed
+values using the ``lt``, ``le``, ``gt``, ``ge`` parameters on :func:`Param <ext.commands.Param>`.
+For instance, you could restrict an option to only accept positive integers:
+
+.. code-block:: python3
+
+    @bot.slash_command()
+    async def command(
+        inter: disnake.ApplicationCommandInteraction,
+        amount: int = commands.Param(gt=0),
+    ):
+        ...
+
+
+Instead of using :func:`Param <ext.commands.Param>`, you can also use a :class:`Range` annotation.
+The range bounds are both inclusive; the type of the option is determined by the range bounds,
+with the option being a :class:`float` if at least one of the bounds is a :class:`float`, and :class:`int` otherwise.
+
+.. code-block:: python3
+
+    @bot.slash_command()
+    async def ranges(
+        inter: disnake.ApplicationCommandInteraction,
+        a: int = commands.Param(lt=0),  # negative int
+        b: commands.Range[1, ...],      # positive int
+        c: commands.Range[0, 10],       # 0 - 10 int
+        d: commands.Range[0, 10.0],     # 0 - 10 float
+    ):
+        ...
+
+.. note::
+
+    Type-checker support for :class:`Range` is limited. Pylance/Pyright seem to handle it correctly;
+    MyPy currently needs a plugin for it to understand :class:`Range` semantics, which can be added in
+    the configuration file (``setup.cfg``, ``mypy.ini``):
+
+    .. code-block:: ini
+
+        [mypy]
+        plugins = disnake.mypy_plugin
+
+    For ``pyproject.toml`` configs, use this instead:
+
+    .. code-block:: toml
+
+        [tool.mypy]
+        plugins = "disnake.mypy_plugin"
+
+
 Docstrings
 ----------
 
@@ -202,9 +254,9 @@ Parameter Descriptors
 +++++++++++++++++++++
 
 Python has no truly *clean* way to provide metadata for parameters, so disnake uses the same approach as fastapi using
-parameter defaults. At the current time there's only :class:`Param`.
+parameter defaults. At the current time there's only :class:`Param <ext.commands.Param>`.
 
-With this you may set the name, description, custom converters and :ref:`autocompleters`.
+With this you may set the name, description, custom converters, :ref:`autocompleters`, and more.
 
 .. code-block:: python3
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -181,21 +181,21 @@ with the option being a :class:`float` if at least one of the bounds is a :class
 
 .. note::
 
-    Type-checker support for :class:`Range` is limited. Pylance/Pyright seem to handle it correctly;
+    Type checker support for :class:`Range` is limited. Pylance/Pyright seem to handle it correctly;
     MyPy currently needs a plugin for it to understand :class:`Range` semantics, which can be added in
     the configuration file (``setup.cfg``, ``mypy.ini``):
 
     .. code-block:: ini
 
         [mypy]
-        plugins = disnake.mypy_plugin
+        plugins = disnake.ext.mypy_plugin
 
     For ``pyproject.toml`` configs, use this instead:
 
     .. code-block:: toml
 
         [tool.mypy]
-        plugins = "disnake.mypy_plugin"
+        plugins = "disnake.ext.mypy_plugin"
 
 
 Docstrings


### PR DESCRIPTION
## Summary

This PR adds documentation for `ext.commands.Range`, as well as a mypy plugin which fixes `Range` annotations.
Apparently mypy doesn't understand/handle custom `__getitem__` in metaclasses or `__class_getitem__` outside of generics, which resulted in several type-checking issues (e.g. `"Range" expects no type arguments, but 2 given`). The plugin helps mypy infer the resulting type correctly.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
