### PR TITLE
Minor refactor of interaction types

### DIFF
--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -1260,7 +1260,6 @@ class InteractionBotBase(CommonBotBase):
         if slash_command is None:
             return
 
-        inter.bot = self  # type: ignore
         inter.application_command = slash_command
         if slash_command.guild_ids is None or inter.guild_id in slash_command.guild_ids:
             await slash_command._call_relevant_autocompleter(inter)
@@ -1309,7 +1308,6 @@ class InteractionBotBase(CommonBotBase):
                     pass
                 return
 
-        interaction.bot = self  # type: ignore
         command_type = interaction.data.type
         command_name = interaction.data.name
         app_command = None

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
         TextChannel,
         VoiceChannel,
     )
-    from ..ext.commands import AutoShardedBot, Bot, InvokableApplicationCommand
+    from ..ext.commands import InvokableApplicationCommand
     from ..state import ConnectionState
     from ..threads import Thread
     from ..types.interactions import (
@@ -71,8 +71,6 @@ if TYPE_CHECKING:
         ApplicationCommandInteractionData as ApplicationCommandInteractionDataPayload,
         ApplicationCommandInteractionDataResolved as ApplicationCommandInteractionDataResolvedPayload,
     )
-
-    BotBase = Union[Bot, AutoShardedBot]
 
     InteractionChannel = Union[
         VoiceChannel,
@@ -110,8 +108,6 @@ class ApplicationCommandInteraction(Interaction):
         The guild ID the interaction was sent from.
     channel_id: :class:`int`
         The channel ID the interaction was sent from.
-    bot: Optional[:class:`.Bot`]
-        The interaction's bot. There is an alias for this named ``client``.
     author: Union[:class:`User`, :class:`Member`]
         The user or member that sent the interaction.
     locale: :class:`str`
@@ -134,9 +130,9 @@ class ApplicationCommandInteraction(Interaction):
         Returns the follow up webhook for follow up interactions.
     data: :class:`ApplicationCommandInteractionData`
         The wrapped interaction data.
+    client: :class:`Client`
+        The interaction client.
     """
-
-    bot: BotBase
 
     def __init__(self, *, data: ApplicationCommandInteractionPayload, state: ConnectionState):
         super().__init__(data=data, state=state)

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -102,30 +102,28 @@ class ApplicationCommandInteraction(Interaction):
         The interaction's ID.
     type: :class:`InteractionType`
         The interaction type.
-    guild_id: Optional[:class:`int`]
-        The guild ID the interaction was sent from.
-    channel_id: Optional[:class:`int`]
-        The channel ID the interaction was sent from.
     application_id: :class:`int`
         The application ID that the interaction was for.
+    token: :class:`str`
+        The token to continue the interaction. These are valid for 15 minutes.
+    guild_id: Optional[:class:`int`]
+        The guild ID the interaction was sent from.
+    channel_id: :class:`int`
+        The channel ID the interaction was sent from.
     bot: Optional[:class:`.Bot`]
         The interaction's bot. There is an alias for this named ``client``.
-    author: Optional[Union[:class:`User`, :class:`Member`]]
+    author: Union[:class:`User`, :class:`Member`]
         The user or member that sent the interaction.
     locale: :class:`str`
         The selected language of the interaction's author.
 
         .. versionadded:: 2.4
-    guild: Optional[:class:`Guild`]
-        The guild the interaction was sent from.
     guild_locale: Optional[:class:`str`]
         The selected language of the interaction's guild.
         This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
         If the interaction was in a DM, then this value is ``None``.
 
         .. versionadded:: 2.4
-    channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]
-        The channel the interaction was sent from.
     me: Union[:class:`.Member`, :class:`.ClientUser`]
         Similar to :attr:`.Guild.me`
     permissions: :class:`Permissions`
@@ -134,9 +132,6 @@ class ApplicationCommandInteraction(Interaction):
         Returns an object responsible for handling responding to the interaction.
     followup: :class:`Webhook`
         Returns the follow up webhook for follow up interactions.
-    token: :class:`str`
-        The token to continue the interaction. These are valid
-        for 15 minutes.
     data: :class:`ApplicationCommandInteractionData`
         The wrapped interaction data.
     """

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -110,6 +110,10 @@ class Interaction:
         The interaction's ID.
     type: :class:`InteractionType`
         The interaction type.
+    application_id: :class:`int`
+        The application ID that the interaction was for.
+    token: :class:`str`
+        The token to continue the interaction. These are valid for 15 minutes.
     guild_id: Optional[:class:`int`]
         The guild ID the interaction was sent from.
     guild_locale: Optional[:class:`str`]
@@ -118,19 +122,14 @@ class Interaction:
         If the interaction was in a DM, then this value is ``None``.
 
         .. versionadded:: 2.4
-    channel_id: Optional[:class:`int`]
+    channel_id: :class:`int`
         The channel ID the interaction was sent from.
-    application_id: :class:`int`
-        The application ID that the interaction was for.
-    author: Optional[Union[:class:`User`, :class:`Member`]]
+    author: Union[:class:`User`, :class:`Member`]
         The user or member that sent the interaction.
     locale: :class:`str`
         The selected language of the interaction's author.
 
         .. versionadded:: 2.4
-    token: :class:`str`
-        The token to continue the interaction. These are valid
-        for 15 minutes.
     """
 
     __slots__: Tuple[str, ...] = (

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -165,9 +165,7 @@ class Interaction:
         self._session: ClientSession = state.http._HTTPClient__session  # type: ignore
         self.client: Client = state._get_client()
         self._original_message: Optional[InteractionMessage] = None
-        self._from_data(data)
 
-    def _from_data(self, data: InteractionPayload):
         self.id: int = int(data["id"])
         self.type: InteractionType = try_enum(InteractionType, data["type"])
         self.token: str = data["token"]

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -33,9 +33,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Uni
 from .. import utils
 from ..app_commands import OptionChoice
 from ..channel import ChannelType, PartialMessageable
-from ..enums import InteractionResponseType, InteractionType, try_enum
+from ..enums import InteractionResponseType, InteractionType, WebhookType, try_enum
 from ..errors import (
-    ClientException,
     HTTPException,
     InteractionNotResponded,
     InteractionResponded,
@@ -98,10 +97,10 @@ MISSING: Any = utils.MISSING
 
 
 class Interaction:
-    """A base class representing a Discord interaction.
+    """A base class representing a user-initiated Discord interaction.
 
-    An interaction happens when a user does an action that needs to
-    be notified. Current examples are application commands and components.
+    An interaction happens when a user performs an action that the client needs to
+    be notified of. Current examples are application commands and components.
 
     .. versionadded:: 2.0
 
@@ -161,21 +160,22 @@ class Interaction:
         # TODO: Maybe use a unique session
         self._session: ClientSession = state.http._HTTPClient__session  # type: ignore
         self._original_message: Optional[InteractionMessage] = None
-        self._from_data(data)
         self.bot: Optional[Bot] = None
+        self._from_data(data)
 
     def _from_data(self, data: InteractionPayload):
         self.id: int = int(data["id"])
         self.type: InteractionType = try_enum(InteractionType, data["type"])
         self.token: str = data["token"]
         self.version: int = data["version"]
-        self.channel_id: Optional[int] = utils._get_as_snowflake(data, "channel_id")
-        self.guild_id: Optional[int] = utils._get_as_snowflake(data, "guild_id")
         self.application_id: int = int(data["application_id"])
+
+        self.channel_id: int = int(data["channel_id"])
+        self.guild_id: Optional[int] = utils._get_as_snowflake(data, "guild_id")
         self.locale: str = data["locale"]
         self.guild_locale: Optional[str] = data.get("guild_locale")
-        # think about the user's experience
-        self.author: Union[User, Member] = None  # type: ignore
+        # one of user and member will always exist
+        self.author: Union[User, Member] = MISSING
         self._permissions: int = 0
 
         # TODO: there's a potential data loss here
@@ -207,13 +207,13 @@ class Interaction:
         return self.bot
 
     @property
-    def user(self) -> Optional[Union[User, Member]]:
+    def user(self) -> Union[User, Member]:
         return self.author
 
     @property
     def guild(self) -> Optional[Guild]:
         """Optional[:class:`Guild`]: The guild the interaction was sent from."""
-        return self._state and self._state._get_guild(self.guild_id)
+        return self._state._get_guild(self.guild_id)
 
     @utils.cached_slot_property("_cs_me")
     def me(self) -> Union[Member, ClientUser]:
@@ -226,7 +226,7 @@ class Interaction:
 
     @utils.cached_slot_property("_cs_channel")
     def channel(self) -> Union[TextChannel, Thread, VoiceChannel]:
-        """Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]: The channel the interaction was sent from.
+        """Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]: The channel the interaction was sent from.
 
         Note that due to a Discord limitation, DM channels are not resolved since there is
         no data to complete them. These are :class:`PartialMessageable` instead.
@@ -235,12 +235,10 @@ class Interaction:
         guild = self.guild
         channel = guild and guild._resolve_channel(self.channel_id)
         if channel is None:
-            if self.channel_id is not None:
-                type = (
-                    None if self.guild_id is not None else ChannelType.private
-                )  # could be a text, voice, or thread channel in a guild
-                return PartialMessageable(state=self._state, id=self.channel_id, type=type)  # type: ignore
-            return None  # type: ignore
+            type = (
+                None if self.guild_id is not None else ChannelType.private
+            )  # could be a text, voice, or thread channel in a guild
+            return PartialMessageable(state=self._state, id=self.channel_id, type=type)  # type: ignore
         return channel  # type: ignore
 
     @property
@@ -265,7 +263,7 @@ class Interaction:
         """:class:`Webhook`: Returns the follow up webhook for follow up interactions."""
         payload = {
             "id": self.application_id,
-            "type": 3,
+            "type": WebhookType.application.value,
             "token": self.token,
         }
         return Webhook.from_state(data=payload, state=self._state)
@@ -291,8 +289,6 @@ class Interaction:
         -------
         HTTPException
             Fetching the original response message failed.
-        ClientException
-            The channel for the message could not be resolved.
 
         Returns
         --------
@@ -303,11 +299,6 @@ class Interaction:
         if self._original_message is not None:
             return self._original_message
 
-        # TODO: fix later to not raise?
-        channel = self.channel
-        if channel is None:
-            raise ClientException("Channel for message could not be resolved")
-
         adapter = async_context.get()
         data = await adapter.get_original_interaction_response(
             application_id=self.application_id,
@@ -315,7 +306,7 @@ class Interaction:
             session=self._session,
         )
         state = _InteractionMessageState(self, self._state)
-        message = InteractionMessage(state=state, channel=channel, data=data)  # type: ignore
+        message = InteractionMessage(state=state, channel=self.channel, data=data)  # type: ignore
         self._original_message = message
         return message
 

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -88,9 +88,9 @@ class MessageInteraction(Interaction):
         Returns the follow up webhook for follow up interactions.
     data: :class:`MessageInteractionData`
         The wrapped interaction data.
+    client: :class:`Client`
+        The interaction client.
     """
-
-    target: Message
 
     def __init__(self, *, data: MessageInteractionPayload, state: ConnectionState):
         super().__init__(data=data, state=state)

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -54,29 +54,29 @@ class MessageInteraction(Interaction):
     -----------
     id: :class:`int`
         The interaction's ID.
-    guild_id: Optional[:class:`int`]
-        The guild ID the interaction was sent from.
-    channel_id: Optional[:class:`int`]
-        The channel ID the interaction was sent from.
+    type: :class:`InteractionType`
+        The interaction type.
     application_id: :class:`int`
         The application ID that the interaction was for.
-    author: Optional[Union[:class:`User`, :class:`Member`]]
+    token: :class:`str`
+        The token to continue the interaction. These are valid for 15 minutes.
+    guild_id: Optional[:class:`int`]
+        The guild ID the interaction was sent from.
+    channel_id: :class:`int`
+        The channel ID the interaction was sent from.
+    author: Union[:class:`User`, :class:`Member`]
         The user or member that sent the interaction.
     locale: :class:`str`
         The selected language of the interaction's author.
 
         .. versionadded:: 2.4
-    guild: Optional[:class:`Guild`]
-        The guild the interaction was sent from.
     guild_locale: Optional[:class:`str`]
         The selected language of the interaction's guild.
         This value is only meaningful in guilds with ``COMMUNITY`` feature and receives a default value otherwise.
         If the interaction was in a DM, then this value is ``None``.
 
         .. versionadded:: 2.4
-    channel: Optional[Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]]
-        The channel the interaction was sent from.
-    message: Optional[:class:`Message`]
+    message: :class:`Message`
         The message that sent this interaction.
     me: Union[:class:`.Member`, :class:`.ClientUser`]
         Similar to :attr:`.Guild.me`
@@ -86,11 +86,6 @@ class MessageInteraction(Interaction):
         Returns an object responsible for handling responding to the interaction.
     followup: :class:`Webhook`
         Returns the follow up webhook for follow up interactions.
-    type: :class:`InteractionType`
-        The interaction type.
-    token: :class:`str`
-        The token to continue the interaction. These are valid
-        for 15 minutes.
     data: :class:`MessageInteractionData`
         The wrapped interaction data.
     """

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from ..state import ConnectionState
     from ..types.interactions import (
         ComponentInteractionData as ComponentInteractionDataPayload,
-        Interaction as InteractionPayload,
+        MessageInteraction as MessageInteractionPayload,
     )
 
 
@@ -97,10 +97,10 @@ class MessageInteraction(Interaction):
 
     target: Message
 
-    def __init__(self, *, data: InteractionPayload, state: ConnectionState):
+    def __init__(self, *, data: MessageInteractionPayload, state: ConnectionState):
         super().__init__(data=data, state=state)
-        self.data = MessageInteractionData(data=data.get("data", {}))
-        self.message = Message(state=self._state, channel=self.channel, data=data["message"])  # type: ignore
+        self.data = MessageInteractionData(data=data["data"])
+        self.message = Message(state=self._state, channel=self.channel, data=data["message"])
 
     @property
     def values(self) -> Optional[List[str]]:
@@ -141,6 +141,6 @@ class MessageInteractionData:
     __slots__ = ("custom_id", "component_type", "values")
 
     def __init__(self, *, data: ComponentInteractionDataPayload):
-        self.custom_id: str = data.get("custom_id")
-        self.component_type: ComponentType = try_enum(ComponentType, data.get("component_type", 0))
+        self.custom_id: str = data["custom_id"]
+        self.component_type: ComponentType = try_enum(ComponentType, data["component_type"])
         self.values: Optional[List[str]] = data.get("values")

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -74,7 +74,9 @@ if TYPE_CHECKING:
     from .threads import AnyThreadArchiveDuration
     from .types.components import Component as ComponentPayload
     from .types.embed import Embed as EmbedPayload
-    from .types.interactions import MessageInteraction as InteractionReferencePayload
+    from .types.interactions import (
+        InteractionMessageReference as InteractionMessageReferencePayload,
+    )
     from .types.member import Member as MemberPayload, UserWithMember as UserWithMemberPayload
     from .types.message import (
         Attachment as AttachmentPayload,
@@ -650,7 +652,7 @@ class InteractionReference:
 
     __slots__ = ("id", "type", "name", "user", "_state")
 
-    def __init__(self, *, state: ConnectionState, data: InteractionReferencePayload):
+    def __init__(self, *, state: ConnectionState, data: InteractionMessageReferencePayload):
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.type: InteractionType = try_enum(InteractionType, int(data["type"]))

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -63,7 +63,7 @@ from .flags import ApplicationFlags, Intents, MemberCacheFlags
 from .guild import Guild
 from .guild_scheduled_event import GuildScheduledEvent
 from .integrations import _integration_factory
-from .interactions import ApplicationCommandInteraction, Interaction, MessageInteraction
+from .interactions import ApplicationCommandInteraction, MessageInteraction
 from .invite import Invite
 from .member import Member
 from .mentions import AllowedMentions
@@ -885,7 +885,8 @@ class ConnectionState:
 
     def parse_interaction_create(self, data) -> None:
         if data["type"] == 1:
-            interaction = Interaction(data=data, state=self)
+            # PING interaction should never be received
+            return
         elif data["type"] == 2:
             interaction = ApplicationCommandInteraction(data=data, state=self)
             self.dispatch("application_command", interaction)

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -239,7 +239,7 @@ class InteractionResponse(_InteractionResponseOptional):
     type: InteractionResponseType
 
 
-class MessageInteraction(TypedDict):
+class InteractionMessageReference(TypedDict):
     id: Snowflake
     type: InteractionType
     name: str

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -31,7 +31,7 @@ from .channel import ChannelType
 from .components import Component
 from .embed import Embed
 from .emoji import PartialEmoji
-from .interactions import MessageInteraction
+from .interactions import InteractionMessageReference
 from .member import Member, UserWithMember
 from .snowflake import Snowflake, SnowflakeList
 from .sticker import StickerItem
@@ -107,7 +107,7 @@ class _MessageOptional(TypedDict, total=False):
     flags: int
     sticker_items: List[StickerItem]
     referenced_message: Optional[Message]
-    interaction: MessageInteraction
+    interaction: InteractionMessageReference
     components: List[Component]
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4049,6 +4049,7 @@ Interaction
 
 .. autoclass:: Interaction()
     :members:
+    :inherited-members:
 
 ApplicationCommandInteraction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

This PR is a small refactor of interaction types, primarily removing some `# type: ignore`s and improving the types of a few properties.

Changes:
  - Rename `types.MessageInteraction` (a property on messages, represents the interaction that caused it) to `types.InteractionMessageReference`
  - Split `types.Interaction` into `BaseInteraction`, `Interaction`, `ApplicationCommandInteraction`, and `MessageInteraction`; some properties were changed according to the docs (mostly changing some optional -> non-optional)
  - Update interaction parsing according to `types.*Interaction` changes, which allowed removing some `# type: ignore`s. This should hopefully not result in any exceptions (the docs specify `channel_id` as optional, I can't imagine a situation where it would be though, outside of `PING` interactions; other libraries handle it similarly), and it provides stronger guarantees to the user: `channel_id`, `channel`, `user` and `author` are no longer optional
  - Update user/member parsing in `Interaction`; functionality-wise pretty much unchanged, but fewer `try/except`s and `# type: ignore`s
  - Remove handling of `PING` interaction in `parse_interaction_create`
  - Rework `Interaction.bot`/`.client`, no longer optional
    - I considered making `Interaction` (etc.) generic over `TypeVar(..., bound=Client)`, but that would've required changing every annotation that uses `*Interaction`, since type checkers infer `Unknown`/`Any` for those properties for some reason (?), if a generic parameter isn't specified

I recommend viewing the commits one by one, otherwise the diff won't really make sense :^)

part of an ongoing effort to make pyright shut up, more to come

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
  - just typing-related: `*Interaction.client` is no longer annotated as `Bot`, but instead as `Client`
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
