### PR TITLE
feat(GuildScheduledEvent): add support for image

### DIFF
--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -263,7 +263,7 @@ class Asset(AssetMixin):
     def _from_guild_scheduled_event_image(cls, state, event_id: int, image_hash: str) -> Asset:
         return cls(
             state,
-            url=f"{cls.BASE}/guild-events/{event_id}/{image_hash}?size=1536",
+            url=f"{cls.BASE}/guild-events/{event_id}/{image_hash}?size=2048",
             key=image_hash,
             animated=False,
         )

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -263,7 +263,7 @@ class Asset(AssetMixin):
     def _from_guild_scheduled_event_image(cls, state, event_id: int, image_hash: str) -> Asset:
         return cls(
             state,
-            url=f"{cls.BASE}/guild-events/{event_id}/{image_hash}?size=2048",
+            url=f"{cls.BASE}/guild-events/{event_id}/{image_hash}.png?size=2048",
             key=image_hash,
             animated=False,
         )

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -259,6 +259,15 @@ class Asset(AssetMixin):
             animated=animated,
         )
 
+    @classmethod
+    def _from_guild_scheduled_event_image(cls, state, event_id: int, image_hash: str) -> Asset:
+        return cls(
+            state,
+            url=f"{cls.BASE}/guild-events/{event_id}/{image_hash}?size=1536",
+            key=image_hash,
+            animated=False,
+        )
+
     def __str__(self) -> str:
         return self._url
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1863,7 +1863,7 @@ class Guild(Hashable):
         description: :class:`str`
             The description of the guild scheduled event.
         image: :class:`bytes`
-            The image of the guild scheduled event.
+            The cover image of the guild scheduled event.
 
             .. versionadded:: 2.4
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1843,10 +1843,11 @@ class Guild(Hashable):
         scheduled_start_time: datetime.datetime,
         entity_type: GuildScheduledEventEntityType,
         privacy_level: GuildScheduledEventPrivacyLevel = MISSING,
-        channel_id: Snowflake = MISSING,
+        channel_id: int = MISSING,
         entity_metadata: GuildScheduledEventMetadata = MISSING,
         scheduled_end_time: datetime.datetime = MISSING,
         description: str = MISSING,
+        image: bytes = MISSING,
         reason: Optional[str] = None,
     ) -> GuildScheduledEvent:
         """|coro|
@@ -1861,6 +1862,11 @@ class Guild(Hashable):
             The name of the guild scheduled event.
         description: :class:`str`
             The description of the guild scheduled event.
+        image: :class:`bytes`
+            The image of the guild scheduled event.
+
+            .. versionadded:: 2.4
+
         channel_id: :class:`int`
             The channel ID in which the guild scheduled event will be hosted.
         privacy_level: :class:`GuildScheduledEventPrivacyLevel`
@@ -1911,6 +1917,9 @@ class Guild(Hashable):
 
         if description is not MISSING:
             fields["description"] = description
+
+        if image is not MISSING:
+            fields["image"] = utils._bytes_to_base64_data(image)
 
         if channel_id is not MISSING:
             fields["channel_id"] = channel_id

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -245,7 +245,7 @@ class GuildScheduledEvent(Hashable):
 
     @property
     def image(self) -> Optional[Asset]:
-        """Optional[:class:`Asset`]: The image associated with the guild scheduled event, if any."""
+        """Optional[:class:`Asset`]: The cover image asset of the guild scheduled event, if available."""
         if self._image is None:
             return None
         return Asset._from_guild_scheduled_event_image(self._state, self.id, self._image)
@@ -298,7 +298,7 @@ class GuildScheduledEvent(Hashable):
         description: :class:`str`
             The description of the guild scheduled event.
         image: Optional[:class:`bytes`]
-            The image of the guild scheduled event. Set to ``None`` to remove the image.
+            The cover image of the guild scheduled event. Set to ``None`` to remove the image.
 
             .. versionadded:: 2.4
 

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -250,7 +250,7 @@ class GuildScheduledEvent(Hashable):
             return None
         return Asset._from_guild_scheduled_event_image(self._state, self.id, self._image)
 
-    async def delete(self):
+    async def delete(self) -> None:
         """|coro|
 
         Deletes the guild scheduled event.

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1876,6 +1876,7 @@ class HTTPClient:
         entity_metadata: Optional[Dict[str, Any]] = None,
         scheduled_end_time: Optional[str] = None,
         description: Optional[str] = None,
+        image: Optional[str] = None,
         reason: Optional[str] = None,
     ) -> Response[guild_scheduled_event.GuildScheduledEvent]:
         r = Route("POST", "/guilds/{guild_id}/scheduled-events", guild_id=guild_id)
@@ -1897,6 +1898,9 @@ class HTTPClient:
 
         if description is not None:
             payload["description"] = description
+
+        if image is not None:
+            payload["image"] = image
 
         return self.request(r, json=payload, reason=reason)
 

--- a/disnake/types/guild_scheduled_event.py
+++ b/disnake/types/guild_scheduled_event.py
@@ -65,3 +65,4 @@ class GuildScheduledEvent(_GuildScheduledEventOptional):
     entity_type: GuildScheduledEventEntityType
     entity_id: Optional[Snowflake]
     entity_metadata: Optional[GuildScheduledEventEntityMetadata]
+    image: Optional[str]

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -79,7 +79,8 @@ if TYPE_CHECKING:
     from ..state import ConnectionState
     from ..types.message import Message as MessagePayload
     from ..types.webhook import Webhook as WebhookPayload
-    from ..ui import Components, View
+    from ..ui.action_row import Components
+    from ..ui.view import View
 
 MISSING = utils.MISSING
 

--- a/test_bot/cogs/guild_scheduled_events.py
+++ b/test_bot/cogs/guild_scheduled_events.py
@@ -1,0 +1,48 @@
+from datetime import timedelta
+
+import disnake
+from disnake.enums import GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel
+from disnake.ext import commands
+
+
+class GuildScheduledEvents(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.slash_command()
+    async def fetch_event(self, inter: disnake.GuildCommandInteraction, id: commands.LargeInt):
+        gse = await inter.guild.fetch_scheduled_event(id)
+        await inter.response.send_message(str(gse.image))
+
+    @commands.slash_command()
+    async def edit_event(
+        self, inter: disnake.GuildCommandInteraction, id: commands.LargeInt, new_image: bool
+    ):
+        await inter.response.defer()
+        gse = await inter.guild.fetch_scheduled_event(id)
+        image = disnake.File("./assets/banner.png")
+        if new_image:
+            gse2 = await gse.edit(image=image.fp.read())
+        else:
+            gse2 = await gse.edit(image=None)
+        await inter.edit_original_message(content=str(gse2.image))
+
+    @commands.slash_command()
+    async def create_event(
+        self, inter: disnake.GuildCommandInteraction, name: str, channel: disnake.VoiceChannel
+    ):
+        image = disnake.File("./assets/banner.png")
+        gse = await inter.guild.create_scheduled_event(
+            name=name,
+            privacy_level=GuildScheduledEventPrivacyLevel.guild_only,
+            scheduled_start_time=disnake.utils.utcnow() + timedelta(days=1),
+            entity_type=GuildScheduledEventEntityType.voice,
+            channel_id=channel.id,
+            image=image.fp.read(),
+        )
+        await inter.response.send_message(str(gse.image))
+
+
+def setup(bot: commands.Bot):
+    bot.add_cog(GuildScheduledEvents(bot))
+    print(f"> Extension {__name__} is ready\n")

--- a/test_bot/main.py
+++ b/test_bot/main.py
@@ -19,7 +19,12 @@ class TestBot(commands.Bot):
             help_command=None,  # type: ignore
             sync_commands_debug=True,
             sync_permissions=True,
-            test_guilds=[570841314200125460, 768247229840359465, 808030843078836254],
+            test_guilds=[
+                570841314200125460,
+                768247229840359465,
+                808030843078836254,
+                723976264511389746,
+            ],
         )
 
     def load_all_extensions(self, folder: str) -> None:


### PR DESCRIPTION
## Summary

Discord pushed it into canary last night, the cdn endpoint is the one that the client uses.
![image](https://user-images.githubusercontent.com/67214928/150150711-1839a191-3a61-4066-9fcd-b57ccb6fb8be.png)

note: there isn't any PR in discord-api-docs, but the `image` field has been there for a while.

Todo:
- [ ] Audit log (there aren't any audit logs for it yet)

ref:
https://github.com/Discord-Datamining/Discord-Datamining/commit/d633cd1d95e097d9c97beaef42926d958395bc7c
https://github.com/discord/discord-api-docs/pull/4380


<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
