### PR TITLE
fix: message converter now reattempts to fetch messages

### DIFF
--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -353,7 +353,7 @@ class PartialMessageConverter(Converter[disnake.PartialMessage]):
         if not match:
             raise MessageNotFound(argument)
         data = match.groupdict()
-        channel_id = disnake.utils._get_as_snowflake(data, "channel_id")
+        channel_id = disnake.utils._get_as_snowflake(data, "channel_id") or ctx.channel.id
         message_id = int(data["message_id"])
         guild_id = data.get("guild_id")
         if guild_id is None:


### PR DESCRIPTION
## Summary
fixes bug introduced with 1a4e73d59932cdbe7bf2c281f25e32529fc7ae1f
which required messages be in the cache if no channel id was provided, contrary to the docstring

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
