### PR TITLE
Application commands permissions v2 implementation

### DIFF
--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -13,7 +13,7 @@ __title__ = "disnake"
 __author__ = "Rapptz, EQUENOS"
 __license__ = "MIT"
 __copyright__ = "Copyright 2015-present Rapptz, 2021-present EQUENOS"
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -579,7 +579,7 @@ def guild_permissions(
     return decorator
 
 
-def require_permissions(**permissions: bool) -> Callable[[Callable], Callable]:
+def require_permissions(**permissions: bool) -> Callable[[T], T]:
     """
     A decorator that sets default required member permissions in all guilds.
 
@@ -590,11 +590,11 @@ def require_permissions(**permissions: bool) -> Callable[[Callable], Callable]:
     """
     perms_value = Permissions(**permissions).value
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: T) -> T:
         if isinstance(func, InvokableApplicationCommand):
             func.body._default_member_permissions = perms_value
         else:
-            func.__default_member_permissions__ = perms_value
+            func.__default_member_permissions__ = perms_value  # type: ignore
         return func
 
     return decorator

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2003,11 +2003,6 @@ class HTTPClient:
         command_id: Snowflake,
         payload: interactions.EditApplicationCommand,
     ) -> Response[interactions.ApplicationCommand]:
-        valid_keys = (
-            "name",
-            "description",
-            "options",
-        )
         payload = {k: v for k, v in payload.items() if k in valid_keys}  # type: ignore
         r = Route(
             "PATCH",
@@ -2083,11 +2078,6 @@ class HTTPClient:
         command_id: Snowflake,
         payload: interactions.EditApplicationCommand,
     ) -> Response[interactions.ApplicationCommand]:
-        valid_keys = (
-            "name",
-            "description",
-            "options",
-        )
         payload = {k: v for k, v in payload.items() if k in valid_keys}  # type: ignore
         r = Route(
             "PATCH",

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -84,7 +84,7 @@ class ApplicationCommandOptionChoice(TypedDict):
     value: ApplicationCommandOptionChoiceValue
 
 
-ApplicationCommandPermissionType = Literal[1, 2]
+ApplicationCommandPermissionType = Literal[1, 2, 3]
 
 
 class ApplicationCommandPermissions(TypedDict):

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -250,6 +250,8 @@ class _EditApplicationCommandOptional(TypedDict, total=False):
     description: str
     options: Optional[List[ApplicationCommandOption]]
     default_permission: bool
+    dm_permission: bool
+    default_member_permissions: str
     type: ApplicationCommandType
 
 


### PR DESCRIPTION
## Summary

Discord is going to roll out proper permissions for application commands. They will be based on member permissions. v1 permissions will be deprecated. `PUT` permission endpoints will be removed, as well as `default_permission` field.

Let's keep this as draft until discord makes this public. Feel free to review it and suggest better design solutions.

This PR adds:
- `ApplicationCommand.dm_permission` (including subclasses)
- `ApplicationCommand.(_)default_member_permissinons` (including subclasses)
- `commands.require_permissions` decorator
- Type-3 for v1 permissions (channel permissions)

Refactor:
- `ApplicationCommand.__repr__` (including subclasses)
- `ApplicationCommand.__str__` (including subclasses)
- `ApplicationCommand.from_dict` (only subclasses)

Things no one cares about:
- `HTTPClient.edit_global(guild)_command` code no longer filters valid fields

## Main feature being added

```py
@commands.require_permissions(administrator=True)
@bot.slash_command()
async def ban(inter: disnake.CommandInteraction, user: disnake.User):
    """This command is greyed out because it's only available for admins"""
    ...
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
