### PR TITLE
feat: support timeouts in permissions_for

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -225,8 +225,14 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         return ChannelType.text.value
 
     @utils.copy_doc(disnake.abc.GuildChannel.permissions_for)
-    def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:
-        base = super().permissions_for(obj)
+    def permissions_for(
+        self,
+        obj: Union[Member, Role],
+        /,
+        *,
+        ignore_timeout: bool = MISSING,
+    ) -> Permissions:
+        base = super().permissions_for(obj, ignore_timeout=ignore_timeout)
 
         # text channels do not have voice related permissions
         denied = Permissions.voice()
@@ -933,8 +939,14 @@ class VocalGuildChannel(disnake.abc.Connectable, disnake.abc.GuildChannel, Hasha
         # fmt: on
 
     @utils.copy_doc(disnake.abc.GuildChannel.permissions_for)
-    def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:
-        base = super().permissions_for(obj)
+    def permissions_for(
+        self,
+        obj: Union[Member, Role],
+        /,
+        *,
+        ignore_timeout: bool = MISSING,
+    ) -> Permissions:
+        base = super().permissions_for(obj, ignore_timeout=ignore_timeout)
 
         # voice channels cannot be edited by people who can't connect to them
         # It also implicitly denies all other voice perms
@@ -1823,8 +1835,14 @@ class StoreChannel(disnake.abc.GuildChannel, Hashable):
         return ChannelType.store
 
     @utils.copy_doc(disnake.abc.GuildChannel.permissions_for)
-    def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:
-        base = super().permissions_for(obj)
+    def permissions_for(
+        self,
+        obj: Union[Member, Role],
+        /,
+        *,
+        ignore_timeout: bool = MISSING,
+    ) -> Permissions:
+        base = super().permissions_for(obj, ignore_timeout=ignore_timeout)
 
         # store channels do not have voice related permissions
         denied = Permissions.voice()
@@ -1993,7 +2011,13 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         """:class:`datetime.datetime`: Returns the direct message channel's creation time in UTC."""
         return utils.snowflake_time(self.id)
 
-    def permissions_for(self, obj: Any = None, /) -> Permissions:
+    def permissions_for(
+        self,
+        obj: Any = None,
+        /,
+        *,
+        ignore_timeout: bool = MISSING,
+    ) -> Permissions:
         """Handles permission resolution for a :class:`User`.
 
         This function is there for compatibility with other channel types.
@@ -2010,6 +2034,10 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         obj: :class:`User`
             The user to check permissions for. This parameter is ignored
             but kept for compatibility with other ``permissions_for`` methods.
+
+        ignore_timeout: :class:`bool`
+            Whether to ignore the guild timeout when checking permsisions.
+            This parameter is ignored but kept for compatibility with other ``permissions_for`` methods.
 
         Returns
         --------
@@ -2140,7 +2168,13 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
         """:class:`datetime.datetime`: Returns the channel's creation time in UTC."""
         return utils.snowflake_time(self.id)
 
-    def permissions_for(self, obj: Snowflake, /) -> Permissions:
+    def permissions_for(
+        self,
+        obj: Snowflake,
+        /,
+        *,
+        ignore_timeout: bool = MISSING,
+    ) -> Permissions:
         """Handles permission resolution for a :class:`User`.
 
         This function is there for compatibility with other channel types.
@@ -2158,6 +2192,10 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
         -----------
         obj: :class:`~disnake.abc.Snowflake`
             The user to check permissions for.
+
+        ignore_timeout: :class:`bool`
+            Whether to ignore the guild timeout when checking permsisions.
+            This parameter is ignored but kept for compatibility with other ``permissions_for`` methods.
 
         Returns
         --------

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -364,7 +364,7 @@ class Thread(Messageable, Hashable):
 
             .. versionadded:: 2.4
 
-            .. note:: This only applies to `~disnake.Member` objects.
+            .. note:: This only applies to :class:`~disnake.Member` objects.
 
         Raises
         -------

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -337,7 +337,13 @@ class Thread(Messageable, Hashable):
         parent = self.parent
         return parent is not None and parent.is_nsfw()
 
-    def permissions_for(self, obj: Union[Member, Role], /) -> Permissions:
+    def permissions_for(
+        self,
+        obj: Union[Member, Role],
+        /,
+        *,
+        ignore_timeout: bool = MISSING,
+    ) -> Permissions:
         """Handles permission resolution for the :class:`~disnake.Member`
         or :class:`~disnake.Role`.
 
@@ -352,6 +358,13 @@ class Thread(Messageable, Hashable):
             The object to resolve permissions for. This could be either
             a member or a role. If it's a role then member overwrites
             are not computed.
+        ignore_timeout: :class:`bool`
+            Whether or not to ignore the user's timeout.
+            Defaults to ``True`` for backwards compatibility.
+
+            .. versionadded:: 2.4
+
+            .. note:: This only applies to `~disnake.Member` objects.
 
         Raises
         -------
@@ -367,7 +380,7 @@ class Thread(Messageable, Hashable):
         parent = self.parent
         if parent is None:
             raise ClientException("Parent channel not found")
-        return parent.permissions_for(obj)
+        return parent.permissions_for(obj, ignore_timeout=ignore_timeout)
 
     async def delete_messages(self, messages: Iterable[Snowflake]) -> None:
         """|coro|


### PR DESCRIPTION
## Summary
Add ignore_timeout parameter to permission_for methods.

This allows a developer to more easily view the permissions of a user without needing to 
check this themselves.

Leads way to support this in `commands.has_permissions`


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
