### PR TITLE
Improve `converter.py` annotations

### DIFF
--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -91,17 +91,16 @@ __all__ = (
 
 _utils_get = disnake.utils.get
 T = TypeVar("T")
-U = TypeVar("U")
 T_co = TypeVar("T_co", covariant=True)
 CT = TypeVar("CT", bound=disnake.abc.GuildChannel)
 TT = TypeVar("TT", bound=disnake.Thread)
 
 
 def _get_from_guilds(
-    client: disnake.Client, func: Callable[[disnake.Guild, T], Optional[U]], argument: T
-) -> Optional[U]:
+    client: disnake.Client, func: Callable[[disnake.Guild], Optional[T]]
+) -> Optional[T]:
     for guild in client.guilds:
-        if result := func(guild, argument):
+        if result := func(guild):
             return result
     return None
 
@@ -249,7 +248,7 @@ class MemberConverter(IDConverter[disnake.Member]):
             if guild:
                 result = guild.get_member_named(argument)
             else:
-                result = _get_from_guilds(bot, lambda g, a: g.get_member_named(a), argument)
+                result = _get_from_guilds(bot, lambda g: g.get_member_named(argument))
         else:
             user_id = int(match.group(1))
             if guild:
@@ -258,7 +257,7 @@ class MemberConverter(IDConverter[disnake.Member]):
                 )
                 result = guild.get_member(user_id) or _utils_get(mentions, id=user_id)
             else:
-                result = _get_from_guilds(bot, lambda g, a: g.get_member(a), user_id)
+                result = _get_from_guilds(bot, lambda g: g.get_member(user_id))
 
         if result is None:
             if guild is None:
@@ -467,7 +466,7 @@ class GuildChannelConverter(IDConverter[disnake.abc.GuildChannel]):
             if guild:
                 result = guild.get_channel(channel_id)
             else:
-                result = _get_from_guilds(bot, lambda g, a: g.get_channel(a), channel_id)
+                result = _get_from_guilds(bot, lambda g: g.get_channel(channel_id))
 
         if not isinstance(result, type):
             raise ChannelNotFound(argument)

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -31,6 +31,7 @@ import re
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Generic,
     Iterable,
@@ -108,7 +109,7 @@ def _get_from_guilds(
 @runtime_checkable
 class Converter(Protocol[T_co]):
     """The base class of custom converters that require the :class:`.Context`
-    to be passed to be useful.
+    or :class:`.ApplicationCommandInteraction` to be passed to be useful.
 
     This allows you to implement converters that function similar to the
     special cased ``disnake`` classes.
@@ -128,7 +129,7 @@ class Converter(Protocol[T_co]):
 
         Parameters
         -----------
-        ctx: :class:`.Context`
+        ctx: Union[:class:`.Context`, :class:`.ApplicationCommandInteraction`]
             The invocation context that the argument is being used in.
         argument: :class:`str`
             The argument that is being converted.


### PR DESCRIPTION
## Summary

This PR adds missing annotations in `converter.py`, and changes `Converter.convert` to use `Union[Context, ApplicationCommandInteraction]` instead of `Context`. No functional changes, except for `_get_from_guilds`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
