### PR TITLE
docs(Thread): add deprecation warning to `archiver_id`

### DIFF
--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -313,9 +313,9 @@ class Thread(Messageable, Hashable):
 
         .. warning::
 
-            This property will be deleted in a future version.
+            This property will be removed in a future version.
         """
-        warn_deprecated("archiver_id is deprecated and will be removed in a future version.")
+        warn_deprecated("archiver_id is deprecated and will be removed in a future version.", stacklevel=2)
         return self._archiver_id
 
     def is_private(self) -> bool:

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from distutils.log import warn
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Union
 
 from .abc import Messageable

--- a/disnake/types/threads.py
+++ b/disnake/types/threads.py
@@ -41,7 +41,6 @@ class ThreadMember(TypedDict):
 
 
 class _ThreadMetadataOptional(TypedDict, total=False):
-    archiver_id: Snowflake
     locked: bool
     invitable: bool
 


### PR DESCRIPTION
## Summary

Discord doesn't provide this field anymore. It will be deleted in a future version (probably version 2.5).

ref:
https://github.com/discord/discord-api-docs/pull/3108

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
