### PR TITLE
Add separate types for command objects returned by the API

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -391,6 +391,9 @@ class APIApplicationCommand(ApplicationCommand):
         "version",
     )
 
+    def __repr__(self) -> str:
+        return f"<APIApplicationCommand type={self.type!r} name={self.name!r} id={self.id!r}>"
+
     def _update_common(self, data: ApplicationCommandPayload) -> None:
         self.id: int = int(data["id"])
         self.application_id: int = int(data["application_id"])
@@ -431,6 +434,9 @@ class APIUserCommand(UserCommand, APIApplicationCommand):
         self._update_common(data)
         return self
 
+    def __repr__(self) -> str:
+        return f"<APIUserCommand name={self.name!r} id={self.id!r}>"
+
 
 class MessageCommand(ApplicationCommand):
     __slots__ = ()
@@ -464,6 +470,9 @@ class APIMessageCommand(MessageCommand, APIApplicationCommand):
         self = super().from_dict(data)
         self._update_common(data)
         return self
+
+    def __repr__(self) -> str:
+        return f"<APIMessageCommand name={self.name!r} id={self.id!r}>"
 
 
 class SlashCommand(ApplicationCommand):
@@ -579,6 +588,12 @@ class APISlashCommand(SlashCommand, APIApplicationCommand):
         self = super().from_dict(data)
         self._update_common(data)
         return self
+
+    def __repr__(self) -> str:
+        return (
+            f"<APISlashCommand name={self.name!r} description={self.description!r} "
+            f"default_permission={self.default_permission!r} options={self.options!r} id={self.id!r}>"
+        )
 
 
 class ApplicationCommandPermissions:

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -86,14 +86,14 @@ __all__ = (
 )
 
 
-def application_command_factory(data: ApplicationCommandPayload) -> ApplicationCommand:
+def application_command_factory(data: ApplicationCommandPayload) -> APIApplicationCommand:
     cmd_type = try_enum(ApplicationCommandType, data.get("type", 1))
     if cmd_type is ApplicationCommandType.chat_input:
-        return SlashCommand.from_dict(data)
+        return APISlashCommand.from_dict(data)
     if cmd_type is ApplicationCommandType.user:
-        return UserCommand.from_dict(data)
+        return APIUserCommand.from_dict(data)
     if cmd_type is ApplicationCommandType.message:
-        return MessageCommand.from_dict(data)
+        return APIMessageCommand.from_dict(data)
 
     raise TypeError(f"Application command of type {cmd_type} is not valid")
 

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -380,6 +380,8 @@ class APIApplicationCommand(ApplicationCommand):
     """
     The base class for application commands returned by the API
 
+    .. versionadded:: 2.4
+
     Attributes
     ----------
     type: :class:`ApplicationCommandType`
@@ -452,6 +454,8 @@ class APIUserCommand(UserCommand, APIApplicationCommand):
     """
     A user context menu command returned by the API
 
+    .. versionadded:: 2.4
+
     Attributes
     ----------
     name: :class:`str`
@@ -516,6 +520,8 @@ class MessageCommand(ApplicationCommand):
 class APIMessageCommand(MessageCommand, APIApplicationCommand):
     """
     A message context menu command returned by the API
+
+    .. versionadded:: 2.4
 
     Attributes
     ----------
@@ -651,6 +657,8 @@ class SlashCommand(ApplicationCommand):
 class APISlashCommand(SlashCommand, APIApplicationCommand):
     """
     A slash command returned by the API
+
+    .. versionadded:: 2.4
 
     Attributes
     ----------

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -340,13 +340,6 @@ class ApplicationCommand(ABC):
     The base class for application commands
     """
 
-    __slots__ = (
-        "type",
-        "name",
-        "default_permission",
-        "_always_synced",
-    )
-
     def __init__(self, type: ApplicationCommandType, name: str, default_permission: bool = True):
         self.type: ApplicationCommandType = enum_if_int(ApplicationCommandType, type)
         self.name: str = name
@@ -384,13 +377,6 @@ class APIApplicationCommand(ApplicationCommand):
     # the `from_dict` methods in subtypes could've been part of this class,
     # but typing super calls in mixins is difficult
 
-    __slots__ = (
-        "id",
-        "application_id",
-        "guild_id",
-        "version",
-    )
-
     def __repr__(self) -> str:
         return f"<APIApplicationCommand type={self.type!r} name={self.name!r} id={self.id!r}>"
 
@@ -402,8 +388,6 @@ class APIApplicationCommand(ApplicationCommand):
 
 
 class UserCommand(ApplicationCommand):
-    __slots__ = ()
-
     def __init__(self, name: str, default_permission: bool = True):
         super().__init__(
             type=ApplicationCommandType.user,
@@ -439,8 +423,6 @@ class APIUserCommand(UserCommand, APIApplicationCommand):
 
 
 class MessageCommand(ApplicationCommand):
-    __slots__ = ()
-
     def __init__(self, name: str, default_permission: bool = True):
         super().__init__(
             type=ApplicationCommandType.message,
@@ -490,8 +472,6 @@ class SlashCommand(ApplicationCommand):
     default_permission : :class:`bool`
         Whether the command is enabled by default when the app is added to a guild
     """
-
-    __slots__ = ("description", "options")
 
     def __init__(
         self,

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -338,6 +338,15 @@ class Option:
 class ApplicationCommand(ABC):
     """
     The base class for application commands
+
+    Attributes
+    ----------
+    type: :class:`ApplicationCommandType`
+        The command type
+    name: :class:`str`
+        The command name
+    default_permission: :class:`bool`
+        Whether the command is usable by default
     """
 
     def __init__(self, type: ApplicationCommandType, name: str, default_permission: bool = True):
@@ -370,6 +379,23 @@ class ApplicationCommand(ABC):
 class APIApplicationCommand(ApplicationCommand):
     """
     The base class for application commands returned by the API
+
+    Attributes
+    ----------
+    type: :class:`ApplicationCommandType`
+        The command type
+    name: :class:`str`
+        The command name
+    default_permission: :class:`bool`
+        Whether the command is usable by default
+    id: :class:`int`
+        The command ID
+    application_id: :class:`int`
+        The ID of the application this command belongs to
+    guild_id: Optional[:class:`int`]
+        The guild ID of the command, if not global
+    version: :class:`int`
+        The version identifier of the command, updated on substantial changes
     """
 
     # note: subtypes should call `self._update_common`
@@ -388,6 +414,17 @@ class APIApplicationCommand(ApplicationCommand):
 
 
 class UserCommand(ApplicationCommand):
+    """
+    A user context menu command
+
+    Attributes
+    ----------
+    name: :class:`str`
+        The command name
+    default_permission: :class:`bool`
+        Whether the command is usable by default
+    """
+
     def __init__(self, name: str, default_permission: bool = True):
         super().__init__(
             type=ApplicationCommandType.user,
@@ -412,6 +449,25 @@ class UserCommand(ApplicationCommand):
 
 
 class APIUserCommand(UserCommand, APIApplicationCommand):
+    """
+    A user context menu command returned by the API
+
+    Attributes
+    ----------
+    name: :class:`str`
+        The command name
+    default_permission: :class:`bool`
+        Whether the command is usable by default
+    id: :class:`int`
+        The command ID
+    application_id: :class:`int`
+        The ID of the application this command belongs to
+    guild_id: Optional[:class:`int`]
+        The guild ID of the command, if not global
+    version: :class:`int`
+        The version identifier of the command, updated on substantial changes
+    """
+
     @classmethod
     def from_dict(cls, data: ApplicationCommandPayload) -> APIUserCommand:
         self = super().from_dict(data)
@@ -423,6 +479,17 @@ class APIUserCommand(UserCommand, APIApplicationCommand):
 
 
 class MessageCommand(ApplicationCommand):
+    """
+    A message context menu command
+
+    Attributes
+    ----------
+    name: :class:`str`
+        The command name
+    default_permission: :class:`bool`
+        Whether the command is usable by default
+    """
+
     def __init__(self, name: str, default_permission: bool = True):
         super().__init__(
             type=ApplicationCommandType.message,
@@ -447,6 +514,25 @@ class MessageCommand(ApplicationCommand):
 
 
 class APIMessageCommand(MessageCommand, APIApplicationCommand):
+    """
+    A message context menu command returned by the API
+
+    Attributes
+    ----------
+    name: :class:`str`
+        The command name
+    default_permission: :class:`bool`
+        Whether the command is usable by default
+    id: :class:`int`
+        The command ID
+    application_id: :class:`int`
+        The ID of the application this command belongs to
+    guild_id: Optional[:class:`int`]
+        The guild ID of the command, if not global
+    version: :class:`int`
+        The version identifier of the command, updated on substantial changes
+    """
+
     @classmethod
     def from_dict(cls, data: ApplicationCommandPayload) -> APIMessageCommand:
         self = super().from_dict(data)
@@ -463,14 +549,14 @@ class SlashCommand(ApplicationCommand):
 
     Parameters
     ----------
-    name : :class:`str`
+    name: :class:`str`
         The command name
-    description : :class:`str`
-        The command description (it'll be displayed by disnake)
-    options : List[:class:`Option`]
-        The options of the command
-    default_permission : :class:`bool`
+    default_permission: :class:`bool`
         Whether the command is enabled by default when the app is added to a guild
+    description: :class:`str`
+        The command description
+    options: List[:class:`Option`]
+        The options of the command
     """
 
     def __init__(
@@ -563,6 +649,29 @@ class SlashCommand(ApplicationCommand):
 
 
 class APISlashCommand(SlashCommand, APIApplicationCommand):
+    """
+    A slash command returned by the API
+
+    Attributes
+    ----------
+    name: :class:`str`
+        The command name
+    default_permission: :class:`bool`
+        Whether the command is usable by default
+    description: :class:`str`
+        The command description
+    options: List[:class:`Option`]
+        The options of the command
+    id: :class:`int`
+        The command ID
+    application_id: :class:`int`
+        The ID of the application this command belongs to
+    guild_id: Optional[:class:`int`]
+        The guild ID of the command, if not global
+    version: :class:`int`
+        The version identifier of the command, updated on substantial changes
+    """
+
     @classmethod
     def from_dict(cls, data: ApplicationCommandPayload) -> APISlashCommand:
         self = super().from_dict(data)

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -69,9 +69,13 @@ if TYPE_CHECKING:
 __all__ = (
     "application_command_factory",
     "ApplicationCommand",
+    "APIApplicationCommand",
     "SlashCommand",
+    "APISlashCommand",
     "UserCommand",
+    "APIUserCommand",
     "MessageCommand",
+    "APIMessageCommand",
     "OptionChoice",
     "Option",
     "ApplicationCommandPermissions",

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -53,12 +53,13 @@ import aiohttp
 from . import utils
 from .activity import ActivityTypes, BaseActivity, create_activity
 from .app_commands import (
+    APIApplicationCommand,
+    APIMessageCommand,
+    APISlashCommand,
+    APIUserCommand,
     ApplicationCommand,
     GuildApplicationCommandPermissions,
-    MessageCommand,
     PartialGuildApplicationCommandPermissions,
-    SlashCommand,
-    UserCommand,
 )
 from .appinfo import AppInfo
 from .backoff import ExponentialBackoff
@@ -417,35 +418,35 @@ class Client:
         return self._connection.application_flags  # type: ignore
 
     @property
-    def global_application_commands(self) -> List[ApplicationCommand]:
-        """List[:class:`.ApplicationCommand`]: The client's global application commands."""
+    def global_application_commands(self) -> List[APIApplicationCommand]:
+        """List[:class:`.APIApplicationCommand`]: The client's global application commands."""
         return list(self._connection._global_application_commands.values())
 
     @property
-    def global_slash_commands(self) -> List[SlashCommand]:
-        """List[:class:`.SlashCommand`]: The client's global slash commands."""
+    def global_slash_commands(self) -> List[APISlashCommand]:
+        """List[:class:`.APISlashCommand`]: The client's global slash commands."""
         return [
             cmd
             for cmd in self._connection._global_application_commands.values()
-            if isinstance(cmd, SlashCommand)
+            if isinstance(cmd, APISlashCommand)
         ]
 
     @property
-    def global_user_commands(self) -> List[UserCommand]:
-        """List[:class:`.UserCommand`]: The client's global user commands."""
+    def global_user_commands(self) -> List[APIUserCommand]:
+        """List[:class:`.APIUserCommand`]: The client's global user commands."""
         return [
             cmd
             for cmd in self._connection._global_application_commands.values()
-            if isinstance(cmd, UserCommand)
+            if isinstance(cmd, APIUserCommand)
         ]
 
     @property
-    def global_message_commands(self) -> List[MessageCommand]:
-        """List[:class:`.MessageCommand`]: The client's global message commands."""
+    def global_message_commands(self) -> List[APIMessageCommand]:
+        """List[:class:`.APIMessageCommand`]: The client's global message commands."""
         return [
             cmd
             for cmd in self._connection._global_application_commands.values()
-            if isinstance(cmd, MessageCommand)
+            if isinstance(cmd, APIMessageCommand)
         ]
 
     def get_message(self, id: int) -> Optional[Message]:
@@ -1089,7 +1090,7 @@ class Client:
         for guild in self.guilds:
             yield from guild.members
 
-    def get_guild_application_commands(self, guild_id: int) -> List[ApplicationCommand]:
+    def get_guild_application_commands(self, guild_id: int) -> List[APIApplicationCommand]:
         """
         Returns a list of all application commands in the guild.
 
@@ -1100,13 +1101,13 @@ class Client:
 
         Returns
         -------
-        List[:class:`.ApplicationCommand`]
+        List[:class:`.APIApplicationCommand`]
             The list of application commands.
         """
         data = self._connection._guild_application_commands.get(guild_id, {})
         return list(data.values())
 
-    def get_guild_slash_commands(self, guild_id: int) -> List[SlashCommand]:
+    def get_guild_slash_commands(self, guild_id: int) -> List[APISlashCommand]:
         """
         Returns a list of all slash commands in the guild.
 
@@ -1117,13 +1118,13 @@ class Client:
 
         Returns
         -------
-        List[:class:`.SlashCommand`]
+        List[:class:`.APISlashCommand`]
             The list of slash commands.
         """
         data = self._connection._guild_application_commands.get(guild_id, {})
-        return [cmd for cmd in data.values() if isinstance(cmd, SlashCommand)]
+        return [cmd for cmd in data.values() if isinstance(cmd, APISlashCommand)]
 
-    def get_guild_user_commands(self, guild_id: int) -> List[UserCommand]:
+    def get_guild_user_commands(self, guild_id: int) -> List[APIUserCommand]:
         """
         Returns a list of all user commands in the guild.
 
@@ -1134,13 +1135,13 @@ class Client:
 
         Returns
         -------
-        List[:class:`.UserCommand`]
+        List[:class:`.APIUserCommand`]
             The list of user commands.
         """
         data = self._connection._guild_application_commands.get(guild_id, {})
-        return [cmd for cmd in data.values() if isinstance(cmd, UserCommand)]
+        return [cmd for cmd in data.values() if isinstance(cmd, APIUserCommand)]
 
-    def get_guild_message_commands(self, guild_id: int) -> List[MessageCommand]:
+    def get_guild_message_commands(self, guild_id: int) -> List[APIMessageCommand]:
         """
         Returns a list of all message commands in the guild.
 
@@ -1151,13 +1152,13 @@ class Client:
 
         Returns
         -------
-        List[:class:`.MessageCommand`]
+        List[:class:`.APIMessageCommand`]
             The list of message commands.
         """
         data = self._connection._guild_application_commands.get(guild_id, {})
-        return [cmd for cmd in data.values() if isinstance(cmd, MessageCommand)]
+        return [cmd for cmd in data.values() if isinstance(cmd, APIMessageCommand)]
 
-    def get_global_command(self, id: int) -> Optional[ApplicationCommand]:
+    def get_global_command(self, id: int) -> Optional[APIApplicationCommand]:
         """
         Returns a global application command.
 
@@ -1168,12 +1169,12 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.ApplicationCommand`]
+        Optional[:class:`.APIApplicationCommand`]
             The application command.
         """
         return self._connection._get_global_application_command(id)
 
-    def get_guild_command(self, guild_id: int, id: int) -> Optional[ApplicationCommand]:
+    def get_guild_command(self, guild_id: int, id: int) -> Optional[APIApplicationCommand]:
         """
         Returns a guild application command.
 
@@ -1186,14 +1187,14 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.ApplicationCommand`]
+        Optional[:class:`.APIApplicationCommand`]
             The application command.
         """
         return self._connection._get_guild_application_command(guild_id, id)
 
     def get_global_command_named(
         self, name: str, cmd_type: ApplicationCommandType = None
-    ) -> Optional[ApplicationCommand]:
+    ) -> Optional[APIApplicationCommand]:
         """
         Returns a global application command matching the specified name.
 
@@ -1206,14 +1207,14 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.ApplicationCommand`]
+        Optional[:class:`.APIApplicationCommand`]
             The application command.
         """
         return self._connection._get_global_command_named(name, cmd_type)
 
     def get_guild_command_named(
         self, guild_id: int, name: str, cmd_type: ApplicationCommandType = None
-    ) -> Optional[ApplicationCommand]:
+    ) -> Optional[APIApplicationCommand]:
         """
         Returns a guild application command matching the name.
 
@@ -1228,7 +1229,7 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.ApplicationCommand`]
+        Optional[:class:`.APIApplicationCommand`]
             The application command.
         """
         return self._connection._get_guild_command_named(guild_id, name, cmd_type)
@@ -2015,7 +2016,7 @@ class Client:
 
     # Application commands (global)
 
-    async def fetch_global_commands(self) -> List[ApplicationCommand]:
+    async def fetch_global_commands(self) -> List[APIApplicationCommand]:
         """|coro|
 
         Requests a list of global application commands.
@@ -2024,12 +2025,12 @@ class Client:
 
         Returns
         -------
-        List[:class:`.ApplicationCommand`]
+        List[:class:`.APIApplicationCommand`]
             A list of application commands.
         """
         return await self._connection.fetch_global_commands()
 
-    async def fetch_global_command(self, command_id: int) -> ApplicationCommand:
+    async def fetch_global_command(self, command_id: int) -> APIApplicationCommand:
         """|coro|
 
         Requests a global application command.
@@ -2043,14 +2044,14 @@ class Client:
 
         Returns
         -------
-        :class:`.ApplicationCommand`
+        :class:`.APIApplicationCommand`
             The requested application command.
         """
         return await self._connection.fetch_global_command(command_id)
 
     async def create_global_command(
         self, application_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         """|coro|
 
         Creates a global application command.
@@ -2064,14 +2065,14 @@ class Client:
 
         Returns
         -------
-        :class:`.ApplicationCommand`
+        :class:`.APIApplicationCommand`
             The application command that was created.
         """
         return await self._connection.create_global_command(application_command)
 
     async def edit_global_command(
         self, command_id: int, new_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         """|coro|
 
         Edits a global application command.
@@ -2087,7 +2088,7 @@ class Client:
 
         Returns
         -------
-        :class:`.ApplicationCommand`
+        :class:`.APIApplicationCommand`
             The edited application command.
         """
         return await self._connection.edit_global_command(command_id, new_command)
@@ -2108,7 +2109,7 @@ class Client:
 
     async def bulk_overwrite_global_commands(
         self, application_commands: List[ApplicationCommand]
-    ) -> List[ApplicationCommand]:
+    ) -> List[APIApplicationCommand]:
         """|coro|
 
         Overwrites several global application commands in one API request.
@@ -2122,14 +2123,14 @@ class Client:
 
         Returns
         -------
-        List[:class:`.ApplicationCommand`]
+        List[:class:`.APIApplicationCommand`]
             A list of registered application commands.
         """
         return await self._connection.bulk_overwrite_global_commands(application_commands)
 
     # Application commands (guild)
 
-    async def fetch_guild_commands(self, guild_id: int) -> List[ApplicationCommand]:
+    async def fetch_guild_commands(self, guild_id: int) -> List[APIApplicationCommand]:
         """|coro|
 
         Requests a list of guild application commands.
@@ -2143,12 +2144,12 @@ class Client:
 
         Returns
         -------
-        List[:class:`.ApplicationCommand`]
+        List[:class:`.APIApplicationCommand`]
             A list of application commands.
         """
         return await self._connection.fetch_guild_commands(guild_id)
 
-    async def fetch_guild_command(self, guild_id: int, command_id: int) -> ApplicationCommand:
+    async def fetch_guild_command(self, guild_id: int, command_id: int) -> APIApplicationCommand:
         """|coro|
 
         Requests a guild application command.
@@ -2164,14 +2165,14 @@ class Client:
 
         Returns
         -------
-        :class:`.ApplicationCommand`
+        :class:`.APIApplicationCommand`
             The requested application command.
         """
         return await self._connection.fetch_guild_command(guild_id, command_id)
 
     async def create_guild_command(
         self, guild_id: int, application_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         """|coro|
 
         Creates a guild application command.
@@ -2187,14 +2188,14 @@ class Client:
 
         Returns
         -------
-        :class:`.ApplicationCommand`
+        :class:`.APIApplicationCommand`
             The application command that was created.
         """
         return await self._connection.create_guild_command(guild_id, application_command)
 
     async def edit_guild_command(
         self, guild_id: int, command_id: int, new_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         """|coro|
 
         Edits a guild application command.
@@ -2212,7 +2213,7 @@ class Client:
 
         Returns
         -------
-        :class:`.ApplicationCommand`
+        :class:`.APIApplicationCommand`
             The edited application command.
         """
         return await self._connection.edit_guild_command(guild_id, command_id, new_command)
@@ -2235,7 +2236,7 @@ class Client:
 
     async def bulk_overwrite_guild_commands(
         self, guild_id: int, application_commands: List[ApplicationCommand]
-    ) -> List[ApplicationCommand]:
+    ) -> List[APIApplicationCommand]:
         """|coro|
 
         Overwrites several guild application commands in one API request.
@@ -2251,7 +2252,7 @@ class Client:
 
         Returns
         -------
-        List[:class:`.ApplicationCommand`]
+        List[:class:`.APIApplicationCommand`]
             A list of registered application commands.
         """
         return await self._connection.bulk_overwrite_guild_commands(guild_id, application_commands)

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -53,7 +53,6 @@ import aiohttp
 from . import utils
 from .activity import ActivityTypes, BaseActivity, create_activity
 from .app_commands import (
-    APIApplicationCommand,
     APIMessageCommand,
     APISlashCommand,
     APIUserCommand,
@@ -89,6 +88,7 @@ from .widget import Widget
 
 if TYPE_CHECKING:
     from .abc import GuildChannel, PrivateChannel, Snowflake, SnowflakeTime, User as ABCUser
+    from .app_commands import APIApplicationCommand
     from .channel import DMChannel
     from .member import Member
     from .message import Message
@@ -419,7 +419,7 @@ class Client:
 
     @property
     def global_application_commands(self) -> List[APIApplicationCommand]:
-        """List[:class:`.APIApplicationCommand`]: The client's global application commands."""
+        """List[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]: The client's global application commands."""
         return list(self._connection._global_application_commands.values())
 
     @property
@@ -1101,7 +1101,7 @@ class Client:
 
         Returns
         -------
-        List[:class:`.APIApplicationCommand`]
+        List[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             The list of application commands.
         """
         data = self._connection._guild_application_commands.get(guild_id, {})
@@ -1169,7 +1169,7 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.APIApplicationCommand`]
+        Optional[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             The application command.
         """
         return self._connection._get_global_application_command(id)
@@ -1187,7 +1187,7 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.APIApplicationCommand`]
+        Optional[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             The application command.
         """
         return self._connection._get_guild_application_command(guild_id, id)
@@ -1207,7 +1207,7 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.APIApplicationCommand`]
+        Optional[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             The application command.
         """
         return self._connection._get_global_command_named(name, cmd_type)
@@ -1229,7 +1229,7 @@ class Client:
 
         Returns
         -------
-        Optional[:class:`.APIApplicationCommand`]
+        Optional[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             The application command.
         """
         return self._connection._get_guild_command_named(guild_id, name, cmd_type)
@@ -2025,7 +2025,7 @@ class Client:
 
         Returns
         -------
-        List[:class:`.APIApplicationCommand`]
+        List[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             A list of application commands.
         """
         return await self._connection.fetch_global_commands()
@@ -2044,7 +2044,7 @@ class Client:
 
         Returns
         -------
-        :class:`.APIApplicationCommand`
+        Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]
             The requested application command.
         """
         return await self._connection.fetch_global_command(command_id)
@@ -2065,7 +2065,7 @@ class Client:
 
         Returns
         -------
-        :class:`.APIApplicationCommand`
+        Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]
             The application command that was created.
         """
         return await self._connection.create_global_command(application_command)
@@ -2088,7 +2088,7 @@ class Client:
 
         Returns
         -------
-        :class:`.APIApplicationCommand`
+        Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]
             The edited application command.
         """
         return await self._connection.edit_global_command(command_id, new_command)
@@ -2123,7 +2123,7 @@ class Client:
 
         Returns
         -------
-        List[:class:`.APIApplicationCommand`]
+        List[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             A list of registered application commands.
         """
         return await self._connection.bulk_overwrite_global_commands(application_commands)
@@ -2144,7 +2144,7 @@ class Client:
 
         Returns
         -------
-        List[:class:`.APIApplicationCommand`]
+        List[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             A list of application commands.
         """
         return await self._connection.fetch_guild_commands(guild_id)
@@ -2165,7 +2165,7 @@ class Client:
 
         Returns
         -------
-        :class:`.APIApplicationCommand`
+        Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]
             The requested application command.
         """
         return await self._connection.fetch_guild_command(guild_id, command_id)
@@ -2188,7 +2188,7 @@ class Client:
 
         Returns
         -------
-        :class:`.APIApplicationCommand`
+        Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]
             The application command that was created.
         """
         return await self._connection.create_guild_command(guild_id, application_command)
@@ -2213,7 +2213,7 @@ class Client:
 
         Returns
         -------
-        :class:`.APIApplicationCommand`
+        Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]
             The edited application command.
         """
         return await self._connection.edit_guild_command(guild_id, command_id, new_command)
@@ -2252,7 +2252,7 @@ class Client:
 
         Returns
         -------
-        List[:class:`.APIApplicationCommand`]
+        List[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
             A list of registered application commands.
         """
         return await self._connection.bulk_overwrite_guild_commands(guild_id, application_commands)

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -654,7 +654,7 @@ class InteractionBotBase(CommonBotBase):
 
         try:
             commands = await self.fetch_global_commands()
-            self._connection._global_application_commands = {  # type: ignore
+            self._connection._global_application_commands = {
                 command.id: command for command in commands
             }
         except Exception:
@@ -663,7 +663,7 @@ class InteractionBotBase(CommonBotBase):
             try:
                 commands = await self.fetch_guild_commands(guild_id)
                 if commands:
-                    self._connection._guild_application_commands[guild_id] = {  # type: ignore
+                    self._connection._guild_application_commands[guild_id] = {
                         command.id: command for command in commands
                     }
             except Exception:
@@ -795,7 +795,7 @@ class InteractionBotBase(CommonBotBase):
                 if not self.owner_id and not self.owner_ids:
                     await self._fill_owners()
                 resolved_perms = perms.resolve(
-                    command_id=cmd.id,  # type: ignore
+                    command_id=cmd.id,
                     owners=[self.owner_id] if self.owner_id else self.owner_ids,
                 )
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -94,7 +94,7 @@ MISSING = utils.MISSING
 
 if TYPE_CHECKING:
     from .abc import Snowflake, SnowflakeTime, User as ABCUser
-    from .app_commands import ApplicationCommand
+    from .app_commands import APIApplicationCommand
     from .channel import CategoryChannel, StageChannel, StoreChannel, TextChannel, VoiceChannel
     from .permissions import Permissions
     from .state import ConnectionState
@@ -431,7 +431,7 @@ class Guild(Hashable):
 
         return role
 
-    def get_command(self, application_command_id: int, /) -> Optional[ApplicationCommand]:
+    def get_command(self, application_command_id: int, /) -> Optional[APIApplicationCommand]:
         """
         Gets a cached application command matching the specified ID.
 
@@ -442,7 +442,7 @@ class Guild(Hashable):
         """
         self._state._get_guild_application_command(self.id, application_command_id)
 
-    def get_command_named(self, name: str, /) -> Optional[ApplicationCommand]:
+    def get_command_named(self, name: str, /) -> Optional[APIApplicationCommand]:
         """
         Gets a cached application command matching the specified name.
 

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -81,7 +81,7 @@ from .utils import MISSING
 
 if TYPE_CHECKING:
     from .abc import PrivateChannel
-    from .app_commands import ApplicationCommand
+    from .app_commands import APIApplicationCommand, ApplicationCommand
     from .client import Client
     from .gateway import DiscordWebSocket
     from .guild import GuildChannel, VocalGuildChannel
@@ -283,8 +283,8 @@ class ConnectionState:
         self._guilds: Dict[int, Guild] = {}
 
         if application_commands:
-            self._global_application_commands: Dict[int, ApplicationCommand] = {}
-            self._guild_application_commands: Dict[int, Dict[int, ApplicationCommand]] = {}
+            self._global_application_commands: Dict[int, APIApplicationCommand] = {}
+            self._guild_application_commands: Dict[int, Dict[int, APIApplicationCommand]] = {}
             self._application_command_permissions: Dict[
                 int, Dict[int, GuildApplicationCommandPermissions]
             ] = {}
@@ -433,10 +433,12 @@ class ConnectionState:
 
     def _get_global_application_command(
         self, application_command_id: int
-    ) -> Optional[ApplicationCommand]:
+    ) -> Optional[APIApplicationCommand]:
         return self._global_application_commands.get(application_command_id)
 
-    def _add_global_application_command(self, application_command: ApplicationCommand, /) -> None:
+    def _add_global_application_command(
+        self, application_command: APIApplicationCommand, /
+    ) -> None:
         assert application_command.id
         self._global_application_commands[application_command.id] = application_command
 
@@ -449,13 +451,13 @@ class ConnectionState:
 
     def _get_guild_application_command(
         self, guild_id: int, application_command_id: int
-    ) -> Optional[ApplicationCommand]:
+    ) -> Optional[APIApplicationCommand]:
         granula = self._guild_application_commands.get(guild_id)
         if granula is not None:
             return granula.get(application_command_id)
 
     def _add_guild_application_command(
-        self, guild_id: int, application_command: ApplicationCommand
+        self, guild_id: int, application_command: APIApplicationCommand
     ) -> None:
         assert application_command.id
         try:
@@ -479,14 +481,14 @@ class ConnectionState:
 
     def _get_global_command_named(
         self, name: str, cmd_type: ApplicationCommandType = None
-    ) -> Optional[ApplicationCommand]:
+    ) -> Optional[APIApplicationCommand]:
         for cmd in self._global_application_commands.values():
             if cmd.name == name and (cmd_type is None or cmd.type is cmd_type):
                 return cmd
 
     def _get_guild_command_named(
         self, guild_id: int, name: str, cmd_type: ApplicationCommandType = None
-    ) -> Optional[ApplicationCommand]:
+    ) -> Optional[APIApplicationCommand]:
         granula = self._guild_application_commands.get(guild_id, {})
         for cmd in granula.values():
             if cmd.name == name and (cmd_type is None or cmd.type is cmd_type):
@@ -1762,17 +1764,17 @@ class ConnectionState:
     # All these methods (except fetchers) update the application command cache as well,
     # since there're no events related to application command updates
 
-    async def fetch_global_commands(self) -> List[ApplicationCommand]:
+    async def fetch_global_commands(self) -> List[APIApplicationCommand]:
         results = await self.http.get_global_commands(self.application_id)  # type: ignore
         return [application_command_factory(data) for data in results]
 
-    async def fetch_global_command(self, command_id: int) -> ApplicationCommand:
+    async def fetch_global_command(self, command_id: int) -> APIApplicationCommand:
         result = await self.http.get_global_command(self.application_id, command_id)  # type: ignore
         return application_command_factory(result)
 
     async def create_global_command(
         self, application_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         result = await self.http.upsert_global_command(
             self.application_id, application_command.to_dict()  # type: ignore
         )
@@ -1782,7 +1784,7 @@ class ConnectionState:
 
     async def edit_global_command(
         self, command_id: int, new_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         result = await self.http.edit_global_command(
             self.application_id, command_id, new_command.to_dict()  # type: ignore
         )
@@ -1796,7 +1798,7 @@ class ConnectionState:
 
     async def bulk_overwrite_global_commands(
         self, application_commands: List[ApplicationCommand]
-    ) -> List[ApplicationCommand]:
+    ) -> List[APIApplicationCommand]:
         payload = [cmd.to_dict() for cmd in application_commands]
         results = await self.http.bulk_upsert_global_commands(self.application_id, payload)  # type: ignore
         commands = [application_command_factory(data) for data in results]
@@ -1805,17 +1807,17 @@ class ConnectionState:
 
     # Application commands (guild)
 
-    async def fetch_guild_commands(self, guild_id: int) -> List[ApplicationCommand]:
+    async def fetch_guild_commands(self, guild_id: int) -> List[APIApplicationCommand]:
         results = await self.http.get_guild_commands(self.application_id, guild_id)  # type: ignore
         return [application_command_factory(data) for data in results]
 
-    async def fetch_guild_command(self, guild_id: int, command_id: int) -> ApplicationCommand:
+    async def fetch_guild_command(self, guild_id: int, command_id: int) -> APIApplicationCommand:
         result = await self.http.get_guild_command(self.application_id, guild_id, command_id)  # type: ignore
         return application_command_factory(result)
 
     async def create_guild_command(
         self, guild_id: int, application_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         result = await self.http.upsert_guild_command(
             self.application_id, guild_id, application_command.to_dict()  # type: ignore
         )
@@ -1825,7 +1827,7 @@ class ConnectionState:
 
     async def edit_guild_command(
         self, guild_id: int, command_id: int, new_command: ApplicationCommand
-    ) -> ApplicationCommand:
+    ) -> APIApplicationCommand:
         result = await self.http.edit_guild_command(
             self.application_id, guild_id, command_id, new_command.to_dict()  # type: ignore
         )
@@ -1841,13 +1843,13 @@ class ConnectionState:
 
     async def bulk_overwrite_guild_commands(
         self, guild_id: int, application_commands: List[ApplicationCommand]
-    ) -> List[ApplicationCommand]:
+    ) -> List[APIApplicationCommand]:
         payload = [cmd.to_dict() for cmd in application_commands]
         results = await self.http.bulk_upsert_guild_commands(
             self.application_id, guild_id, payload  # type: ignore
         )
         commands = [application_command_factory(data) for data in results]
-        self._guild_application_commands[guild_id] = {cmd.id: cmd for cmd in commands}  # type: ignore
+        self._guild_application_commands[guild_id] = {cmd.id: cmd for cmd in commands}
         return commands
 
     # Application command permissions

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3873,14 +3873,6 @@ MessageCommand
 .. autoclass:: MessageCommand()
     :members:
 
-APIApplicationCommand
-~~~~~~~~~~~~~~~~~~~~~
-
-.. attributetable:: APIApplicationCommand
-
-.. autoclass:: APIApplicationCommand()
-    :members:
-
 APISlashCommand
 ~~~~~~~~~~~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3873,6 +3873,38 @@ MessageCommand
 .. autoclass:: MessageCommand()
     :members:
 
+APIApplicationCommand
+~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: APIApplicationCommand
+
+.. autoclass:: APIApplicationCommand()
+    :members:
+
+APISlashCommand
+~~~~~~~~~~~~~~~
+
+.. attributetable:: APISlashCommand
+
+.. autoclass:: APISlashCommand()
+    :members:
+
+APIUserCommand
+~~~~~~~~~~~~~~
+
+.. attributetable:: APIUserCommand
+
+.. autoclass:: APIUserCommand()
+    :members:
+
+APIMessageCommand
+~~~~~~~~~~~~~~~~~
+
+.. attributetable:: APIMessageCommand
+
+.. autoclass:: APIMessageCommand()
+    :members:
+
 Option
 ~~~~~~
 


### PR DESCRIPTION
## Summary

This PR introduces new `API*Command` types, subtypes of the respective `*Command` types but with the additional fields returned by the API, most importantly the `id`. These fields were previously present in `ApplicationCommand` but marked optional since no distinction was made between command objects sent to the API and those returned by it.
The core benefit of this is that the `id` in objects returned by `application_command_factory` is no longer optional.

<sup>fun fact: this fixes exactly one (1) pyright error! just 95 more to go, woo</sup>

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
