### PR TITLE
Improve member deserialization with separate user data

### DIFF
--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -432,11 +432,11 @@ class GuildScheduledEvent(Hashable):
         user: Union[User, Member]
 
         for data in raw_users:
+            user_data = data["user"]
             member_data = data.get("member")
             if member_data is not None and self.guild is not None:
-                member_data["user"] = data["user"]  # upgrade to MemberWithUser
-                user = self.guild.get_member(int(member_data["user"]["id"])) or Member(
-                    data=member_data, guild=self.guild, state=self._state
+                user = self.guild.get_member(int(user_data["id"])) or Member(
+                    data=member_data, user_data=user_data, guild=self.guild, state=self._state
                 )
             else:
                 user = self._state.store_user(data["user"])

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -402,7 +402,8 @@ class ApplicationCommandInteractionDataResolved:
                     guild
                     and guild.get_member(user_id)
                     or Member(
-                        data={**member, "user": user},  # type: ignore
+                        data=member,
+                        user_data=user,
                         guild=guild,  # type: ignore
                         state=state,
                     )

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -355,7 +355,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         self._roles: utils.SnowflakeList = utils.SnowflakeList(map(int, data["roles"]))
         self._client_status: Dict[Optional[str], str] = {None: "offline"}
         self.activities: Tuple[ActivityTypes, ...] = tuple()
-        self.nick: Optional[str] = data.get("nick", None)
+        self.nick: Optional[str] = data.get("nick")
         self.pending: bool = data.get("pending", False)
         self._avatar: Optional[str] = data.get("avatar")
         timeout_datetime = utils.parse_time(data.get("communication_disabled_until"))

--- a/disnake/types/member.py
+++ b/disnake/types/member.py
@@ -23,7 +23,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 from .snowflake import SnowflakeList
 from .user import User
@@ -34,18 +34,19 @@ class Nickname(TypedDict):
 
 
 class _OptionalMember(TypedDict, total=False):
-    avatar: str
-    nick: str
+    avatar: Optional[str]
+    nick: Optional[str]
     premium_since: str
     pending: bool
     permissions: str
+    communication_disabled_until: Optional[str]
 
 
 class BaseMember(_OptionalMember):
     roles: SnowflakeList
     joined_at: str
-    deaf: str
-    mute: str
+    deaf: bool
+    mute: bool
 
 
 class Member(BaseMember, total=False):

--- a/disnake/types/member.py
+++ b/disnake/types/member.py
@@ -33,33 +33,28 @@ class Nickname(TypedDict):
     nick: str
 
 
-class PartialMember(TypedDict):
+class _OptionalMember(TypedDict, total=False):
+    avatar: str
+    nick: str
+    premium_since: str
+    pending: bool
+    permissions: str
+
+
+class BaseMember(_OptionalMember):
     roles: SnowflakeList
     joined_at: str
     deaf: str
     mute: str
 
 
-class Member(PartialMember, total=False):
-    avatar: str
+class Member(BaseMember, total=False):
     user: User
-    nick: str
-    premium_since: str
-    pending: bool
-    permissions: str
 
 
-class _OptionalMemberWithUser(PartialMember, total=False):
-    avatar: str
-    nick: str
-    premium_since: str
-    pending: bool
-    permissions: str
-
-
-class MemberWithUser(_OptionalMemberWithUser):
+class MemberWithUser(BaseMember):
     user: User
 
 
 class UserWithMember(User, total=False):
-    member: _OptionalMemberWithUser
+    member: BaseMember

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -136,7 +136,7 @@ class BaseUser(_UserTag):
 
         return self
 
-    def _to_minimal_user_json(self) -> Dict[str, Any]:
+    def _to_minimal_user_json(self) -> UserPayload:
         return {
             "username": self.name,
             "id": self.id,


### PR DESCRIPTION
## Summary

This PR adds a new kwarg to `Member.__init__` which allows passing user data in separately, instead of modifying the member data at the call site. The functionality of `.types.member` is mostly unchanged, the types were just renamed a bit to make more sense.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
