### PR TITLE
feat: support disnake.Thread annotations in slash command params

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2297,7 +2297,9 @@ def _threaded_guild_channel_factory(channel_type: int):
     return cls, value
 
 
-def _channel_type_factory(cls: Type[disnake.abc.GuildChannel]) -> List[ChannelType]:
+def _channel_type_factory(
+    cls: Union[Type[disnake.abc.GuildChannel], Type[Thread]]
+) -> List[ChannelType]:
     return {
         disnake.abc.GuildChannel: list(ChannelType.__members__.values()),
         VocalGuildChannel: [ChannelType.voice, ChannelType.stage_voice],

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -448,7 +448,11 @@ class ParamInfo:
 
         self.type = type(self.choices[0].value)
 
-    def _parse_guild_channel(self, *channels: Type[disnake.abc.GuildChannel]) -> None:
+    def _parse_guild_channel(
+        self, *channels: Union[Type[disnake.abc.GuildChannel], Type[disnake.Thread]]
+    ) -> None:
+        # this variable continues to be GuildChannel because the type is still
+        # determined from the TYPE mapping in the class definition
         self.type = disnake.abc.GuildChannel
 
         if not self.channel_types:
@@ -497,13 +501,15 @@ class ParamInfo:
             self._parse_enum(annotation)
         elif get_origin(annotation) in (Union, UnionType):
             args = annotation.__args__
-            if all(issubclass_(channel, disnake.abc.GuildChannel) for channel in args):
+            if all(
+                issubclass_(channel, (disnake.abc.GuildChannel, disnake.Thread)) for channel in args
+            ):
                 self._parse_guild_channel(*args)
             else:
                 raise TypeError(
                     "Unions for anything else other than channels or a mentionable are not supported"
                 )
-        elif issubclass_(annotation, disnake.abc.GuildChannel):
+        elif issubclass_(annotation, (disnake.abc.GuildChannel, disnake.Thread)):
             self._parse_guild_channel(annotation)
         elif issubclass_(get_origin(annotation), collections.abc.Sequence):
             raise TypeError(


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
support disnake.Thread annotations in slash command params

![image](https://user-images.githubusercontent.com/71233171/150870687-4fa9f9f0-5b2c-4275-897d-ffeb7cc54683.png)
```py
@bot.slash_command(name="threads")
async def threads(inter: disnake.CommandInteraction, thread: disnake.Thread):
    """Threads"""
    await inter.response.send_message("ok.", ephemeral=True)
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
