### PR TITLE
feat: jump to channel properties

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -539,6 +539,19 @@ class GuildChannel(ABC):
         category = self.guild.get_channel(self.category_id)
         return bool(category and category.overwrites == self.overwrites)
 
+    @property
+    def jump_url(self) -> str:
+        """
+        A URL that can be used to jump to this channel.
+
+        .. versionadded:: 2.4
+
+        .. note::
+
+            This exists for all guild channels but may not be usable by the client for all guild channel types.
+        """
+        return f"https://discord.com/channels/{self.guild.id}/{self.id}"
+
     def permissions_for(
         self,
         obj: Union[Member, Role],

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2011,6 +2011,15 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         """:class:`datetime.datetime`: Returns the direct message channel's creation time in UTC."""
         return utils.snowflake_time(self.id)
 
+    @property
+    def jump_url(self) -> str:
+        """
+        A URL that can be used to jump to this channel.
+
+        .. versionadded:: 2.4
+        """
+        return f"https://discord.com/channels/@me/{self.id}"
+
     def permissions_for(
         self,
         obj: Any = None,

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -332,6 +332,15 @@ class Thread(Messageable, Hashable):
         )
         return self._archiver_id
 
+    @property
+    def jump_url(self) -> str:
+        """
+        A URL that can be used to jump to this thread.
+
+        .. versionadded:: 2.4
+        """
+        return f"https://discord.com/channels/{self.guild.id}/{self.id}"
+
     def is_private(self) -> bool:
         """Whether the thread is a private thread.
 


### PR DESCRIPTION
## Summary
feat: jump to channel properties

these were not added to GroupChannel since
1) the integration has been discontinued and
2) those GroupChannels don't show up in the official user interface so jump urls aren't useful

added jump_url to all guild channels because of the tentative text in voice feature
and I don't see it being a problem to implement it this way
it was also the easiest way to implement it.


Closes #315 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
