### PR TITLE
touch up permissions

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -607,7 +607,7 @@ class GuildChannel(ABC):
         # The operation first takes into consideration the denied
         # and then the allowed.
 
-        # Timeouted users have only read_messages and read_message_history
+        # Timeouted users have only view_channel and read_message_history
         # if they already have them.
         if ignore_timeout is not MISSING and isinstance(obj, Role):
             raise TypeError("ignore_timeout is only supported for disnake.Member objects")
@@ -695,15 +695,15 @@ class GuildChannel(ABC):
             base.embed_links = False
             base.attach_files = False
 
-        # if you can't read a channel then you have no permissions there
-        if not base.read_messages:
+        # if you can't view a channel then you have no permissions there
+        if not base.view_channel:
             denied = Permissions.all_channel()
             base.value &= ~denied.value
 
         # if you have a timeout then you can't have any permissions
         # except read messages and read message history
         if not ignore_timeout and obj.current_timeout:
-            denied = Permissions(read_messages=True, read_message_history=True)
+            denied = Permissions(view_channel=True, read_message_history=True)
             base.value &= denied.value
 
         return base
@@ -781,7 +781,7 @@ class GuildChannel(ABC):
 
         Setting allow and deny: ::
 
-            await message.channel.set_permissions(message.author, read_messages=True,
+            await message.channel.set_permissions(message.author, view_channel=True,
                                                                   send_messages=False)
 
         Deleting overwrites ::
@@ -792,7 +792,7 @@ class GuildChannel(ABC):
 
             overwrite = disnake.PermissionOverwrite()
             overwrite.send_messages = False
-            overwrite.read_messages = True
+            overwrite.view_channel = True
             await channel.set_permissions(member, overwrite=overwrite)
 
         Parameters

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2024,7 +2024,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
 
         Actual direct messages do not really have the concept of permissions.
 
-        This returns all the :meth:`Permissions.private_channel` set to ``True``.
+        This returns all the :meth:`Permissions.private_channel` permissions set to ``True``.
 
         Parameters
         -----------

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2174,7 +2174,7 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
 
         Actual direct messages do not really have the concept of permissions.
 
-        This returns all the :meth:`Permissions.private_channel` set to ``True``.
+        This returns all the :meth:`Permissions.private_channel` permissions set to ``True``.
 
         This also checks the kick_members permission if the user is the owner.
 

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2024,10 +2024,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
 
         Actual direct messages do not really have the concept of permissions.
 
-        This returns all the Text related permissions set to ``True`` except:
-
-        - :attr:`~Permissions.send_tts_messages`: You cannot send TTS messages in a DM.
-        - :attr:`~Permissions.manage_messages`: You cannot delete others messages in a DM.
+        This returns all the :meth:`Permissions.private_channel` set to ``True``.
 
         Parameters
         -----------
@@ -2045,11 +2042,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
             The resolved permissions.
         """
 
-        base = Permissions.text()
-        base.read_messages = True
-        base.send_tts_messages = False
-        base.manage_messages = False
-        return base
+        return Permissions.private_channel()
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.
@@ -2181,10 +2174,7 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
 
         Actual direct messages do not really have the concept of permissions.
 
-        This returns all the Text related permissions set to ``True`` except:
-
-        - :attr:`~Permissions.send_tts_messages`: You cannot send TTS messages in a DM.
-        - :attr:`~Permissions.manage_messages`: You cannot delete others messages in a DM.
+        This returns all the :meth:`Permissions.private_channel` set to ``True``.
 
         This also checks the kick_members permission if the user is the owner.
 
@@ -2203,11 +2193,7 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
             The resolved permissions for the user.
         """
 
-        base = Permissions.text()
-        base.read_messages = True
-        base.send_tts_messages = False
-        base.manage_messages = False
-        base.mention_everyone = True
+        base = Permissions.private_channel()
 
         if obj.id == self.owner_id:
             base.kick_members = True

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -242,7 +242,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
     @property
     def members(self) -> List[Member]:
         """List[:class:`Member`]: Returns all members that can see this channel."""
-        return [m for m in self.guild.members if self.permissions_for(m).read_messages]
+        return [m for m in self.guild.members if self.permissions_for(m).view_channel]
 
     @property
     def threads(self) -> List[Thread]:

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1150,8 +1150,8 @@ class Guild(Hashable):
         .. code-block:: python3
 
             overwrites = {
-                guild.default_role: disnake.PermissionOverwrite(read_messages=False),
-                guild.me: disnake.PermissionOverwrite(read_messages=True)
+                guild.default_role: disnake.PermissionOverwrite(view_channel=False),
+                guild.me: disnake.PermissionOverwrite(view_channel=True)
             }
 
             channel = await guild.create_text_channel('secret', overwrites=overwrites)

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -178,7 +178,6 @@ class Interaction:
         self.guild_locale: Optional[str] = data.get("guild_locale")
         # one of user and member will always exist
         self.author: Union[User, Member] = MISSING
-        self._permissions: int = 0
 
         if self.guild_id and (member := data.get("member")):
             guild: Guild = self.guild or Object(id=self.guild_id)  # type: ignore
@@ -190,6 +189,7 @@ class Interaction:
             self._permissions = int(member.get("permissions", 0))
         elif user := data.get("user"):
             self.author = self._state.store_user(user)
+            self._permissions = None
 
     @property
     def bot(self) -> AnyBot:
@@ -243,9 +243,11 @@ class Interaction:
     def permissions(self) -> Permissions:
         """:class:`Permissions`: The resolved permissions of the member in the channel, including overwrites.
 
-        In a non-guild context where this doesn't apply, an empty permissions object is returned.
+        In a non-guild context this will be an instance of :meth:`Permissions.private_channel`.
         """
-        return Permissions(self._permissions)
+        if self._permissions is not None:
+            return Permissions(self._permissions)
+        return Permissions.private_channel()
 
     @utils.cached_slot_property("_cs_response")
     def response(self) -> InteractionResponse:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -178,6 +178,7 @@ class Interaction:
         self.guild_locale: Optional[str] = data.get("guild_locale")
         # one of user and member will always exist
         self.author: Union[User, Member] = MISSING
+        self._permissions = None
 
         if self.guild_id and (member := data.get("member")):
             guild: Guild = self.guild or Object(id=self.guild_id)  # type: ignore
@@ -189,7 +190,6 @@ class Interaction:
             self._permissions = int(member.get("permissions", 0))
         elif user := data.get("user"):
             self.author = self._state.store_user(user)
-            self._permissions = None
 
     @property
     def bot(self) -> AnyBot:

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
+from functools import wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -62,6 +63,7 @@ def make_permission_alias(alias: str) -> Callable[[Callable[[Any], int]], permis
 
 
 def cached_creation(func):
+    @wraps(func)
     def wrapped(cls):
         try:
             value = func.__stored_value__

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -377,6 +377,34 @@ class Permissions(BaseFlags):
             administrator=True,
         )
 
+    @classmethod
+    @cached_creation
+    def private_channel(cls: Type[P]) -> P:
+        """A factor method that creates a :class:`Permissions` with the
+        best representation of a PrivateChannel's permissions.
+
+        This exists to maintain compatibility with other channel types.
+
+        This is equivalent to :meth:`Permissions.text` with :attr:`~Permissions.view_channel` with the following set to False:
+        - :attr:`~Permissions.send_tts_messages`: You cannot send TTS messages in a DM.
+        - :attr:`~Permissions.manage_messages`: You cannot delete others messages in a DM.
+        - :attr:`~Permissions.manage_threads`: You cannot manage threads in a DM.
+        - :attr:`~Permissions.send_messages_in_threads`: You cannot make threads in a DM.
+        - :attr:`~Permissions.create_public_threads`: You cannot make public threads in a DM.
+        - :attr:`~Permissions.create_private_threads`: You cannot make private threads in a DM.
+
+        .. versionadded:: 2.4
+        """
+        base = cls.text()
+        base.read_messages = True
+        base.send_tts_messages = False
+        base.manage_messages = False
+        base.manage_threads = False
+        base.send_messages_in_threads = False
+        base.create_private_threads = False
+        base.create_private_threads = False
+        return base
+
     def update(self, **kwargs: bool) -> None:
         r"""Bulk updates this permission object.
 

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -492,16 +492,19 @@ class Permissions(BaseFlags):
         return 1 << 9
 
     @flag_value
-    def read_messages(self) -> int:
-        """:class:`bool`: Returns ``True`` if a user can read messages from all or specific text channels."""
-        return 1 << 10
-
-    @make_permission_alias("read_messages")
     def view_channel(self) -> int:
-        """:class:`bool`: An alias for :attr:`read_messages`.
+        """:class:`bool`: Returns ``True`` if a user can view all or specific channels.
 
         .. versionadded:: 1.3
+
+        .. versionchanged:: 2.4
+            :attr:`~Permissions.read_messages` is now an alias of :attr:`~Permissions.view_channel`.
         """
+        return 1 << 10
+
+    @make_permission_alias("view_channel")
+    def read_messages(self) -> int:
+        """:class:`bool`: An alias for :attr:`view_channel`."""
         return 1 << 10
 
     @flag_value


### PR DESCRIPTION
## Summary

- added Permissions.private_channel() classmethod
- Interaction.permissions returns an instance of the above in a private channel
- switched the view_channel and read_messages aliases

closes #312
closes #313

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
