### PR TITLE
fix(views): views in interaction responses

### DIFF
--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -836,7 +836,16 @@ class InteractionResponse:
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 
-            self._parent._state.store_view(view, self._parent.id)
+            key_id = None
+            if self._parent.type is InteractionType.component:
+                try:
+                    key_id = (await self._parent.original_message()).id
+                except HTTPException:
+                    pass
+            else:
+                key_id = self._parent.id
+
+            self._parent._state.store_view(view, key_id)
 
         if delete_after is not MISSING:
             await self._parent.delete_original_message(delay=delete_after)

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -433,7 +433,7 @@ class Interaction:
         state = _InteractionMessageState(self, self._state)
         message = InteractionMessage(state=state, channel=self.channel, data=data)  # type: ignore
         if view and not view.is_finished():
-            self._state.store_view(view, message.id)
+            self._state.store_view(view, self.id)
         return message
 
     async def delete_original_message(self, *, delay: float = None) -> None:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -914,7 +914,15 @@ class InteractionResponse:
         parent = self._parent
         msg: Optional[Message] = getattr(parent, "message", None)
         state = parent._state
-        message_id = msg.id if msg else None
+
+        id_for_view: Optional[int]
+        if msg is None:
+            id_for_view = None
+        elif msg.interaction is None:
+            id_for_view = msg.id
+        else:
+            id_for_view = msg.interaction.id
+
         if parent.type is not InteractionType.component:
             return
 
@@ -961,8 +969,8 @@ class InteractionResponse:
             raise TypeError("cannot mix view and components keyword arguments")
 
         if view is not MISSING:
-            if message_id:
-                state.prevent_view_updates_for(message_id)
+            if id_for_view:
+                state.prevent_view_updates_for(id_for_view)
             payload["components"] = [] if view is None else view.to_components()
 
         if components is not MISSING:
@@ -984,7 +992,7 @@ class InteractionResponse:
                     f.close()
 
         if view and not view.is_finished():
-            state.store_view(view, message_id)
+            state.store_view(view, id_for_view)
 
         self._responded = True
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -830,7 +830,7 @@ class InteractionResponse:
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 
-            self._parent._state.store_view(view)
+            self._parent._state.store_view(view, self._parent.id)
 
         if delete_after is not MISSING:
             await self._parent.delete_original_message(delay=delete_after)

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -535,12 +535,21 @@ class ViewStore:
 
     def dispatch(self, interaction: MessageInteraction):
         self.__verify_integrity()
-        message_id: Optional[int] = interaction.message and interaction.message.id
+
+        # this can be None, message.id or message.interaction.id
+        main_id: Optional[int]
+        if interaction.message is None:
+            main_id = None
+        elif interaction.message.interaction is None:
+            main_id = interaction.message.id
+        else:
+            main_id = interaction.message.interaction.id
+
         component_type = try_enum_to_int(interaction.data.component_type)
         custom_id = interaction.data.custom_id
-        key = (component_type, message_id, custom_id)
-        # Fallback to None message_id searches in case a persistent view
-        # was added without an associated message_id
+        key = (component_type, main_id, custom_id)
+        # Fallback to None main_id searches in case a persistent view
+        # was added without an associated main_id
         value = self._views.get(key) or self._views.get((component_type, None, custom_id))
         if value is None:
             return


### PR DESCRIPTION
## Summary

Currently views fail to do the job if you send them with interaction responses.

Example:
```py
class TestView(disnake.ui.View):
    def __init__(self):
        super().__init__(timeout=60)

    @disnake.ui.button(label="Hello world", custom_id="test")
    async def on_test(self, button, inter):
        button.label = "Goodbye world"
        button.disabled = True
        await inter.response.edit_message(view=self)
        self.stop()

@bot.slash_command()
async def test(inter):
    await inter.send("...", view=TestView())
```

Invoke this command twice and then click the buttons under each message.

**Expected result:** both views respond

**Actual result:** only one view responds

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
