### PR TITLE
feat(Thread): dispatch `on_thread_create` event and add `_newly_created`

### DIFF
--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1034,7 +1034,7 @@ class ConnectionState:
             _log.debug("THREAD_CREATE referencing an unknown guild ID: %s. Discarding", guild_id)
             return
 
-        if data.get("newly_created") is None:
+        if "newly_created" not in data:
             # Skipping since we just want thread create event,
             # as thread join is handled in thread_members_update.
             return

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1041,7 +1041,7 @@ class ConnectionState:
 
         thread = Thread(guild=guild, state=guild._state, data=data)
         guild._add_thread(thread)
-        if thread._newly_created is True:
+        if thread._newly_created:
             self.dispatch("thread_create", thread)
 
     def parse_thread_update(self, data) -> None:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1034,11 +1034,15 @@ class ConnectionState:
             _log.debug("THREAD_CREATE referencing an unknown guild ID: %s. Discarding", guild_id)
             return
 
+        if data.get("newly_created") is None:
+            # Skipping since we just want thread create event,
+            # as thread join is handled in thread_members_update.
+            return
+
         thread = Thread(guild=guild, state=guild._state, data=data)
-        has_thread = guild.get_thread(thread.id)
         guild._add_thread(thread)
-        if not has_thread:
-            self.dispatch("thread_join", thread)
+        if thread._newly_created is True:
+            self.dispatch("thread_create", thread)
 
     def parse_thread_update(self, data) -> None:
         guild_id = int(data["guild_id"])

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -148,6 +148,7 @@ class Thread(Messageable, Hashable):
         "auto_archive_duration",
         "archive_timestamp",
         "create_timestamp",
+        "_newly_created",
         "_type",
         "_state",
         "_members",
@@ -182,6 +183,7 @@ class Thread(Messageable, Hashable):
         self.slowmode_delay = data.get("rate_limit_per_user", 0)
         self.message_count = data.get("message_count")
         self.member_count = data.get("member_count")
+        self._newly_created: Optional[bool] = data.get("newly_created")
         self._unroll_metadata(data["thread_metadata"])
 
         try:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -767,7 +767,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     .. versionchanged:: 2.4
 
         This is now only dispatched when the bot joins a thread, not when a thread is created.
-        If you want an event for when a thread is created, use :ref:`on_thread_created` instead.
+        If you want an event for when a thread is created, use :ref:`on_thread_create` instead.
 
     Note that you can get the guild from :attr:`Thread.guild`.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -762,8 +762,12 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_thread_join(thread)
 
-    Called whenever a thread is joined or created. Note that from the API's perspective there is no way to
-    differentiate between a thread being created or the bot joining a thread.
+    Called whenever your bot joins a thread.
+
+    .. versionchanged:: 2.4
+
+        This is now only dispatched when the bot joins a thread, not when a thread is created.
+        If you want an event for when a thread is created, use :ref:`on_thread_created` instead.
 
     Note that you can get the guild from :attr:`Thread.guild`.
 
@@ -792,6 +796,19 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     .. versionadded:: 2.0
 
     :param thread: The thread that got removed.
+    :type thread: :class:`Thread`
+
+.. function:: on_thread_create(thread)
+
+    Called whenever a thread is created.
+
+    Note that you can get the guild from :attr:`Thread.guild`.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. versionadded:: 2.4
+
+    :param thread: The thread that got created.
     :type thread: :class:`Thread`
 
 .. function:: on_thread_delete(thread)


### PR DESCRIPTION
## Summary

1. Added `Thread._newly_created` (it's private since in the other events, such as `on_thread_join` etc, it gets the cached Thread, so having that attribute public would be inaccurate with the actual behavior)
2. Added `on_thread_create` event, and deleted handling of `on_thread_join` in `parse_thread_create` since Discord seems to call `THREAD_MEMBERS_UPDATE` (for when a user joins a thread) and `THREAD_CREATE` (for the same purpose), so it was dispatching `on_thread_join` twice (pretty sure it was an issue before too)
<sup>A little more context can be found [here](https://canary.discord.com/channels/808030843078836254/937828640463401001/939658154613039175)</sup>

referece:
https://github.com/discord/discord-api-docs/commit/1875d80011ea62bf555ce807459ccf97950291e9

Closes #323

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
