### PR TITLE
Fix undesired behavior

### DIFF
--- a/examples/views/disable_view.py
+++ b/examples/views/disable_view.py
@@ -35,6 +35,9 @@ class MyView(disnake.ui.View):
         # view = None removes the view
         await interaction.response.edit_message(view=None)
 
+        # Prevents on_timeout from being triggered after the view is removed
+        self.stop()
+
 
 @bot.command()
 async def view(ctx):


### PR DESCRIPTION
## Summary

`on_timeout` gets triggered even after the view is removed via the `remove` button, which causes a disabled `disable` button to appear.

**Expected behavior:** View is stopped after either of the buttons are pressed

**Actual behavior:** View times out if the `remove` button is pressed.

**Solution:** Call `self.stop()` in the `remove` button.
## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
