### PR TITLE
fix(Guild): missing return in `get_command`

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -433,15 +433,19 @@ class Guild(Hashable):
         return role
 
     def get_command(self, application_command_id: int, /) -> Optional[APIApplicationCommand]:
-        """
-        Gets a cached application command matching the specified ID.
+        """Gets a cached application command matching the specified ID.
 
         Parameters
         ----------
-        name: :class:`int`
-            the ID to compare to.
+        application_command_id: :class:`int`
+            The application command ID to search for.
+
+        Returns
+        -------
+        Optional[Union[:class:`.APIUserCommand`, :class:`.APIMessageCommand`, :class:`.APISlashCommand`]]
+            The application command if found, or ``None`` otherwise.
         """
-        self._state._get_guild_application_command(self.id, application_command_id)
+        return self._state._get_guild_application_command(self.id, application_command_id)
 
     def get_command_named(self, name: str, /) -> Optional[APIApplicationCommand]:
         """


### PR DESCRIPTION
## Summary

as title, fixes a missing `return` and updates the docstring (partially taken from #275)

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
