### PR TITLE
Making guild.chunk() return a list of guild members.

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3228,13 +3228,18 @@ class Guild(Hashable):
         -------
         ClientException
             The members intent is not enabled.
+
+        Returns
+        --------
+        Optional[List[:class:`Member`]]
+             Returns a list of all the members within the guild.
         """
 
         if not self._state._intents.members:
             raise ClientException("Intents.members must be enabled to use this.")
 
         if not self._state.is_guild_evicted(self):
-            await self._state.chunk_guild(self, cache=cache)
+            return await self._state.chunk_guild(self, cache=cache)
 
     async def query_members(
         self,

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3144,7 +3144,6 @@ class Guild(Hashable):
 
     async def widget(self) -> Widget:
         """|coro|
-        
         Returns the widget of the guild.
 
         .. note::

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3144,7 +3144,7 @@ class Guild(Hashable):
 
     async def widget(self) -> Widget:
         """|coro|
-
+        
         Returns the widget of the guild.
 
         .. note::

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3211,7 +3211,9 @@ class Guild(Hashable):
 
     async def chunk(self, *, cache: bool = True) -> None:
         """|coro|
-
+        
+        Returns a :class:`list` of all guild members.
+        
         Requests all members that belong to this guild. In order to use this,
         :meth:`Intents.members` must be enabled.
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3209,7 +3209,7 @@ class Guild(Hashable):
 
         await self._state.http.edit_widget(self.id, payload=payload, reason=reason)
 
-    async def chunk(self, *, cache: bool = True) -> None:
+    async def chunk(self, *, cache: bool = True) -> Optional[List[Member]]:
         """|coro|
         
         Returns a :class:`list` of all guild members.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3210,9 +3210,9 @@ class Guild(Hashable):
 
     async def chunk(self, *, cache: bool = True) -> Optional[List[Member]]:
         """|coro|
-        
+
         Returns a :class:`list` of all guild members.
-        
+
         Requests all members that belong to this guild. In order to use this,
         :meth:`Intents.members` must be enabled.
 


### PR DESCRIPTION
This was previously an undocumented feature of Danny’s Discord.py that I frequently use when chunking a guild without cache saving. Unfortunately it appears to have been removed in Disnake, despite its excellent use cases. 

I have added both documentation & re-added the functionality.
Example use case: members = await guild.chunk(cache=False)

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
