### PR TITLE
feat(interactions): add `attachments` parameter to `InteractionResponse.edit_message`

### DIFF
--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -28,7 +28,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union, cast
 
 from .. import utils
 from ..app_commands import OptionChoice
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
     )
     from ..ui.action_row import Components
     from ..ui.view import View
+    from .message import MessageInteraction
 
     InteractionChannel = Union[
         VoiceChannel,
@@ -95,6 +96,8 @@ if TYPE_CHECKING:
     ]
 
     AnyBot = Union[Bot, AutoShardedBot]
+else:
+    MessageInteraction = ...  # only used for typecasting
 
 MISSING: Any = utils.MISSING
 
@@ -843,7 +846,7 @@ class InteractionResponse:
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
         files: List[File] = MISSING,
-        # attachments: List[Attachment] = MISSING,
+        attachments: List[Attachment] = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         view: Optional[View] = MISSING,
         components: Optional[Components] = MISSING,
@@ -854,17 +857,10 @@ class InteractionResponse:
         a component interaction.
 
         .. note::
-            The ``attachments`` parameter is currently non-functional, removing/replacing existing
-            attachments using this method is presently not supported (API limitation, see
-            `this <https://github.com/discord/discord-api-docs/discussions/3335>`_).
-            As a workaround, respond to the interaction first (e.g. using :meth:`.defer`),
-            then edit the message using :meth:`Interaction.edit_original_message`.
-
-        .. note::
             If the original message has embeds with images that were created from local files
             (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
             those images will be removed if the message's attachments are edited in any way
-            (i.e. by setting ``file``/``files``, or adding an embed with local files).
+            (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
 
         Parameters
         -----------
@@ -888,6 +884,12 @@ class InteractionResponse:
             Files will be appended to the message.
 
             .. versionadded:: 2.2
+        attachments: List[:class:`Attachment`]
+            A list of attachments to keep in the message. If ``[]`` is passed
+            then all existing attachments are removed.
+            Keeps existing attachments if not provided.
+
+            .. versionadded:: 2.4
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         view: Optional[:class:`~disnake.ui.View`]
@@ -917,6 +919,7 @@ class InteractionResponse:
         message_id = msg.id if msg else None
         if parent.type is not InteractionType.component:
             return
+        parent = cast(MessageInteraction, parent)
 
         payload = {}
         if content is not MISSING:
@@ -954,8 +957,12 @@ class InteractionResponse:
         elif previous_mentions is not None:
             payload["allowed_mentions"] = previous_mentions.to_dict()
 
-        # if attachments is not MISSING:
-        #     payload["attachments"] = [a.to_dict() for a in attachments]
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        if attachments is MISSING and (file or files):
+            attachments = parent.message.attachments
+        if attachments is not MISSING:
+            payload["attachments"] = [a.to_dict() for a in attachments]
 
         if view is not MISSING and components is not MISSING:
             raise TypeError("cannot mix view and components keyword arguments")


### PR DESCRIPTION
## Summary

This PR adds the `attachments` parameter to `InteractionResponse.edit_message`, which was disabled previously as the API didn't support it.

ref: https://github.com/discord/discord-api-docs/discussions/3335

<img src="https://user-images.githubusercontent.com/8530778/153304809-fe17919e-d504-4686-9fdf-3a8b7f1b0201.gif" width=500 />


## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
