### PR TITLE
fix: slash commands options with no description

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -195,7 +195,7 @@ class Option:
     ):
         self.name: str = name.lower()
         _validate_name(self.name)
-        self.description: str = description or "\u200b"
+        self.description: str = description or "-"
         self.type: OptionType = enum_if_int(OptionType, type) or OptionType.string
         self.required: bool = required
         self.options: List[Option] = options or []

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -573,7 +573,7 @@ class ParamInfo:
 
         return Option(
             name=self.name,
-            description=self.description or "\u200b",
+            description=self.description or "-",
             type=self.discord_type,
             required=self.required,
             choices=self.choices or None,


### PR DESCRIPTION
## Summary

Discord did an API change, making options in slash commands with no description broken, since Discord doesn't allow `\u200b`.

I'm not sure if Discord is going to fix this, but either way, using `-` is better

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
