### PR TITLE
Backport #338 to 2.3

### DIFF
--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -13,7 +13,7 @@ __title__ = "disnake"
 __author__ = "Rapptz, EQUENOS"
 __license__ = "MIT"
 __copyright__ = "Copyright 2015-present Rapptz, 2021-present EQUENOS"
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
@@ -72,6 +72,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=2, minor=3, micro=1, releaselevel="beta", serial=0)
+version_info: VersionInfo = VersionInfo(major=2, minor=3, micro=2, releaselevel="beta", serial=0)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -475,7 +475,7 @@ class ParamInfo:
 
         return Option(
             name=self.name,
-            description=self.description or "\u200b",
+            description=self.description or "-",
             type=self.discord_type,
             required=self.required,
             choices=self.choices or None,

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -12,6 +12,17 @@ This page keeps a detailed human friendly rendering of what's new and changed
 in specific versions.
 
 
+.. _vp2p3p2:
+
+v2.3.2
+------
+
+Bug Fixes
+~~~~~~~~~
+
+- Fix invalid default value for application command option descriptions (:issue:`338`)
+
+
 .. _vp2p3p1:
 
 v2.3.1
@@ -219,6 +230,17 @@ Miscellaneous
 - Add guide for configuring inviting a bot through its profile (:issue:`153`)
 - Rewrite project README (:issue:`191`)
 - Improve examples (:issue:`143`)
+
+
+.. _vp2p2p3:
+
+v2.2.3
+------
+
+Bug Fixes
+~~~~~~~~~
+
+- Fix invalid default value for application command option descriptions (:issue:`338`)
 
 
 .. _vp2p2p2:


### PR DESCRIPTION
## Summary

Backport of #338 for 2.3, bumps version to 2.3.2 and adds changelog for new 2.2.x and 2.3.x versions (the former is already in the [v2.2.x branch](https://github.com/DisnakeDev/disnake/tree/v2.2.x), but included again here for rtd).

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
