### PR TITLE
fix(slashcmd): improve handling of uppercase slash command names

### DIFF
--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -375,8 +375,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
             default_permission=default_permission,
         )
         # `SlashCommand.__init__` converts names to lowercase, need to use that name here as well
-        self.name = self.body.name
-        self.qualified_name = self.name
+        self.qualified_name = self.name = self.body.name
 
     @property
     def description(self) -> str:

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -149,7 +149,12 @@ class SubCommandGroup(InvokableApplicationCommand):
         self.option = Option(
             name=self.name, description="-", type=OptionType.sub_command_group, options=[]
         )
+        self.name = self.option.name
         self.qualified_name: str = ""
+
+    @property
+    def body(self) -> Option:
+        return self.option
 
     def sub_command(
         self,
@@ -254,6 +259,7 @@ class SubCommand(InvokableApplicationCommand):
             type=OptionType.sub_command,
             options=options,
         )
+        self.name = self.option.name
         self.qualified_name = ""
 
     @property
@@ -368,6 +374,9 @@ class InvokableSlashCommand(InvokableApplicationCommand):
             options=options or [],
             default_permission=default_permission,
         )
+        # `SlashCommand.__init__` converts names to lowercase, need to use that name here as well
+        self.name = self.body.name
+        self.qualified_name = self.name
 
     @property
     def description(self) -> str:


### PR DESCRIPTION
## Summary

This PR fixes command caching and `InvokableSlashCommand.qualified_name` for names with uppercase chars, as the inner object (`body`/`option`) converts the name to lowercase, but command caching uses the (unmodified) `InvokableApplicationCommand.name` instead of `.body.name`.
Also adds `SubCommandGroup.body` which was missing before, to match the other types.

fixes #336

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
