### PR TITLE
`GuildChannel.set_permissions` kwargs can be `None`

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -748,7 +748,7 @@ class GuildChannel(ABC):
         target: Union[Member, Role],
         *,
         reason: Optional[str] = ...,
-        **permissions: bool,
+        **permissions: Optional[bool],
     ) -> None:
         ...
 


### PR DESCRIPTION
## Summary

They're only used to create a `PermissionOverwrite`, [which accepts `Optional[bool]`](https://github.com/DisnakeDev/disnake/blob/5d1f3b2fb8d674f4cb55022031abbb7b4b6c6da6/disnake/permissions.py#L852).




## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
