### PR TITLE
fix: improve components parameter docs and `isinstance` check

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1386,12 +1386,12 @@ class Messageable:
             .. versionadded:: 1.6
 
         view: :class:`.ui.View`
-            A Discord UI View to add to the message. This can not be mixed with ``components``.
+            A Discord UI View to add to the message. This cannot be mixed with ``components``.
 
             .. versionadded:: 2.0
 
         components: |components_type|
-            A list of components to include in the message. This can not be mixed with ``view``.
+            A list of components to include in the message. This cannot be mixed with ``view``.
 
             .. versionadded:: 2.4
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -376,10 +376,10 @@ class Interaction:
             .. versionadded:: 2.2
 
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. If ``None`` is passed then
-            the view is removed. This can not be mixed with ``components``.
+            The updated view to update this message with. This cannot be mixed with ``components``.
+            If ``None`` is passed then the view is removed.
         components: Optional[|components_type|]
-            A list of components to update this message with. This can not be mixed with ``view``.
+            A list of components to update this message with. This cannot be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
@@ -549,9 +549,9 @@ class Interaction:
         tts: :class:`bool`
             Whether the message should be sent using text-to-speech.
         view: :class:`disnake.ui.View`
-            The view to send with the message. This can not be mixed with ``components``.
+            The view to send with the message. This cannot be mixed with ``components``.
         components: |components_type|
-            A list of components to send with the message. This can not be mixed with ``view``.
+            A list of components to send with the message. This cannot be mixed with ``view``.
 
             .. versionadded:: 2.4
 
@@ -733,9 +733,9 @@ class InteractionResponse:
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         view: :class:`disnake.ui.View`
-            The view to send with the message. This can not be mixed with ``components``.
+            The view to send with the message. This cannot be mixed with ``components``.
         components: |components_type|
-            A list of components to send with the message. This can not be mixed with ``view``.
+            A list of components to send with the message. This cannot be mixed with ``view``.
 
             .. versionadded:: 2.4
 
@@ -910,10 +910,10 @@ class InteractionResponse:
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. This can not be mixed with ``components``.
+            The updated view to update this message with. This cannot be mixed with ``components``.
             If ``None`` is passed then the view is removed.
         components: Optional[|components_type|]
-            A list of components to update this message with. This can not be mixed with ``view``.
+            A list of components to update this message with. This cannot be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
@@ -1249,10 +1249,10 @@ class InteractionMessage(Message):
             .. versionadded:: 2.2
 
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. This can not be mixed with ``components``.
+            The updated view to update this message with. This cannot be mixed with ``components``.
             If ``None`` is passed then the view is removed.
         components: Optional[|components_type|]
-            A list of components to update this message with. This can not be mixed with ``view``.
+            A list of components to update this message with. This cannot be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1524,13 +1524,13 @@ class Message(Hashable):
             .. versionadded:: 1.4
 
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. This can not be mixed with ``components``.
+            The updated view to update this message with. This cannot be mixed with ``components``.
             If ``None`` is passed then the view is removed.
 
             .. versionadded:: 2.0
 
         components: |components_type|
-            The updated components to update this message with. This can not be mixed with ``view``.
+            The updated components to update this message with. This cannot be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
@@ -2086,13 +2086,13 @@ class PartialMessage(Hashable):
                 Unlike :meth:`Message.edit`, this does not default to
                 :attr:`Client.allowed_mentions` if no object is passed.
         view: Optional[:class:`~disnake.ui.View`]
-            The updated view to update this message with. This can not be mixed with ``components``.
+            The updated view to update this message with. This cannot be mixed with ``components``.
             If ``None`` is passed then the view is removed.
 
             .. versionadded:: 2.0
 
         components: |components_type|
-            The updated components to update this message with. This can not be mixed with ``view``.
+            The updated components to update this message with. This cannot be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -293,13 +293,14 @@ def components_to_rows(components: Components) -> List[ActionRow]:
             if isinstance(component, ActionRow):
                 action_rows.append(component)
 
-            elif isinstance(component, list):
+            elif isinstance(component, Sequence):
                 action_rows.append(ActionRow(*component))
 
             else:
                 raise ValueError(
-                    "components must be a WrappedComponent, a list of ActionRow "
-                    "or a list of WrappedComponent"
+                    "`components` must be a `WrappedComponent` or `ActionRow`, "
+                    "a sequence/list of `WrappedComponent`s or `ActionRow`s, "
+                    "or a nested sequence/list of `WrappedComponent`s"
                 )
 
     if auto_row.width > 0:

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -738,13 +738,13 @@ class WebhookMessage(Message):
             .. versionadded:: 2.2
 
         view: Optional[:class:`~disnake.ui.View`]
-            The view to update this message with. If ``None`` is passed then
-            the view is removed. This can not be mixed with ``components``.
+            The view to update this message with. This cannot be mixed with ``components``.
+            If ``None`` is passed then the view is removed.
 
             .. versionadded:: 2.0
 
         components: Optional[|components_type|]
-            A list of components to update the message with. This can not be mixed with ``view``.
+            A list of components to update the message with. This cannot be mixed with ``view``.
             If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
@@ -1444,12 +1444,12 @@ class Webhook(BaseWebhook):
             The view to send with the message. You can only send a view
             if this webhook is not partial and has state attached. A
             webhook has state attached if the webhook is managed by the
-            library. This can not be mixed with ``components``.
+            library. This cannot be mixed with ``components``.
 
             .. versionadded:: 2.0
 
         components: |components_type|
-            A list of components to include in the message. This can not be mixed with ``view``.
+            A list of components to include in the message. This cannot be mixed with ``view``.
 
             .. versionadded:: 2.4
 
@@ -1675,12 +1675,12 @@ class Webhook(BaseWebhook):
         view: Optional[:class:`~disnake.ui.View`]
             The updated view to update this message with. If ``None`` is passed then
             the view is removed. The webhook must have state attached, similar to
-            :meth:`send`. This can not be mixed with ``components``.
+            :meth:`send`. This cannot be mixed with ``components``.
 
             .. versionadded:: 2.0
 
         components: |components_type|
-            A list of components to update this message with. This can not be mixed with ``view``.
+            A list of components to update this message with. This cannot be mixed with ``view``.
 
             .. versionadded:: 2.4
 


### PR DESCRIPTION
## Summary

This PR makes the documentation for the `view` and `components` kwarg more consistent with the rest of the docs (regarding spelling and order), updates the error message in `components_to_rows` to match the definition of the `Components` union, and fixes an `isinstance` check to use `Sequence` instead of `list`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
