### PR TITLE
chore: use the proper http method for joining threads and remove unused methods

### DIFF
--- a/disnake/http.py
+++ b/disnake/http.py
@@ -889,19 +889,6 @@ class HTTPClient:
     def edit_profile(self, payload: Dict[str, Any]) -> Response[user.User]:
         return self.request(Route("PATCH", "/users/@me"), json=payload)
 
-    def change_my_nickname(
-        self,
-        guild_id: Snowflake,
-        nickname: str,
-        *,
-        reason: Optional[str] = None,
-    ) -> Response[member.Nickname]:
-        r = Route("PATCH", "/guilds/{guild_id}/members/@me/nick", guild_id=guild_id)
-        payload = {
-            "nick": nickname,
-        }
-        return self.request(r, json=payload, reason=reason)
-
     def change_nickname(
         self,
         guild_id: Snowflake,
@@ -929,6 +916,16 @@ class HTTPClient:
             "PATCH", "/guilds/{guild_id}/voice-states/{user_id}", guild_id=guild_id, user_id=user_id
         )
         return self.request(r, json=payload)
+
+    def edit_my_member(
+        self,
+        guild_id: Snowflake,
+        *,
+        reason: Optional[str] = None,
+        **fields: Any,
+    ) -> Response[member.Nickname]:
+        r = Route("PATCH", "/guilds/{guild_id}/members/@me", guild_id=guild_id)
+        return self.request(r, json=fields, reason=reason)
 
     def edit_member(
         self,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -923,7 +923,7 @@ class HTTPClient:
         *,
         reason: Optional[str] = None,
         **fields: Any,
-    ) -> Response[member.Nickname]:
+    ) -> Response[member.MemberWithUser]:
         r = Route("PATCH", "/guilds/{guild_id}/members/@me", guild_id=guild_id)
         return self.request(r, json=fields, reason=reason)
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1082,7 +1082,7 @@ class HTTPClient:
 
     def join_thread(self, channel_id: Snowflake) -> Response[None]:
         return self.request(
-            Route("POST", "/channels/{channel_id}/thread-members/@me", channel_id=channel_id)
+            Route("PUT", "/channels/{channel_id}/thread-members/@me", channel_id=channel_id)
         )
 
     def add_user_to_thread(self, channel_id: Snowflake, user_id: Snowflake) -> Response[None]:

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -496,9 +496,6 @@ class HTTPClient:
             reason=reason,
         )
 
-    def logout(self) -> Response[None]:
-        return self.request(Route("POST", "/auth/logout"))
-
     # Group functionality
 
     def start_group(

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -829,7 +829,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         if nick is not MISSING:
             nick = nick or ""
             if me:
-                await http.change_my_nickname(guild_id, nick, reason=reason)
+                await http.edit_my_member(guild_id, nick=nick, reason=reason)
             else:
                 payload["nick"] = nick
 

--- a/disnake/types/member.py
+++ b/disnake/types/member.py
@@ -29,10 +29,6 @@ from .snowflake import SnowflakeList
 from .user import User
 
 
-class Nickname(TypedDict):
-    nick: str
-
-
 class _OptionalMember(TypedDict, total=False):
     avatar: Optional[str]
     nick: Optional[str]


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
https://discord.com/developers/docs/resources/channel#join-thread

> `PUT` `/channels/{channel.id}/thread-members/@me`

Additionally, removes an unused method from http.py, http.logout, while we're here. This endpoint can not be used by bots.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
