### PR TITLE
feat: add widget settings, widget images

### DIFF
--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -64,6 +64,7 @@ __all__ = (
     "GuildScheduledEventStatus",
     "GuildScheduledEventPrivacyLevel",
     "ThreadArchiveDuration",
+    "WidgetStyle",
 )
 
 
@@ -705,6 +706,17 @@ class ThreadArchiveDuration(Enum):
     day = 1440
     three_days = 4320
     week = 10080
+
+
+class WidgetStyle(Enum):
+    shield = "shield"
+    banner1 = "banner1"
+    banner2 = "banner2"
+    banner3 = "banner3"
+    banner4 = "banner4"
+
+    def __str__(self):
+        return self.value
 
 
 T = TypeVar("T")

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -67,6 +67,7 @@ from .enums import (
     VerificationLevel,
     VideoQualityMode,
     VoiceRegion,
+    WidgetStyle,
     try_enum,
 )
 from .errors import ClientException, HTTPException, InvalidArgument, InvalidData
@@ -84,7 +85,7 @@ from .stage_instance import StageInstance
 from .sticker import GuildSticker
 from .threads import Thread, ThreadMember
 from .user import User
-from .widget import Widget
+from .widget import Widget, WidgetSettings
 
 __all__ = ("Guild",)
 
@@ -261,6 +262,26 @@ class Guild(Hashable):
         Only available for manually fetched guilds.
 
         .. versionadded:: 2.3
+
+    widget_enabled: Optional[:class:`bool`]
+        Whether the widget is enabled.
+
+        .. versionadded:: 2.5
+
+        .. note::
+
+            This value is unreliable and will only be set after the guild was updated at least once.
+            Avoid using this and use :func:`widget_settings` instead.
+
+    widget_channel_id: Optional[:class:`int`]
+        The widget channel ID, if set.
+
+        .. versionadded:: 2.5
+
+        .. note::
+
+            This value is unreliable and will only be set after the guild was updated at least once.
+            Avoid using this and use :func:`widget_settings` instead.
     """
 
     __slots__ = (
@@ -289,6 +310,8 @@ class Guild(Hashable):
         "nsfw_level",
         "approximate_member_count",
         "approximate_presence_count",
+        "widget_enabled",
+        "widget_channel_id",
         "_members",
         "_channels",
         "_icon",
@@ -537,6 +560,8 @@ class Guild(Hashable):
         self.premium_progress_bar_enabled: bool = guild.get("premium_progress_bar_enabled", False)
         self.approximate_presence_count: Optional[int] = guild.get("approximate_presence_count")
         self.approximate_member_count: Optional[int] = guild.get("approximate_member_count")
+        self.widget_enabled: Optional[bool] = guild.get("widget_enabled")
+        self.widget_channel_id: Optional[int] = utils._get_as_snowflake(guild, "widget_channel_id")
 
         self._stage_instances: Dict[int, StageInstance] = {}
         for s in guild.get("stage_instances", []):
@@ -3178,7 +3203,8 @@ class Guild(Hashable):
 
     async def widget(self) -> Widget:
         """|coro|
-        Returns the widget of the guild.
+
+        Retrieves the widget of the guild.
 
         .. note::
 
@@ -3200,21 +3226,49 @@ class Guild(Hashable):
 
         return Widget(state=self._state, data=data)
 
+    async def widget_settings(self) -> WidgetSettings:
+        """|coro|
+
+        Retrieves the widget settings of the guild.
+
+        To edit the widget settings, you may also use :func:`.edit_widget`.
+
+        .. versionadded:: 2.5
+
+        Raises
+        ------
+        Forbidden
+            You do not have permission to view the widget settings.
+        HTTPException
+            Retrieving the widget settings failed.
+
+        Returns
+        -------
+        :class:`WidgetSettings`
+            The guild's widget settings.
+        """
+        data = await self._state.http.get_widget_settings(self.id)
+        return WidgetSettings(state=self._state, guild=self, data=data)
+
     async def edit_widget(
         self,
         *,
         enabled: bool = MISSING,
         channel: Optional[Snowflake] = MISSING,
         reason: Optional[str] = None,
-    ) -> None:
+    ) -> WidgetSettings:
         """|coro|
 
         Edits the widget of the guild.
 
         You must have :attr:`~Permissions.manage_guild` permission to
-        use this
+        use this.
 
         .. versionadded:: 2.0
+
+        .. versionchanged:: 2.5
+
+            Returns the new widget settings.
 
         Parameters
         ----------
@@ -3222,6 +3276,8 @@ class Guild(Hashable):
             Whether to enable the widget for the guild.
         channel: Optional[:class:`~disnake.abc.Snowflake`]
             The new widget channel. ``None`` removes the widget channel.
+            If set, an invite link for this channel will be generated,
+            which allows users to join the guild from the widget.
         reason: Optional[:class:`str`]
             The reason for editing the widget. Shows up on the audit log.
 
@@ -3233,6 +3289,11 @@ class Guild(Hashable):
             You do not have permission to edit the widget.
         HTTPException
             Editing the widget failed.
+
+        Returns
+        -------
+        :class:`WidgetSettings`
+            The new widget settings.
         """
         payload = {}
         if channel is not MISSING:
@@ -3240,7 +3301,25 @@ class Guild(Hashable):
         if enabled is not MISSING:
             payload["enabled"] = enabled
 
-        await self._state.http.edit_widget(self.id, payload=payload, reason=reason)
+        data = await self._state.http.edit_widget(self.id, payload=payload, reason=reason)
+        return WidgetSettings(state=self._state, guild=self, data=data)
+
+    def widget_image_url(self, style: WidgetStyle = WidgetStyle.shield) -> str:
+        """Returns an URL to the widget's .png image.
+
+        .. versionadded:: 2.5
+
+        Parameters
+        ----------
+        style: :class:`WidgetStyle`
+            The widget style.
+
+        Returns
+        -------
+        :class:`str`
+            The widget image URL.
+        """
+        return self._state.http.widget_image_url(self.id, style=str(style))
 
     async def chunk(self, *, cache: bool = True) -> Optional[List[Member]]:
         """|coro|

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3231,7 +3231,7 @@ class Guild(Hashable):
 
         Retrieves the widget settings of the guild.
 
-        To edit the widget settings, you may also use :func:`.edit_widget`.
+        To edit the widget settings, you may also use :func:`~Guild.edit_widget`.
 
         .. versionadded:: 2.5
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1654,9 +1654,9 @@ class HTTPClient:
         )
 
     def widget_image_url(self, guild_id: Snowflake, *, style: str) -> str:
-        # constructing a route for api coverage reasons
-        base = Route("GET", "/guilds/{guild_id}/widget.png", guild_id=guild_id).url
-        return str(yarl.URL(base).with_query(style=style))
+        return str(
+            yarl.URL(Route.BASE).with_path(f"/guilds/{guild_id}/widget.png").with_query(style=style)
+        )
 
     # Invite management
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -48,6 +48,7 @@ from typing import (
 from urllib.parse import quote as _uriquote
 
 import aiohttp
+import yarl
 
 from . import __version__, utils
 from .errors import (
@@ -1640,6 +1641,9 @@ class HTTPClient:
     def get_widget(self, guild_id: Snowflake) -> Response[widget.Widget]:
         return self.request(Route("GET", "/guilds/{guild_id}/widget.json", guild_id=guild_id))
 
+    def get_widget_settings(self, guild_id: Snowflake) -> Response[widget.WidgetSettings]:
+        return self.request(Route("GET", "/guilds/{guild_id}/widget", guild_id=guild_id))
+
     def edit_widget(
         self, guild_id: Snowflake, payload: Dict[str, Any], *, reason: Optional[str] = None
     ) -> Response[widget.WidgetSettings]:
@@ -1648,6 +1652,11 @@ class HTTPClient:
             json=payload,
             reason=reason,
         )
+
+    def widget_image_url(self, guild_id: Snowflake, *, style: str) -> str:
+        # constructing a route for api coverage reasons
+        base = Route("GET", "/guilds/{guild_id}/widget.png", guild_id=guild_id).url
+        return str(yarl.URL(base).with_query(style=style))
 
     # Invite management
 

--- a/disnake/widget.py
+++ b/disnake/widget.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from .activity import BaseActivity, Spotify, create_activity
-from .enums import Status, try_enum
+from .enums import Status, WidgetStyle, try_enum
 from .invite import Invite
 from .user import BaseUser
 from .utils import MISSING, _get_as_snowflake, resolve_invite, snowflake_time
@@ -36,13 +36,19 @@ from .utils import MISSING, _get_as_snowflake, resolve_invite, snowflake_time
 if TYPE_CHECKING:
     import datetime
 
-    from .abc import Snowflake
+    from .abc import GuildChannel, Snowflake
+    from .guild import Guild
     from .state import ConnectionState
-    from .types.widget import Widget as WidgetPayload, WidgetMember as WidgetMemberPayload
+    from .types.widget import (
+        Widget as WidgetPayload,
+        WidgetMember as WidgetMemberPayload,
+        WidgetSettings as WidgetSettingsPayload,
+    )
 
 __all__ = (
     "WidgetChannel",
     "WidgetMember",
+    "WidgetSettings",
     "Widget",
 )
 
@@ -206,6 +212,81 @@ class WidgetMember(BaseUser):
         return self.nick or self.name
 
 
+class WidgetSettings:
+    """Represents a :class:`Guild`'s widget settings.
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+    guild: :class:`Guild`
+        The widget's guild.
+    enabled: :class:`bool`
+        Whether the widget is enabled.
+    channel_id: Optional[:class:`int`]
+        The widget channel ID. If set, an invite link for this channel will be generated,
+        which allows users to join the guild from the widget.
+    """
+
+    __slots__ = ("_state", "guild", "enabled", "channel_id")
+
+    def __init__(
+        self, *, state: ConnectionState, guild: Guild, data: WidgetSettingsPayload
+    ) -> None:
+        self._state = state
+        self.guild = guild
+        self.enabled = data["enabled"]
+        self.channel_id = _get_as_snowflake(data, "channel_id")
+
+    def __repr__(self) -> str:
+        return f"<WidgetSettings enabled={self.enabled!r} channel_id={self.channel_id!r} guild={self.guild!r}>"
+
+    @property
+    def channel(self) -> Optional[GuildChannel]:
+        """Optional[:class:`abc.GuildChannel`]: The widget channel, if set."""
+        return self.guild.get_channel(self.channel_id) if self.channel_id is not None else None
+
+    async def edit(
+        self,
+        *,
+        enabled: bool = MISSING,
+        channel: Optional[Snowflake] = MISSING,
+        reason: Optional[str] = None,
+    ) -> WidgetSettings:
+        """|coro|
+
+        Edits the widget.
+
+        You must have :attr:`~Permissions.manage_guild` permission to
+        do this.
+
+        Parameters
+        ----------
+        enabled: :class:`bool`
+            Whether to enable the widget.
+        channel: Optional[:class:`~disnake.abc.Snowflake`]
+            The new widget channel. Pass ``None`` to remove the widget channel.
+            If set, an invite link for this channel will be generated,
+            which allows users to join the guild from the widget.
+        reason: Optional[:class:`str`]
+            The reason for editing the widget. Shows up on the audit log.
+
+        Raises
+        ------
+        Forbidden
+            You do not have permission to edit the widget.
+        HTTPException
+            Editing the widget failed.
+
+        Returns
+        -------
+        :class:`WidgetSettings`
+            The new widget settings.
+        """
+
+        return await self.guild.edit_widget(enabled=enabled, channel=channel, reason=reason)
+
+
 class Widget:
     """Represents a :class:`Guild` widget.
 
@@ -358,3 +439,21 @@ class Widget:
             payload["channel_id"] = None if channel is None else channel.id
 
         await self._state.http.edit_widget(self.id, payload, reason=reason)
+
+    def image_url(self, style: WidgetStyle = WidgetStyle.shield) -> str:
+        """Returns an URL to the widget's .png image.
+
+        .. versionadded:: 2.5
+
+        Parameters
+        ----------
+        style: :class:`WidgetStyle`
+            The widget style.
+
+        Returns
+        -------
+        :class:`str`
+            The widget image URL.
+
+        """
+        return self._state.http.widget_image_url(self.id, style=str(style))

--- a/disnake/widget.py
+++ b/disnake/widget.py
@@ -233,10 +233,10 @@ class WidgetSettings:
     def __init__(
         self, *, state: ConnectionState, guild: Guild, data: WidgetSettingsPayload
     ) -> None:
-        self._state = state
-        self.guild = guild
-        self.enabled = data["enabled"]
-        self.channel_id = _get_as_snowflake(data, "channel_id")
+        self._state: ConnectionState = state
+        self.guild: Guild = guild
+        self.enabled: bool = data["enabled"]
+        self.channel_id: Optional[int] = _get_as_snowflake(data, "channel_id")
 
     def __repr__(self) -> str:
         return f"<WidgetSettings enabled={self.enabled!r} channel_id={self.channel_id!r} guild={self.guild!r}>"

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3074,6 +3074,34 @@ of :class:`enum.Enum`.
 
         The thread will archive after a week of inactivity.
 
+.. class:: WidgetStyle
+
+    Represents the supported widget image styles.
+
+    .. versionadded:: 2.5
+
+    .. attribute:: shield
+
+        A shield style image with a Discord icon and the online member count.
+
+    .. attribute:: banner1
+
+        A large image with guild icon, name and online member count and a footer.
+
+    .. attribute:: banner2
+
+        A small image with guild icon, name and online member count.
+
+    .. attribute:: banner3
+
+        A large image with guild icon, name and online member count and a footer,
+        with a "Chat Now" label on the right.
+
+    .. attribute:: banner4
+
+        A large image with a large Discord logo, guild icon, name and online member count,
+        with a "Join My Server" label at the bottom.
+
 
 Async Iterator
 ----------------
@@ -4499,6 +4527,14 @@ WidgetMember
 .. autoclass:: WidgetMember()
     :members:
     :inherited-members:
+
+WidgetSettings
+~~~~~~~~~~~~~~
+
+.. attributetable:: WidgetSettings
+
+.. autoclass:: WidgetSettings()
+    :members:
 
 Widget
 ~~~~~~~


### PR DESCRIPTION
## Summary

This PR adds functionality for fetching a guild's widget settings, as well as constructing a widget image's URL with one of the predefined styles.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
