### PR TITLE
deprecate: integration create, edit, sync and delete

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2368,8 +2368,12 @@ class Guild(Hashable):
 
         return Template(state=self._state, data=data)
 
+    @utils.deprecated()
     async def create_integration(self, *, type: IntegrationType, id: int) -> None:
         """|coro|
+
+        .. deprecated:: 2.5
+            No longer supported, bots cannot use this endpoint anymore.
 
         Attaches an integration to the guild.
 

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
 from .enums import ExpireBehaviour, try_enum
 from .errors import InvalidArgument
 from .user import User
-from .utils import MISSING, _get_as_snowflake, parse_time
+from .utils import MISSING, _get_as_snowflake, deprecated, parse_time
 
 __all__ = (
     "IntegrationAccount",
@@ -129,8 +129,13 @@ class Integration:
         self.user = User(state=self._state, data=user) if user else None
         self.enabled: bool = data["enabled"]
 
+    @deprecated("Guild.leave")
     async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
+
+        .. deprecated:: 2.5
+            Can only be used on the application's own integration and is therefore
+            equivalent to leaving the guild.
 
         Deletes the integration.
 
@@ -219,6 +224,7 @@ class StreamIntegration(Integration):
         """Optional[:class:`Role`] The role which the integration uses for subscribers."""
         return self.guild.get_role(self._role_id)  # type: ignore
 
+    @deprecated()
     async def edit(
         self,
         *,
@@ -227,6 +233,9 @@ class StreamIntegration(Integration):
         enable_emoticons: bool = MISSING,
     ) -> None:
         """|coro|
+
+        .. deprecated:: 2.5
+            No longer supported, bots cannot use this endpoint anymore.
 
         Edits the integration.
 
@@ -268,8 +277,12 @@ class StreamIntegration(Integration):
         # Unsure if it returns the data or not as a result
         await self._state.http.edit_integration(self.guild.id, self.id, **payload)
 
+    @deprecated()
     async def sync(self) -> None:
         """|coro|
+
+        .. deprecated:: 2.5
+            No longer supported, bots cannot use this endpoint anymore.
 
         Syncs the integration.
 

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -261,7 +261,7 @@ def deprecated(instead: Optional[str] = None) -> Callable[[Callable[P, T]], Call
             else:
                 msg = f"{func.__name__} is deprecated."
 
-            warn_deprecated(msg, stacklevel=3)
+            warn_deprecated(msg, stacklevel=2)
             return func(*args, **kwargs)
 
         return decorated


### PR DESCRIPTION
## Summary

Deprecates integration create, edit, sync and delete, see https://github.com/discord/discord-api-docs/pull/2087.
Integration deletion still works, but only on the bot's own integration, which ends up just being a `Guild.leave` with extra steps.
Also fixes the incorrect `stacklevel` in `utils.deprecated`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
