### PR TITLE
fix: add commands.errors.LargeIntConversionFailure

### DIFF
--- a/disnake/ext/commands/errors.py
+++ b/disnake/ext/commands/errors.py
@@ -74,6 +74,7 @@ __all__ = (
     "GuildStickerNotFound",
     "PartialEmojiConversionFailure",
     "BadBoolArgument",
+    "LargeIntConversionFailure",
     "MissingRole",
     "BotMissingRole",
     "MissingAnyRole",
@@ -534,6 +535,24 @@ class BadBoolArgument(BadArgument):
     def __init__(self, argument: str) -> None:
         self.argument: str = argument
         super().__init__(f"{argument} is not a recognised boolean option")
+
+
+class LargeIntConversionFailure(BadArgument):
+    """Exception raised when a large integer argument was not convertable.
+
+    This inherits from :exc:`BadArgument`
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+    argument: :class:`str`
+        The argument that could not be cocereted to a large integer.
+    """
+
+    def __init__(self, argument: str) -> None:
+        self.argument: str = argument
+        super().__init__(f"{argument} is not able to be coerced to an integer")
 
 
 class DisabledCommand(CommandError):

--- a/disnake/ext/commands/errors.py
+++ b/disnake/ext/commands/errors.py
@@ -538,7 +538,7 @@ class BadBoolArgument(BadArgument):
 
 
 class LargeIntConversionFailure(BadArgument):
-    """Exception raised when a large integer argument was not convertible.
+    """Exception raised when a large integer argument was not able to be converted.
 
     This inherits from :exc:`BadArgument`
 
@@ -547,12 +547,12 @@ class LargeIntConversionFailure(BadArgument):
     Attributes
     ----------
     argument: :class:`str`
-        The argument that could not be coerced to an integer.
+        The argument that could not be converted to an integer.
     """
 
     def __init__(self, argument: str) -> None:
         self.argument: str = argument
-        super().__init__(f"{argument} is not able to be coerced to an integer")
+        super().__init__(f"{argument} is not able to be converted to an integer")
 
 
 class DisabledCommand(CommandError):

--- a/disnake/ext/commands/errors.py
+++ b/disnake/ext/commands/errors.py
@@ -538,7 +538,7 @@ class BadBoolArgument(BadArgument):
 
 
 class LargeIntConversionFailure(BadArgument):
-    """Exception raised when a large integer argument was not convertable.
+    """Exception raised when a large integer argument was not convertible.
 
     This inherits from :exc:`BadArgument`
 
@@ -547,7 +547,7 @@ class LargeIntConversionFailure(BadArgument):
     Attributes
     ----------
     argument: :class:`str`
-        The argument that could not be cocereted to a large integer.
+        The argument that could not be coerced to an integer.
     """
 
     def __init__(self, argument: str) -> None:

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -425,8 +425,8 @@ class ParamInfo:
         if self.large:
             try:
                 argument = int(argument)
-            except Exception as e:
-                raise errors.ConversionError(int, e) from e
+            except ValueError as e:
+                raise errors.LargeIntConversionFailure(argument) from None
 
         if self.converter is None:
             # TODO: Custom validators
@@ -438,6 +438,8 @@ class ParamInfo:
                 return await argument
 
             return argument
+        except errors.CommandError:
+            raise
         except Exception as e:
             raise errors.ConversionError(self.converter, e) from e
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
adds `LargeIntConversionFailure` (named after PartialEmojiConversionFailure)

raising this custom error instead of a commands.errors.ConversionError
falls in line with the documentation for ConversionError, and allows the
end user to more easily handle exceptions for LargeInts that may 
not be easily convertable

additionally, added a missing except clause that lets exceptions propagate 
cleanly as documented


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
Debatable, but will continue to raise a exception dervived of CommandError. Just falls in line with the documentation now.
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
