### PR TITLE
feat: add `message` field to `ModalInteraction`

### DIFF
--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -234,6 +234,14 @@ class MessageInteraction(Interaction):
     message: Message
 
 
+class _ModalInteractionOptional(TypedDict, total=False):
+    message: Message
+
+
+class ModalInteraction(_ModalInteractionOptional, Interaction):
+    data: ModalInteractionData
+
+
 class InteractionApplicationCommandCallbackData(TypedDict, total=False):
     tts: bool
     content: str


### PR DESCRIPTION
## Summary

This PR adds the `message` field to `ModalInteraction`, which exists if the modal was sent in response to a component interaction. This is currently undocumented, but was confirmed as intended here: https://discord.com/channels/613425648685547541/940752915109400617/944311209556074516

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
