### PR TITLE
feat: support edit responses for modal interactions

### DIFF
--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -316,7 +316,7 @@ class InteractionResponded(InteractionException):
     """Exception that's raised when sending another interaction response using
     :class:`InteractionResponse` when one has already been done before.
 
-    An interaction can only responded to once.
+    An interaction can only be responded to once.
 
     .. versionadded:: 2.0
 

--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -58,6 +58,7 @@ __all__ = (
     "InteractionResponded",
     "InteractionNotResponded",
     "ModalChainNotSupported",
+    "InteractionNotEditable",
 )
 
 
@@ -315,7 +316,7 @@ class InteractionResponded(InteractionException):
     """Exception that's raised when sending another interaction response using
     :class:`InteractionResponse` when one has already been done before.
 
-    An interaction can only respond once.
+    An interaction can only responded to once.
 
     .. versionadded:: 2.0
 
@@ -334,14 +335,14 @@ class InteractionNotResponded(InteractionException):
     """Exception that's raised when editing an interaction response without
     sending a response message first.
 
-    An interaction can only respond once.
+    An interaction must be responded to exactly once.
 
     .. versionadded:: 2.0
 
     Attributes
     ----------
     interaction: :class:`Interaction`
-        The interaction that's already been responded to.
+        The interaction that hasn't been responded to.
     """
 
     def __init__(self, interaction: Interaction):
@@ -363,3 +364,20 @@ class ModalChainNotSupported(InteractionException):
     def __init__(self, interaction: ModalInteraction):
         self.interaction: ModalInteraction = interaction
         super().__init__("You cannot respond to a modal with another modal.")
+
+
+class InteractionNotEditable(InteractionException):
+    """Exception that's raised when trying to use :func:`InteractionResponse.edit_message`
+    on an interaction without an associated message (which is thus non-editable).
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+    interaction: :class:`Interaction`
+        The interaction that was responded to.
+    """
+
+    def __init__(self, interaction: Interaction):
+        self.interaction: Interaction = interaction
+        super().__init__("This interaction does not have a message to edit.")

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
     from ..ui.modal import Modal
     from ..ui.view import View
     from .message import MessageInteraction
+    from .modal import ModalInteraction
 
     InteractionChannel = Union[
         VoiceChannel,
@@ -99,8 +100,6 @@ if TYPE_CHECKING:
     ]
 
     AnyBot = Union[Bot, AutoShardedBot]
-else:
-    MessageInteraction = ...  # only used for typecasting
 
 MISSING: Any = utils.MISSING
 
@@ -868,7 +867,8 @@ class InteractionResponse:
         """|coro|
 
         Responds to this interaction by editing the original message of
-        a component interaction.
+        a component interaction or modal interaction (if the modal was sent in
+        response to a component interaction).
 
         .. note::
             If the original message has embeds with images that were created from local files
@@ -931,12 +931,15 @@ class InteractionResponse:
             raise InteractionResponded(self._parent)
 
         parent = self._parent
-        msg: Optional[Message] = getattr(parent, "message", None)
         state = parent._state
-        message_id = msg.id if msg else None
-        if parent.type is not InteractionType.component:
+
+        if parent.type not in (InteractionType.component, InteractionType.modal_submit):
             return
-        parent = cast(MessageInteraction, parent)
+        parent = cast("Union[MessageInteraction, ModalInteraction]", parent)
+        message = parent.message
+        # message in modal interactions only exists if modal was sent from component interaction
+        if not message:
+            return
 
         payload = {}
         if content is not MISSING:
@@ -977,7 +980,7 @@ class InteractionResponse:
         # if no attachment list was provided but we're uploading new files,
         # use current attachments as the base
         if attachments is MISSING and (file or files):
-            attachments = parent.message.attachments
+            attachments = message.attachments
         if attachments is not MISSING:
             payload["attachments"] = [a.to_dict() for a in attachments]
 
@@ -985,8 +988,8 @@ class InteractionResponse:
             raise TypeError("cannot mix view and components keyword arguments")
 
         if view is not MISSING:
-            if message_id:
-                state.prevent_view_updates_for(message_id)
+            if message.id:
+                state.prevent_view_updates_for(message.id)
             payload["components"] = [] if view is None else view.to_components()
 
         if components is not MISSING:
@@ -1008,7 +1011,7 @@ class InteractionResponse:
                     f.close()
 
         if view and not view.is_finished():
-            state.store_view(view, message_id)
+            state.store_view(view, message.id)
 
         self._responded = True
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -36,6 +36,7 @@ from ..channel import ChannelType, PartialMessageable
 from ..enums import InteractionResponseType, InteractionType, WebhookType, try_enum
 from ..errors import (
     HTTPException,
+    InteractionNotEditable,
     InteractionNotResponded,
     InteractionResponded,
     InteractionTimedOut,
@@ -934,12 +935,12 @@ class InteractionResponse:
         state = parent._state
 
         if parent.type not in (InteractionType.component, InteractionType.modal_submit):
-            return
+            raise InteractionNotEditable(parent)
         parent = cast("Union[MessageInteraction, ModalInteraction]", parent)
         message = parent.message
         # message in modal interactions only exists if modal was sent from component interaction
         if not message:
-            return
+            raise InteractionNotEditable(parent)
 
         payload = {}
         if content is not MISSING:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -989,8 +989,7 @@ class InteractionResponse:
             raise TypeError("cannot mix view and components keyword arguments")
 
         if view is not MISSING:
-            if message.id:
-                state.prevent_view_updates_for(message.id)
+            state.prevent_view_updates_for(message.id)
             payload["components"] = [] if view is None else view.to_components()
 
         if components is not MISSING:


### PR DESCRIPTION
## Summary

This PR adds the ability to use `InteractionResponse.edit_message` with `ModalInteraction`s whose associated modal was sent from a component interaction.
A new `InteractionNotEditable` exception is also being added, which is raised when trying to call `.edit_message` on an unsupported interaction type (application command, or modal without component interaction).

Depends on #363 and currently includes those changes (as such, disregard the changes in `modal.py` and `types/interactions.py`).

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
