### PR TITLE
fix Guild.widget_image_url

### DIFF
--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1655,7 +1655,7 @@ class HTTPClient:
 
     def widget_image_url(self, guild_id: Snowflake, *, style: str) -> str:
         return str(
-            yarl.URL(Route.BASE).with_path(f"/guilds/{guild_id}/widget.png").with_query(style=style)
+            yarl.URL(Route.BASE).with_path(f"/api/guilds/{guild_id}/widget.png").with_query(style=style)
         )
 
     # Invite management

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1655,7 +1655,9 @@ class HTTPClient:
 
     def widget_image_url(self, guild_id: Snowflake, *, style: str) -> str:
         return str(
-            yarl.URL(Route.BASE).with_path(f"/api/guilds/{guild_id}/widget.png").with_query(style=style)
+            yarl.URL(Route.BASE)
+            .with_path(f"/api/guilds/{guild_id}/widget.png")
+            .with_query(style=style)
         )
 
     # Invite management


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Hi,

I observed that the URL generated by `Guild.widget_image_url()` method was missing `/api/` parent endpoint, it generates:
```py
https://discord.com/guilds/{guild_id}/widget.png?style={style}
```

However, as per Discord API docs examples on [widget image](https://discord.com/developers/docs/resources/guild#membership-screening-object-widget-style-options) example, URL should be:
```py
https://discord.com/api/guilds/{guild_id}/widget.png?style={style}
```
which properly renders as correct widget image.

This PR hopefully fixes this issue. 😅 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
