### PR TITLE
feat: support reason for `Message.create_thread` and `Thread.delete`

### DIFF
--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1764,6 +1764,7 @@ class Message(Hashable):
         name: str,
         auto_archive_duration: AnyThreadArchiveDuration = None,
         slowmode_delay: int = None,
+        reason: Optional[str] = None,
     ) -> Thread:
         """|coro|
 
@@ -1790,6 +1791,11 @@ class Message(Hashable):
             If not provided, slowmode is disabled.
 
             .. versionadded:: 2.3
+
+        reason: Optional[:class:`str`]
+            The reason for creating the thread. Shows up on the audit log.
+
+            .. versionadded:: 2.5
 
         Raises
         ------
@@ -1822,6 +1828,7 @@ class Message(Hashable):
             name=name,
             auto_archive_duration=auto_archive_duration or default_auto_archive_duration,
             rate_limit_per_user=slowmode_delay or 0,
+            reason=reason,
         )
         return Thread(guild=self.guild, state=self._state, data=data)
 

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -777,12 +777,19 @@ class Thread(Messageable, Hashable):
         members = await self._state.http.get_thread_members(self.id)
         return [ThreadMember(parent=self, data=data) for data in members]
 
-    async def delete(self):
+    async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Deletes this thread.
 
         You must have :attr:`~Permissions.manage_threads` to delete threads.
+
+        Parameters
+        ----------
+        reason: Optional[:class:`str`]
+            The reason for deleting this thread. Shows up on the audit log.
+
+            .. versionadded:: 2.5
 
         Raises
         ------
@@ -791,7 +798,7 @@ class Thread(Messageable, Hashable):
         HTTPException
             Deleting the thread failed.
         """
-        await self._state.http.delete_channel(self.id)
+        await self._state.http.delete_channel(self.id, reason=reason)
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.


### PR DESCRIPTION
## Summary

Adds support for specifying a reason with `Message.create_thread` or `Thread.delete`; note that in the latter case, the reason doesn't show up in the UI, but is still accessible through the API.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
