### PR TITLE
chore: deprecate summary on application objects

### DIFF
--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -74,16 +74,6 @@ class AppInfo:
         grant flow to join.
     rpc_origins: Optional[List[:class:`str`]]
         A list of RPC origin URLs, if RPC is enabled.
-    summary: :class:`str`
-        If this application is a game sold on Discord,
-        this field will be the summary field for the store page of its primary SKU.
-
-        .. versionadded:: 1.3
-
-        .. deprecated:: 2.5
-
-            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
-
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
         GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.
@@ -214,9 +204,17 @@ class AppInfo:
 
     @property
     def summary(self) -> str:
-        # there is no docstring here due to how sphinx autodoc works
+        """:class:`str`: If this application is a game sold on Discord,
+        this field will be the summary field for the store page of its primary SKU.
+
+        .. versionadded:: 1.3
+
+        .. deprecated:: 2.5
+
+            This field is deprecated by discord and is now always blank. Replaced with :attr:`.description`.
+        """
         utils.warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Consider using description instead.",
+            "summary is deprecated and will be removed in a future version. Replaced with description.",
             stacklevel=2,
         )
         return self._summary
@@ -237,15 +235,7 @@ class PartialAppInfo:
         The application's description.
     rpc_origins: Optional[List[:class:`str`]]
         A list of RPC origin URLs, if RPC is enabled.
-    summary: :class:`str`
-        If this application is a game sold on Discord,
-        this field will be the summary field for the store page of its primary SKU.
-
-        .. deprecated:: 2.5
-
-            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
-
-        verify_key: :class:`str`
+    verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
         GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.
     terms_of_service_url: Optional[:class:`str`]
@@ -291,9 +281,15 @@ class PartialAppInfo:
 
     @property
     def summary(self) -> str:
-        # there is no docstring here due to how sphinx autodoc works
+        """:class:`str`: If this application is a game sold on Discord,
+        this field will be the summary field for the store page of its primary SKU.
+
+        .. deprecated:: 2.5
+
+            This field is deprecated by discord and is now always blank. Replaced with :attr:`.description`.
+        """
         utils.warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Consider using description instead.",
+            "summary is deprecated and will be removed in a future version. Replaced with description.",
             stacklevel=2,
         )
         return self._summary

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -211,10 +211,10 @@ class AppInfo:
 
         .. deprecated:: 2.5
 
-            This field is deprecated by discord and is now always blank. Replaced with :attr:`.description`.
+            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
         """
         utils.warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Replaced with description.",
+            "summary is deprecated and will be removed in a future version. Consider using description instead.",
             stacklevel=2,
         )
         return self._summary
@@ -286,10 +286,10 @@ class PartialAppInfo:
 
         .. deprecated:: 2.5
 
-            This field is deprecated by discord and is now always blank. Replaced with :attr:`.description`.
+            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
         """
         utils.warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Replaced with description.",
+            "summary is deprecated and will be removed in a future version. Consider using description instead.",
             stacklevel=2,
         )
         return self._summary

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -80,6 +80,10 @@ class AppInfo:
 
         .. versionadded:: 1.3
 
+        .. deprecated:: 2.5
+
+            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
+
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
         GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.
@@ -131,7 +135,7 @@ class AppInfo:
         "bot_require_code_grant",
         "owner",
         "_icon",
-        "summary",
+        "_summary",
         "verify_key",
         "team",
         "guild_id",
@@ -159,7 +163,7 @@ class AppInfo:
         team: Optional[TeamPayload] = data.get("team")
         self.team: Optional[Team] = Team(state, team) if team else None
 
-        self.summary: str = data["summary"]
+        self._summary: str = data.get("summary", "")
         self.verify_key: str = data["verify_key"]
 
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, "guild_id")
@@ -208,6 +212,15 @@ class AppInfo:
         """
         return self._state._get_guild(self.guild_id)
 
+    @property
+    def summary(self) -> str:
+        # there is no docstring here due to how sphinx autodoc works
+        utils.warn_deprecated(
+            "summary is deprecated and will be removed in a future version. Consider using description instead.",
+            stacklevel=2,
+        )
+        return self._summary
+
 
 class PartialAppInfo:
     """Represents a partial AppInfo given by :func:`~disnake.abc.GuildChannel.create_invite`
@@ -227,7 +240,12 @@ class PartialAppInfo:
     summary: :class:`str`
         If this application is a game sold on Discord,
         this field will be the summary field for the store page of its primary SKU.
-    verify_key: :class:`str`
+
+        .. deprecated:: 2.5
+
+            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
+
+        verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
         GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.
     terms_of_service_url: Optional[:class:`str`]
@@ -242,7 +260,7 @@ class PartialAppInfo:
         "name",
         "description",
         "rpc_origins",
-        "summary",
+        "_summary",
         "verify_key",
         "terms_of_service_url",
         "privacy_policy_url",
@@ -256,7 +274,7 @@ class PartialAppInfo:
         self._icon: Optional[str] = data.get("icon")
         self.description: str = data["description"]
         self.rpc_origins: Optional[List[str]] = data.get("rpc_origins")
-        self.summary: str = data["summary"]
+        self._summary: str = data.get("summary", "")
         self.verify_key: str = data["verify_key"]
         self.terms_of_service_url: Optional[str] = data.get("terms_of_service_url")
         self.privacy_policy_url: Optional[str] = data.get("privacy_policy_url")
@@ -270,3 +288,12 @@ class PartialAppInfo:
         if self._icon is None:
             return None
         return Asset._from_icon(self._state, self.id, self._icon, path="app")
+
+    @property
+    def summary(self) -> str:
+        # there is no docstring here due to how sphinx autodoc works
+        utils.warn_deprecated(
+            "summary is deprecated and will be removed in a future version. Consider using description instead.",
+            stacklevel=2,
+        )
+        return self._summary

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -315,13 +315,6 @@ class IntegrationApplication:
         The application's icon hash.
     description: :class:`str`
         The application's description. Can be an empty string.
-    summary: :class:`str`
-        The application's summary. Can be an empty string.
-
-        .. deprecated:: 2.5
-
-            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
-
     user: Optional[:class:`User`]
         The bot user associated with this application.
     """
@@ -346,9 +339,14 @@ class IntegrationApplication:
 
     @property
     def summary(self) -> str:
-        # there is no docstring here due to how sphinx autodoc works
+        """:class:`str`: The application's summary. Can be an empty string.
+
+        .. deprecated:: 2.5
+
+            This field is deprecated by discord and is now always blank. Replaced with :attr:`.description`.
+        """
         warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Consider using :attr:`.description` instead.",
+            "summary is deprecated and will be removed in a future version. Replaced with :attr:`.description`.",
             stacklevel=2,
         )
         return self._summary

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -343,10 +343,10 @@ class IntegrationApplication:
 
         .. deprecated:: 2.5
 
-            This field is deprecated by discord and is now always blank. Replaced with :attr:`.description`.
+            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
         """
         warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Replaced with :attr:`.description`.",
+            "summary is deprecated and will be removed in a future version. Consider using description instead.",
             stacklevel=2,
         )
         return self._summary

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
 from .enums import ExpireBehaviour, try_enum
 from .errors import InvalidArgument
 from .user import User
-from .utils import MISSING, _get_as_snowflake, deprecated, parse_time
+from .utils import MISSING, _get_as_snowflake, deprecated, parse_time, warn_deprecated
 
 __all__ = (
     "IntegrationAccount",
@@ -317,6 +317,11 @@ class IntegrationApplication:
         The application's description. Can be an empty string.
     summary: :class:`str`
         The application's summary. Can be an empty string.
+
+        .. deprecated:: 2.5
+
+            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
+
     user: Optional[:class:`User`]
         The bot user associated with this application.
     """
@@ -326,7 +331,7 @@ class IntegrationApplication:
         "name",
         "icon",
         "description",
-        "summary",
+        "_summary",
         "user",
     )
 
@@ -335,9 +340,18 @@ class IntegrationApplication:
         self.name: str = data["name"]
         self.icon: Optional[str] = data["icon"]
         self.description: str = data["description"]
-        self.summary: str = data["summary"]
+        self._summary: str = data.get("summary", "")
         user = data.get("bot")
         self.user: Optional[User] = User(state=state, data=user) if user else None
+
+    @property
+    def summary(self) -> str:
+        # there is no docstring here due to how sphinx autodoc works
+        warn_deprecated(
+            "summary is deprecated and will be removed in a future version. Consider using :attr:`.description` instead.",
+            stacklevel=2,
+        )
+        return self._summary
 
 
 class BotIntegration(Integration):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

deprecates Application.summary, IntegrationApplication.summary, AppInfo.summary as the summary parameter is now deprecated and replaced with the description parameter.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
