### PR TITLE
fix: force disable mathjax in documentation

### DIFF
--- a/docs/extensions/builder.py
+++ b/docs/extensions/builder.py
@@ -1,4 +1,8 @@
+import inspect
+
+from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.config import Config
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinx.writers.html5 import HTML5Translator
 
@@ -78,8 +82,21 @@ def add_builders(app):
         app.add_builder(new_builder, override=True)
 
 
+def disable_mathjax(app: Sphinx, config: Config) -> None:
+    # prevent installation of mathjax script, which gets installed due to
+    # https://github.com/readthedocs/sphinx-hoverxref/commit/7c4655092c482bd414b1816bdb4f393da117062a
+    #
+    # inspired by https://github.com/readthedocs/sphinx-hoverxref/blob/003b84fee48262f1a969c8143e63c177bd98aa26/hoverxref/extension.py#L151
+
+    for listener in app.events.listeners.get("html-page-context"):
+        module_name = inspect.getmodule(listener.handler).__name__  # type: ignore
+        if module_name == "sphinx.ext.mathjax":
+            app.disconnect(listener.id)
+
+
 def setup(app):
     app.add_config_value("copy_static_images", [], "env")
 
     add_builders(app)
+    app.connect("config-inited", disable_mathjax)
     app.connect("builder-inited", add_custom_jinja2)


### PR DESCRIPTION
## Summary

The sphinx version bump to `4.4.0` combined with `hoverxref` results in mathjax always being loaded even though it's not being used, which considerably increases load time of the api reference pages in Chrome by several seconds due to an additional layout reflow (weirdly enough not in Firefox, where the difference is just ~500ms).

The HTML builder automatically [loads](https://github.com/sphinx-doc/sphinx/blob/2be06309518d9401a42880bb5b4321dfdd1e5e90/sphinx/builders/html/__init__.py#L1377-L1378) `sphinx.ext.mathjax`, which usually only adds the js script [if required](https://github.com/sphinx-doc/sphinx/blob/2be06309518d9401a42880bb5b4321dfdd1e5e90/sphinx/ext/mathjax.py#L82-L83).
Sphinx 4.1.0 added `html_assets_policy` (specifically for hoverxref), which is used by hoverxref to enable mathjax on all pages even if unused: https://github.com/readthedocs/sphinx-hoverxref/issues/119.

preview:
https://disnake--370.org.readthedocs.build/en/370/api.html
https://docs.disnake.dev/en/latest/api.html

### Profiling

The load time for the primary content itself doesn't change much by removing mathjax, it's mostly a small layout shift that gets skipped which decreases the final load time in Chrome by a bunch: (note the `onload` timestamps in the bottom left)

(before)
![image](https://user-images.githubusercontent.com/8530778/154972597-9bb363a7-31ab-4e61-bac1-d102029a792a.png)

(after)
![image](https://user-images.githubusercontent.com/8530778/154972622-e452d516-2d6f-45ac-9e94-868fd034d438.png)


## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
