### PR TITLE
fix Permissions.private_channel

### DIFF
--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -402,7 +402,7 @@ class Permissions(BaseFlags):
         base.manage_messages = False
         base.manage_threads = False
         base.send_messages_in_threads = False
-        base.create_private_threads = False
+        base.create_public_threads = False
         base.create_private_threads = False
         return base
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Hi,

I saw that `create_private_threads` was put 2 times in `Permissions.private_channel` perm.
I believe one of them should be `create_public_threads` to be consistent with the perm's docstring. Hopefully this PR fixes that. 😅 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
