### PR TITLE
Docs: post cleanup bugfixes

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -59,6 +59,26 @@ let showHideSidebar;
 document.addEventListener('DOMContentLoaded', () => {
   mobileSearch = new SearchBar();
 
+
+  const search_box = document.querySelector(".search input[type='search']");
+  const updateSearchPlaceholder = function() {
+    if (window.matchMedia && window.matchMedia('(max-width: 600px)').matches) {
+      if (!search_box.classList.contains("mobile-search")) {
+        search_box.classList.add("mobile-search");
+        search_box.placeholder = search_box.getAttribute("placeholder-mobile");
+      }
+    } else {
+      if (search_box.classList.contains("mobile-search")) {
+        search_box.classList.remove("mobile-search");
+        search_box.placeholder = search_box.getAttribute("placeholder-desktop");
+      }
+    }
+  }
+  // Alter search box text for small screen sizes to reduce clipping
+  window.addEventListener("resize", updateSearchPlaceholder);
+  updateSearchPlaceholder();
+
+
   bottomHeightThreshold = document.documentElement.scrollHeight - 30;
   sections = document.querySelectorAll('section');
   hamburgerToggle = document.getElementById('hamburger-toggle');

--- a/docs/_static/sidebar.js
+++ b/docs/_static/sidebar.js
@@ -56,11 +56,6 @@ class Sidebar {
     }
   }
 
-  resize() {
-    let rect = this.element.getBoundingClientRect();
-    this.element.style.height = `calc(100vh - 1em - ${rect.top + document.body.offsetTop}px)`;
-  }
-
   collapseSection(icon) {
     icon.classList.remove('expanded');
     icon.classList.add('collapsed');
@@ -118,11 +113,9 @@ function getCurrentSection() {
 
 document.addEventListener('DOMContentLoaded', () => {
   sidebar = new Sidebar(document.getElementById('sidebar'));
-  sidebar.resize();
   sidebar.createCollapsableSections();
 
   window.addEventListener('scroll', () => {
     sidebar.setActiveLink(getCurrentSection());
-    sidebar.resize();
   });
 });

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -705,6 +705,12 @@ aside::-webkit-scrollbar-thumb:hover {
   flex: 9;
 }
 
+.search-wrapper > button[type=submit] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .search-wrapper {
   border: 2px solid var(--search-border);
   border-radius: 8px;

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -690,6 +690,12 @@ aside::-webkit-scrollbar-thumb:hover {
   font-size: 1em;
 }
 
+.search-wrapper > input[type=search]::-webkit-search-cancel-button {
+  /* As of 2022, the search cancel button ignores all sorts of properties and looks bad by default in this theme so we hide it */
+  -webkit-appearance: none;
+  display: none;
+}
+
 .search-wrapper > input[type=search],
 .search-wrapper > button[type=submit] {
   background-color: var(--sub-header-background);

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -306,7 +306,8 @@ aside {
   padding: 12px;
   overflow: auto;
   z-index: 3;
-  max-height: 100vh;
+  top: 50px; /* Space for sticky header */
+  bottom: 0;
   width: 385px;
   overscroll-behavior: contain;
   scrollbar-width: thin;

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -74,7 +74,7 @@
           <img class="disnake-main-logo" src="{{ pathto('_images/' + 'disnake.svg', 1)|e }}" alt="disnake">
         </a>
         <div class="header-breakpoint desktop extension-breakpoint desktop">
-          <a href="{{ pathto('api')|e }}" class="extension-nav">API Reference</a>
+          <a href="{{ pathto('api')|e }}" class="extension-nav">{{ _('API Reference') }}</a>
           {%- for ext, p in discord_extensions %}
           {% set ext_name = ext.split('.') %}
           <a href="{{ pathto(p + '/index')|e }}" class="extension-nav {% if pagename is prefixedwith p %}current-page{% endif %}">{{ ext_name[-1] }}</a>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -83,7 +83,7 @@
         <div class="header-breakpoint search-breakpoint">
           <form role="search" class="search" action="{{ pathto('search') }}" method="get">
             <div class="search-wrapper">
-              <input type="search" name="q" placeholder="{{ _('Search documentation') }}" />
+              <input type="search" name="q" placeholder="{{ _('Search documentation') }}" placeholder-mobile="{{ _('Search') }}" placeholder-desktop="{{ _('Search documentation') }}" />
               <button type="submit">
                 <span class="material-icons">search</span>
               </button>


### PR DESCRIPTION
## Summary

Clean up issues that resulted from the doc's style update and were found in the following weeks:

- [x] Fix search box text getting clipped on mobile
- [x] Hide "clear search box" icon auto-added by chrome that looks bad and is unstyleable
- [x] Search button isn't properly centered on certain browsers
- [x] Sidebar clips off the bottom items, on certain browsers, after scrolling

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
