### PR TITLE
fix PartialInviteChannel.__str__

### DIFF
--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -85,7 +85,7 @@ class PartialInviteChannel:
 
     Attributes
     ----------
-    name: :class:`str`
+    name: Optional[:class:`str`]
         The partial channel's name.
     id: :class:`int`
         The partial channel's ID.
@@ -97,11 +97,13 @@ class PartialInviteChannel:
 
     def __init__(self, data: InviteChannelPayload):
         self.id: int = int(data["id"])
-        self.name: str = data["name"]
+        self.name: Optional[str] = data.get("name")
         self.type: ChannelType = try_enum(ChannelType, data["type"])
 
     def __str__(self) -> str:
-        return self.name
+        if self.type is ChannelType.group:
+            return self.name or "Unnamed"
+        return self.name or ""
 
     def __repr__(self) -> str:
         return f"<PartialInviteChannel id={self.id} name={self.name} type={self.type!r}>"

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -120,6 +120,7 @@ class _ThreadChannelOptional(TypedDict, total=False):
 
 class ThreadChannel(_BaseChannel, _ThreadChannelOptional):
     type: Literal[10, 11, 12]
+    name: str
     guild_id: Snowflake
     parent_id: Snowflake
     owner_id: Snowflake
@@ -171,3 +172,4 @@ class StageInstance(TypedDict):
 
 class GuildDirectory(_BaseChannel):
     type: Literal[14]
+    name: str

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -42,15 +42,12 @@ class PermissionOverwrite(TypedDict):
 ChannelType = Literal[0, 1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14]
 
 
-class _BaseChannelOptional(TypedDict, total=False):
-    name: Optional[str]
-
-
-class _BaseChannel(_BaseChannelOptional):
+class _BaseChannel(TypedDict):
     id: Snowflake
 
 
 class _BaseGuildChannel(_BaseChannel):
+    name: str
     guild_id: Snowflake
     position: int
     permission_overwrites: List[PermissionOverwrite]
@@ -152,6 +149,7 @@ class DMChannel(_BaseChannel):
 
 
 class GroupDMChannel(_BaseChannel):
+    name: Optional[str]
     type: Literal[3]
     icon: Optional[str]
     owner_id: Snowflake

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -42,9 +42,12 @@ class PermissionOverwrite(TypedDict):
 ChannelType = Literal[0, 1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14]
 
 
-class _BaseChannel(TypedDict):
+class _BaseChannelOptional(TypedDict, total=False):
+    name: Optional[str]
+
+
+class _BaseChannel(_BaseChannelOptional):
     id: Snowflake
-    name: str
 
 
 class _BaseGuildChannel(_BaseChannel):


### PR DESCRIPTION
## Summary

Due to some discord api inconsistencies (and a minor doc update, https://github.com/discord/discord-api-docs/pull/4571), this is a simple implementation to fix `__str__`.

A future implementation of PartialInviteChannel will properly use the recipients key to 
provide a close equivalent of how the discord client shows a group DM name.

Unfortunately, the api currently is unclear as what information is provided in the 
recipients key for group dms. The documentation states the array is full user objects,
which is not the case from testing. As such, this has not been implemented.

This can be tracked at discord/discord-api-docs#4572

- fix: mark channel name as both optional and nullable in payload typings
- fix: make PartialInviteChannel.__str__ always return a string



## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint` or `pre-commit run --all-files`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)


closes #382