### PR TITLE
build: update ci, fix tasks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Set up python 3.8
       uses: actions/setup-python@v2
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Set up python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -69,12 +69,13 @@ jobs:
         no-comments: true  # only add comments for one platform (see above)
         warnings: true
 
+
   slotscheck:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Set up python 3.8
       uses: actions/setup-python@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
         cache: "pip"
         cache-dependency-path: |
           requirements_dev.txt
+          requirements.txt
+          setup.py
 
     - name: Install requirements
       run: python -m pip install -r requirements_dev.txt
@@ -42,6 +44,7 @@ jobs:
         cache: "pip"
         cache-dependency-path: |
           requirements_dev.txt
+          requirements.txt
           setup.py
 
     - name: Install requirements
@@ -81,6 +84,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+        cache: "pip"
+        cache-dependency-path: |
+          requirements_dev.txt
+          requirements.txt
+          setup.py
 
     - name: Install requirements
       run: python -m pip install -r requirements.txt -r requirements_dev.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,13 @@ combine_as_imports = true
 filter_files = true
 
 
-[tool.taskipy.settings]
-runner = "dotenv -f task.env run --"
-
 [tool.taskipy.tasks]
 black = { cmd = "task lint black", help = "Run black" }
 docs = { cmd = "cd docs && sphinx-autobuild . _build/html --ignore _build --watch ../disnake --port 8009", help = "Build the documentation on an autoreloading server."}
 isort = { cmd = "task lint isort", help = "Run isort" }
 lint = { cmd = "pre-commit run --all-files", help = "Check all files for linting errors" }
 precommit = { cmd = "pre-commit install --install-hooks", help = "Install the precommit hook" }
-pyright = { cmd = "pyright", help = "Run pyright" }
+pyright = { cmd = "dotenv -f task.env run -- pyright", help = "Run pyright" }
 slotscheck = { cmd = "python -m slotscheck --verbose -m disnake", help = "Run slotscheck" }
 
 


### PR DESCRIPTION
## Summary

- Fixes the `docs` task (broken by #311, oops)
- Updates the `actions/checkout` action to v3, notably also including the v2 changes (duh) which might speed things up a tiny bit as it won't fetch the entire repository by default any longer
- Makes all jobs use the same pip cache

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
