### PR TITLE
refactor: enable additional pyright rules

### DIFF
--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -20,7 +20,7 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 import logging
 from typing import Literal, NamedTuple
 
-from . import abc, opus, ui, utils
+from . import abc as abc, opus as opus, ui as ui, utils as utils
 from .activity import *
 from .app_commands import *
 from .appinfo import *

--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -20,7 +20,7 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 import logging
 from typing import Literal, NamedTuple
 
-from . import abc as abc, opus as opus, ui as ui, utils as utils
+from . import abc as abc, opus as opus, ui as ui, utils as utils  # explicitly re-export modules
 from .activity import *
 from .app_commands import *
 from .appinfo import *

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -466,6 +466,7 @@ class GuildChannel(ABC):
         :class:`~disnake.PermissionOverwrite`
             The permission overwrites for this object.
         """
+        predicate: Callable[[_Overwrites], bool]
         if isinstance(obj, User):
             predicate = lambda p: p.is_member()
         elif isinstance(obj, Role):

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -124,9 +124,9 @@ def _transform_overwrites(
         ow_type = elem["type"]
         ow_id = int(elem["id"])
         target = None
-        if ow_type == "0":
+        if ow_type == 0:
             target = entry.guild.get_role(ow_id)
-        elif ow_type == "1":
+        elif ow_type == 1:
             target = entry._get_member(ow_id)
 
         if target is None:

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -319,7 +319,7 @@ class AuditLogChanges:
             setattr(first, "roles", [])
 
         data = []
-        g: Guild = entry.guild  # type: ignore
+        g: Guild = entry.guild
 
         for e in elem:
             role_id = int(e["id"])
@@ -549,7 +549,7 @@ class AuditLogEntry(Hashable):
         return self.guild
 
     def _convert_target_channel(self, target_id: int) -> Union[abc.GuildChannel, Object]:
-        return self.guild.get_channel(target_id) or Object(id=target_id)  # type: ignore
+        return self.guild.get_channel(target_id) or Object(id=target_id)
 
     def _convert_target_user(self, target_id: int) -> Union[Member, User, None]:
         return self._get_member(target_id)

--- a/disnake/backoff.py
+++ b/disnake/backoff.py
@@ -68,7 +68,9 @@ class ExponentialBackoff(Generic[T]):
         rand = random.Random()
         rand.seed()
 
-        self._randfunc: Callable[..., Union[int, float]] = rand.randrange if integral else rand.uniform  # type: ignore
+        self._randfunc: Callable[..., Union[int, float]] = (
+            rand.randrange if integral else rand.uniform
+        )
 
     @overload
     def delay(self: ExponentialBackoff[Literal[False]]) -> float:

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -212,7 +212,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         )
         self._type: int = data.get("type", self._type)
         self.last_message_id: Optional[int] = utils._get_as_snowflake(data, "last_message_id")
-        self._fill_overwrites(data)  # type: ignore
+        self._fill_overwrites(data)
 
     async def _get_channel(self):
         return self
@@ -2057,7 +2057,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         self._state = state
         self.id = channel_id
         # state.user won't be None here
-        self.me = state.user  # type: ignore
+        self.me = state.user
         self.recipient = state.get_user(user_id) if user_id != self.me.id else None
         return self
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -361,7 +361,7 @@ class Client:
     @property
     def user(self) -> ClientUser:
         """Optional[:class:`.ClientUser`]: Represents the connected client. ``None`` if not logged in."""
-        return self._connection.user  # type: ignore
+        return self._connection.user
 
     @property
     def guilds(self) -> List[Guild]:
@@ -426,7 +426,7 @@ class Client:
 
         .. versionadded:: 2.0
         """
-        return self._connection.application_flags  # type: ignore
+        return self._connection.application_flags
 
     @property
     def global_application_commands(self) -> List[APIApplicationCommand]:
@@ -1535,7 +1535,7 @@ class Client:
         """
         code = utils.resolve_template(code)
         data = await self.http.get_template(code)
-        return Template(data=data, state=self._connection)  # type: ignore
+        return Template(data=data, state=self._connection)
 
     async def fetch_guild(self, guild_id: int, /) -> Guild:
         """|coro|

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -25,7 +25,19 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from .enums import ButtonStyle, ComponentType, TextInputStyle, try_enum
 from .partial_emoji import PartialEmoji, _EmojiTag
@@ -441,8 +453,8 @@ class TextInput(Component):
     def to_dict(self) -> TextInputPayload:
         payload: TextInputPayload = {
             "type": self.type.value,
-            "style": self.style.value,  # type: ignore
-            "label": self.label,  # type: ignore
+            "style": self.style.value,
+            "label": cast(str, self.label),
             "custom_id": self.custom_id,
             "required": self.required,
         }

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -142,7 +142,7 @@ class EnumMeta(type):
         attrs["_enum_member_names_"] = member_names
         attrs["_enum_value_cls_"] = value_cls
         actual_cls = super().__new__(cls, name, bases, attrs)
-        value_cls._actual_enum_cls_ = actual_cls  # type: ignore
+        value_cls._actual_enum_cls_ = actual_cls
         return actual_cls
 
     def __iter__(cls):

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -231,7 +231,7 @@ class InvokableApplicationCommand(ABC):
 
         try:
             self._prepare_cooldowns(inter)
-            await self.call_before_hooks(inter)  # type: ignore
+            await self.call_before_hooks(inter)
         except:
             if self._max_concurrency is not None:
                 await self._max_concurrency.release(inter)  # type: ignore

--- a/disnake/ext/commands/cog.py
+++ b/disnake/ext/commands/cog.py
@@ -244,11 +244,11 @@ class Cog(metaclass=CogMeta):
         # r.e type ignore, type-checker complains about overriding a ClassVar
         self.__cog_commands__ = tuple(c._update_copy(cmd_attrs) for c in cls.__cog_commands__)  # type: ignore
 
-        lookup = {cmd.qualified_name: cmd for cmd in self.__cog_commands__}  # type: ignore
+        lookup = {cmd.qualified_name: cmd for cmd in self.__cog_commands__}
 
         # Update the Command instances dynamically as well
         for command in self.__cog_commands__:
-            setattr(self, command.callback.__name__, command)  # type: ignore
+            setattr(self, command.callback.__name__, command)
             parent = command.parent
             if parent is not None:
                 # Get the latest parent reference

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -1094,7 +1094,7 @@ _GenericAlias = type(List[T])
 
 
 def is_generic_type(tp: Any, *, _GenericAlias: Type = _GenericAlias) -> bool:
-    return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, _GenericAlias)  # type: ignore
+    return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, _GenericAlias)
 
 
 CONVERTER_MAPPING: Dict[Type[Any], Type[Converter]] = {

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -1449,7 +1449,7 @@ class Group(GroupMixin[CogT], Command[CogT, P, T]):
         ret = super().copy()
         for cmd in self.commands:
             ret.add_command(cmd.copy())
-        return ret  # type: ignore
+        return ret
 
     async def invoke(self, ctx: Context) -> None:
         ctx.invoked_subcommand = None

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -1338,7 +1338,7 @@ class GroupMixin(Generic[CogT]):
     ) -> Callable[[CommandCallback[CogT, ContextT, P, T]], CommandT]:
         ...
 
-    def command(  # type: ignore
+    def command(
         self,
         name: str = MISSING,
         cls: Union[Type[Command[CogT, P, T]], Type[CommandT]] = MISSING,
@@ -1384,7 +1384,7 @@ class GroupMixin(Generic[CogT]):
     ) -> Callable[[CommandCallback[CogT, ContextT, P, T]], GroupT]:
         ...
 
-    def group(  # type: ignore
+    def group(
         self,
         name: str = MISSING,
         cls: Union[Type[Group[CogT, P, T]], Type[GroupT]] = MISSING,
@@ -1544,8 +1544,7 @@ def command(
     ...
 
 
-# ignored since the order in the Union in CommandCallback matters here for some reason
-def command(  # type: ignore
+def command(
     name: str = MISSING,
     cls: Union[Type[Command[CogT, P, T]], Type[CommandT]] = MISSING,
     **attrs: Any,
@@ -1610,7 +1609,7 @@ def group(
     ...
 
 
-def group(  # type: ignore  # see command above
+def group(
     name: str = MISSING,
     cls: Union[Type[Group[CogT, P, T]], Type[GroupT]] = MISSING,
     **attrs: Any,

--- a/disnake/ext/commands/errors.py
+++ b/disnake/ext/commands/errors.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:
     from disnake.types.snowflake import Snowflake, SnowflakeList
 
     from .context import Context
-    from .converter import Converter
     from .cooldowns import BucketType, Cooldown
     from .flags import Flag
 

--- a/disnake/ext/commands/flags.py
+++ b/disnake/ext/commands/flags.py
@@ -634,7 +634,7 @@ class FlagConverter(metaclass=FlagsMeta):
             values = [await convert_flag(ctx, value, flag) for value in values]
 
             if flag.cast_to_dict:
-                values = dict(values)  # type: ignore
+                values = dict(values)
 
             setattr(self, flag.attribute, values)
 

--- a/disnake/ext/commands/help.py
+++ b/disnake/ext/commands/help.py
@@ -27,7 +27,7 @@ import copy
 import functools
 import itertools
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
 
 import disnake.utils
 
@@ -527,7 +527,13 @@ class HelpCommand:
             return f'Command "{command.qualified_name}" has no subcommand named {string}'
         return f'Command "{command.qualified_name}" has no subcommands.'
 
-    async def filter_commands(self, commands, *, sort=False, key=None):
+    async def filter_commands(
+        self,
+        commands: Iterable[Command[Any, Any, Any]],
+        *,
+        sort: bool = False,
+        key: Optional[Callable[[Command[Any, Any, Any]], Any]] = None,
+    ):
         """|coro|
 
         Returns a filtered list of commands and optionally sorts them.
@@ -551,7 +557,11 @@ class HelpCommand:
         List[:class:`Command`]
             A list of commands that passed the filter.
         """
-        if sort and key is None:
+
+        # set `key` iff `sort` is true
+        if not sort:
+            key = None
+        elif key is None:
             key = lambda c: c.name
 
         iterator = commands if self.show_hidden else filter(lambda c: not c.hidden, commands)
@@ -559,11 +569,11 @@ class HelpCommand:
         if self.verify_checks is False:
             # if we do not need to verify the checks then we can just
             # run it straight through normally without using await.
-            return sorted(iterator, key=key) if sort else list(iterator)
+            return sorted(iterator, key=key) if key else list(iterator)
 
         if self.verify_checks is None and not self.context.guild:
             # if verify_checks is None and we're in a DM, don't verify
-            return sorted(iterator, key=key) if sort else list(iterator)
+            return sorted(iterator, key=key) if key else list(iterator)
 
         # if we're here then we need to check every command if it can run
         async def predicate(cmd):
@@ -578,7 +588,7 @@ class HelpCommand:
             if valid:
                 ret.append(cmd)
 
-        if sort:
+        if key:
             ret.sort(key=key)
         return ret
 

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -1129,8 +1129,7 @@ class InteractionBotBase(CommonBotBase):
         if len(checks) == 0:
             return True
 
-        # type-checker doesn't distinguish between functions and methods
-        return await disnake.utils.async_all(f(inter) for f in checks)  # type: ignore
+        return await disnake.utils.async_all(f(inter) for f in checks)
 
     def before_slash_command_invoke(self, coro: CFT) -> CFT:
         """Similar to :meth:`Bot.before_invoke` but for slash commands,

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -32,7 +32,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Coroutine,
     Dict,
     Iterable,
     List,
@@ -55,7 +54,6 @@ from disnake.enums import ApplicationCommandType
 
 from . import errors
 from .base_core import InvokableApplicationCommand
-from .cog import Cog
 from .common_bot_base import CommonBotBase
 from .context import Context
 from .ctx_menus_core import (

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -635,10 +635,6 @@ def isolate_self(
     function: Callable,
 ) -> Tuple[Tuple[Optional[inspect.Parameter], ...], Dict[str, inspect.Parameter]]:
     """Create parameters without self and the first interaction"""
-    is_interaction = (
-        lambda annot: issubclass_(annot, CommandInteraction) or annot is inspect.Parameter.empty
-    )
-
     sig = signature(function)
 
     parameters = dict(sig.parameters)
@@ -653,8 +649,10 @@ def isolate_self(
     if parametersl[0].name == "self":
         cog_param = parameters.pop(parametersl[0].name)
         parametersl.pop(0)
-    if parametersl and is_interaction(parametersl[0].annotation):
-        inter_param = parameters.pop(parametersl[0].name)
+    if parametersl:
+        annot = parametersl[0].annotation
+        if issubclass_(annot, CommandInteraction) or annot is inspect.Parameter.empty:
+            inter_param = parameters.pop(parametersl[0].name)
 
     return (cog_param, inter_param), parameters
 

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -457,7 +457,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         finally:
             if stop_propagation:
                 return
-            inter.bot.dispatch("slash_command_error", inter, error)  # type: ignore
+            inter.bot.dispatch("slash_command_error", inter, error)
 
     async def _call_autocompleter(
         self, param: str, inter: ApplicationCommandInteraction, user_input: str

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -604,7 +604,7 @@ class Guild(Hashable):
         if "channels" in data:
             channels = data["channels"]
             for c in channels:
-                factory, ch_type = _guild_channel_factory(c["type"])
+                factory, _ = _guild_channel_factory(c["type"])
                 if factory:
                     self._add_channel(factory(guild=self, data=c, state=self._state))  # type: ignore
 
@@ -1814,7 +1814,7 @@ class Guild(Hashable):
         data = await self._state.http.get_all_guild_channels(self.id)
 
         def convert(d):
-            factory, ch_type = _guild_channel_factory(d["type"])
+            factory, _ = _guild_channel_factory(d["type"])
             if factory is None:
                 raise InvalidData("Unknown channel type {type} for channel ID {id}.".format_map(d))
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -106,7 +106,7 @@ async def json_or_text(response: aiohttp.ClientResponse) -> Union[Dict[str, Any]
     text = await response.text(encoding="utf-8")
     try:
         if response.headers["content-type"] == "application/json":
-            return utils._from_json(text)  # type: ignore
+            return utils._from_json(text)
     except KeyError:
         # Thanks Cloudflare
         pass

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -404,7 +404,7 @@ class ApplicationCommandInteractionDataResolved:
             self.roles[int(str_id)] = Role(guild=guild, state=state, data=role)  # type: ignore
 
         for str_id, channel in channels.items():
-            factory, ch_type = _threaded_channel_factory(channel["type"])
+            factory, _ = _threaded_channel_factory(channel["type"])
             if factory:
                 channel["position"] = 0  # type: ignore
                 self.channels[int(str_id)] = (  # type: ignore

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -442,7 +442,7 @@ class Invite(Hashable):
         guild: Optional[Union[Guild, Object]] = state._get_guild(guild_id)
         channel_id = int(data["channel_id"])
         if guild is not None:
-            channel = guild.get_channel(channel_id) or Object(id=channel_id)  # type: ignore
+            channel = guild.get_channel(channel_id) or Object(id=channel_id)
         else:
             guild = Object(id=guild_id) if guild_id is not None else None
             channel = Object(id=channel_id)

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from .member import Member
     from .message import Message
     from .threads import Thread
-    from .types.audit_log import AuditLog as AuditLogPayload
+    from .types.audit_log import AuditLog as AuditLogPayload, AuditLogEntry as AuditLogEntryPayload
     from .types.guild import Guild as GuildPayload
     from .types.message import Message as MessagePayload
     from .types.threads import Thread as ThreadPayload
@@ -430,7 +430,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         self._users = {}
         self._state = guild._state
 
-        self._filter = None  # entry dict -> bool
+        self._filter: Optional[Callable[[AuditLogEntryPayload], bool]] = None
 
         self.entries = asyncio.Queue()
 

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -293,7 +293,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         self.after = after or OLDEST_OBJECT
         self.around = around
 
-        self._filter = None  # message dict -> bool
+        self._filter: Optional[Callable[[MessagePayload], bool]] = None
 
         self.state = self.messageable._state
         self.logs_from = self.state.http.logs_from
@@ -313,7 +313,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
             elif self.before:
                 self._filter = lambda m: int(m["id"]) < self.before.id  # type: ignore
             elif self.after:
-                self._filter = lambda m: self.after.id < int(m["id"])  # type: ignore
+                self._filter = lambda m: self.after.id < int(m["id"])
         else:
             if self.reverse:
                 self._retrieve_messages = self._retrieve_messages_after_strategy  # type: ignore

--- a/disnake/opus.py
+++ b/disnake/opus.py
@@ -413,7 +413,7 @@ class Encoder(_OpusStruct):
         _lib.opus_encoder_ctl(self._state, CTL_SET_FEC, 1 if enabled else 0)
 
     def set_expected_packet_loss_percent(self, percentage: float) -> None:
-        _lib.opus_encoder_ctl(self._state, CTL_SET_PLP, min(100, max(0, int(percentage * 100))))  # type: ignore
+        _lib.opus_encoder_ctl(self._state, CTL_SET_PLP, min(100, max(0, int(percentage * 100))))
 
     def encode(self, pcm: bytes, frame_size: int) -> bytes:
         max_data_bytes = len(pcm)
@@ -424,7 +424,7 @@ class Encoder(_OpusStruct):
         ret = _lib.opus_encode(self._state, pcm_ptr, frame_size, data, max_data_bytes)
 
         # array can be initialized with bytes but mypy doesn't know
-        return array.array("b", data[:ret]).tobytes()  # type: ignore
+        return array.array("b", data[:ret]).tobytes()
 
 
 class Decoder(_OpusStruct):

--- a/disnake/opus.py
+++ b/disnake/opus.py
@@ -423,7 +423,6 @@ class Encoder(_OpusStruct):
 
         ret = _lib.opus_encode(self._state, pcm_ptr, frame_size, data, max_data_bytes)
 
-        # array can be initialized with bytes but mypy doesn't know
         return array.array("b", data[:ret]).tobytes()
 
 

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -559,7 +559,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         codec = bitrate = None
         loop = asyncio.get_event_loop()
         try:
-            codec, bitrate = await loop.run_in_executor(None, lambda: probefunc(source, executable))  # type: ignore
+            codec, bitrate = await loop.run_in_executor(None, lambda: probefunc(source, executable))
         except Exception:
             if not fallback:
                 _log.exception("Probe '%s' using '%s' failed", method, executable)
@@ -567,7 +567,9 @@ class FFmpegOpusAudio(FFmpegAudio):
 
             _log.exception("Probe '%s' using '%s' failed, trying fallback", method, executable)
             try:
-                codec, bitrate = await loop.run_in_executor(None, lambda: fallback(source, executable))  # type: ignore
+                codec, bitrate = await loop.run_in_executor(
+                    None, lambda: fallback(source, executable)
+                )
             except Exception:
                 _log.exception("Fallback probe using '%s' failed", executable)
             else:

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -452,10 +452,10 @@ class AutoShardedClient(Client):
             if item.type == EventType.close:
                 await self.close()
                 if isinstance(item.error, ConnectionClosed):
-                    if item.error.code != 1000:
-                        raise item.error
                     if item.error.code == 4014:
                         raise PrivilegedIntentsRequired(item.shard.id) from None
+                    if item.error.code != 1000:
+                        raise item.error
                 return
             elif item.type in (EventType.identify, EventType.resume):
                 await item.shard.reidentify(item.error)

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -2016,6 +2016,7 @@ class AutoShardedConnectionState(ConnectionState):
 
         guilds = sorted(processed, key=lambda g: g[0].shard_id)
         for shard_id, info in itertools.groupby(guilds, key=lambda g: g[0].shard_id):
+            # this is equivalent to `children, futures = zip(*info)`, but typed properly
             children: List[Guild] = []
             futures: List[asyncio.Future[List[Member]]] = []
             for c, f in info:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1015,7 +1015,7 @@ class ConnectionState:
             _log.debug("CHANNEL_UPDATE referencing an unknown guild ID: %s. Discarding.", guild_id)
 
     def parse_channel_create(self, data) -> None:
-        factory, ch_type = _channel_factory(data["type"])
+        factory, _ = _channel_factory(data["type"])
         if factory is None:
             _log.debug(
                 "CHANNEL_CREATE referencing an unknown channel type %s. Discarding.", data["type"]

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -586,7 +586,7 @@ class ConnectionState:
 
     def add_dm_channel(self, data: DMChannelPayload) -> DMChannel:
         # self.user is *always* cached when this is called
-        channel = DMChannel(me=self.user, state=self, data=data)  # type: ignore
+        channel = DMChannel(me=self.user, state=self, data=data)
         self._add_private_channel(channel)
         return channel
 
@@ -761,7 +761,7 @@ class ConnectionState:
             else:
                 self.application_id = utils._get_as_snowflake(application, "id")
                 # flags will always be present here
-                self.application_flags = ApplicationFlags._from_value(application["flags"])  # type: ignore
+                self.application_flags = ApplicationFlags._from_value(application["flags"])
 
         for guild_data in data["guilds"]:
             self._add_guild_from_data(guild_data)
@@ -965,7 +965,7 @@ class ConnectionState:
 
     def parse_user_update(self, data) -> None:
         # self.user is *always* cached when this is called
-        user: ClientUser = self.user  # type: ignore
+        user: ClientUser = self.user
         user._update(data)
         ref = self._users.get(user.id)
         if ref:
@@ -1099,7 +1099,7 @@ class ConnectionState:
         thread_id = int(data["id"])
         thread = guild.get_thread(thread_id)
         if thread is not None:
-            guild._remove_thread(thread)  # type: ignore
+            guild._remove_thread(thread)
             self.dispatch("thread_delete", thread)
 
     def parse_thread_list_sync(self, data) -> None:
@@ -1225,7 +1225,7 @@ class ConnectionState:
             user_id = int(data["user"]["id"])
             member = guild.get_member(user_id)
             if member is not None:
-                guild._remove_member(member)  # type: ignore
+                guild._remove_member(member)
                 self.dispatch("member_remove", member)
         else:
             _log.debug(
@@ -1280,7 +1280,7 @@ class ConnectionState:
         for emoji in before_emojis:
             self._emojis.pop(emoji.id, None)
         # guild won't be None here
-        guild.emojis = tuple(map(lambda d: self.store_emoji(guild, d), data["emojis"]))  # type: ignore
+        guild.emojis = tuple(map(lambda d: self.store_emoji(guild, d), data["emojis"]))
         self.dispatch("guild_emojis_update", guild, before_emojis, guild.emojis)
 
     def parse_guild_stickers_update(self, data) -> None:
@@ -1296,7 +1296,7 @@ class ConnectionState:
         for emoji in before_stickers:
             self._stickers.pop(emoji.id, None)
         # guild won't be None here
-        guild.stickers = tuple(map(lambda d: self.store_sticker(guild, d), data["stickers"]))  # type: ignore
+        guild.stickers = tuple(map(lambda d: self.store_sticker(guild, d), data["stickers"]))
         self.dispatch("guild_stickers_update", guild, before_stickers, guild.stickers)
 
     def _get_create_guild(self, data):
@@ -1685,7 +1685,7 @@ class ConnectionState:
         channel_id = utils._get_as_snowflake(data, "channel_id")
         flags = self.member_cache_flags
         # self.user is *always* cached when this is called
-        self_id = self.user.id  # type: ignore
+        self_id = self.user.id
         if guild is not None:
             if int(data["user_id"]) == self_id:
                 voice = self._get_voice_client(guild.id)
@@ -1701,7 +1701,7 @@ class ConnectionState:
                     if channel_id is None and flags._voice_only and member.id != self_id:
                         # Only remove from cache if we only have the voice flag enabled
                         # Member doesn't meet the Snowflake protocol currently
-                        guild._remove_member(member)  # type: ignore
+                        guild._remove_member(member)
                     elif channel_id is not None:
                         guild._add_member(member)
 

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Union
 
 from .channel import ChannelType
 from .components import ActionRow, Component, ComponentType

--- a/disnake/types/invite.py
+++ b/disnake/types/invite.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, Optional, TypedDict, Union
+from typing import Literal, Optional, TypedDict, Union
 
 from .appinfo import PartialAppInfo
 from .channel import PartialChannel

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -113,7 +113,7 @@ class ActionRow:
             raise ValueError("Too many components in this row, can not append a new one.")
 
         self.width += item.width
-        self._underlying.children.append(item._underlying)  # type: ignore
+        self._underlying.children.append(item._underlying)
 
     def add_button(
         self,

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -31,7 +31,6 @@ from typing import (
     Any,
     Callable,
     Coroutine,
-    Dict,
     Generic,
     Optional,
     Protocol,

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import inspect
 import os
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 from ..components import SelectMenu, SelectOption
 from ..enums import ComponentType

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -94,7 +94,7 @@ class _ViewWeights:
     def __init__(self, children: List[Item]):
         self.weights: List[int] = [0, 0, 0, 0, 0]
 
-        key = lambda i: sys.maxsize if i.row is None else i.row
+        key: Callable[[Item[View]], int] = lambda i: sys.maxsize if i.row is None else i.row
         children = sorted(children, key=key)
         for _, group in groupby(children, key=key):
             for item in group:

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -96,7 +96,7 @@ class _ViewWeights:
 
         key = lambda i: sys.maxsize if i.row is None else i.row
         children = sorted(children, key=key)
-        for row, group in groupby(children, key=key):
+        for _, group in groupby(children, key=key):
             for item in group:
                 self.add_item(item)
 

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1231,7 +1231,7 @@ def search_directory(path: str) -> Iterator[str]:
 
     prefix = relpath.replace(os.sep, ".")
 
-    for finder, name, ispkg in pkgutil.iter_modules([path]):
+    for _, name, ispkg in pkgutil.iter_modules([path]):
         if ispkg:
             yield from search_directory(os.path.join(path, name))
         else:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -33,7 +33,6 @@ import os
 import pkgutil
 import re
 import sys
-import types
 import unicodedata
 import warnings
 from base64 import b64encode, urlsafe_b64decode as b64decode
@@ -1059,7 +1058,12 @@ def as_chunks(iterator: _Iter[T], max_size: int) -> _Iter[List[T]]:
     return _chunk(iterator, max_size)
 
 
-PY_310 = sys.version_info >= (3, 10)
+if sys.version_info >= (3, 10):
+    PY_310 = True
+    from types import UnionType
+else:
+    PY_310 = False
+    UnionType = object()
 
 
 def flatten_literal_params(parameters: Iterable[Any]) -> Tuple[Any, ...]:
@@ -1103,7 +1107,7 @@ def evaluate_annotation(
         is_literal = False
         args = tp.__args__
         if not hasattr(tp, "__origin__"):
-            if PY_310 and tp.__class__ is types.UnionType:  # type: ignore
+            if tp.__class__ is UnionType:
                 converted = Union[args]  # type: ignore
                 return evaluate_annotation(converted, globals, locals, cache)
 

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -68,7 +68,7 @@ from urllib.parse import parse_qs, urlencode
 from .errors import InvalidArgument
 
 try:
-    import orjson  # type: ignore
+    import orjson
 except ModuleNotFoundError:
     HAS_ORJSON = False
 else:
@@ -530,7 +530,7 @@ def _bytes_to_base64_data(data: bytes) -> str:
 
 if HAS_ORJSON:
 
-    def _to_json(obj: Any) -> str:  # type: ignore
+    def _to_json(obj: Any) -> str:
         return orjson.dumps(obj).decode("utf-8")
 
     _from_json = orjson.loads  # type: ignore

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -71,8 +71,8 @@ if TYPE_CHECKING:
 has_nacl: bool
 
 try:
-    import nacl.secret  # type: ignore
-    import nacl.utils  # type: ignore
+    import nacl.secret
+    import nacl.utils
 
     has_nacl = True
 except ImportError:

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -1,6 +1,5 @@
 import importlib
 import inspect
-import os
 import re
 from collections import OrderedDict, namedtuple
 

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -155,7 +155,7 @@ def build_lookup_table(env):
         "class",
     }
 
-    for (fullname, _, objtype, docname, _, _) in domain.get_objects():
+    for (fullname, _, objtype, _, _, _) in domain.get_objects():
         if objtype in ignored:
             continue
 

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -1,10 +1,13 @@
 import importlib
 import inspect
 import re
-from collections import OrderedDict, namedtuple
+from collections import defaultdict
+from typing import DefaultDict, Dict, List, NamedTuple, Optional
 
 from docutils import nodes
 from sphinx import addnodes
+from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
 from sphinx.locale import _
 from sphinx.util.docutils import SphinxDirective
 
@@ -142,10 +145,10 @@ class PyAttributeTable(SphinxDirective):
         return [node]
 
 
-def build_lookup_table(env):
+def build_lookup_table(env: BuildEnvironment) -> Dict[str, List[str]]:
     # Given an environment, load up a lookup table of
     # full-class-name: objects
-    result = {}
+    result: DefaultDict[str, List[str]] = defaultdict(list)
     domain = env.domains["py"]
 
     ignored = {
@@ -160,18 +163,19 @@ def build_lookup_table(env):
             continue
 
         classname, _, child = fullname.rpartition(".")
-        try:
-            result[classname].append(child)
-        except KeyError:
-            result[classname] = [child]
+        result[classname].append(child)
 
     return result
 
 
-TableElement = namedtuple("TableElement", "fullname label badge")
+class TableElement(NamedTuple):
+    fullname: str
+    label: str
+    badge: Optional[attributetablebadge]
 
 
-def process_attributetable(app, doctree, fromdocname):
+def process_attributetable(app: Sphinx, doctree: nodes.document, docname: str):
+    assert app.builder and app.builder.env
     env = app.builder.env
 
     lookup = build_lookup_table(env)
@@ -196,16 +200,16 @@ def process_attributetable(app, doctree, fromdocname):
             node.replace_self([table])
 
 
-def get_class_results(lookup, modulename, name, fullname):
+def get_class_results(
+    lookup: Dict[str, List[str]], modulename: str, name: str, fullname: str
+) -> Dict[str, List[TableElement]]:
     module = importlib.import_module(modulename)
     cls = getattr(module, name)
 
-    groups = OrderedDict(
-        [
-            (_("Attributes"), []),
-            (_("Methods"), []),
-        ]
-    )
+    groups: Dict[str, List[TableElement]] = {
+        _("Attributes"): [],
+        _("Methods"): [],
+    }
 
     try:
         members = lookup[fullname]
@@ -251,7 +255,7 @@ def get_class_results(lookup, modulename, name, fullname):
     return groups
 
 
-def class_results_to_node(key, elements):
+def class_results_to_node(key: str, elements: List[TableElement]) -> attributetablecolumn:
     title = attributetabletitle(key, key)
     ul = nodes.bullet_list("")
     ul.set_class("py-attribute-table-list")
@@ -273,7 +277,7 @@ def class_results_to_node(key, elements):
     return attributetablecolumn("", title, ul)
 
 
-def setup(app):
+def setup(app: Sphinx) -> None:
     app.add_directive("attributetable", PyAttributeTable)
     app.add_node(attributetable, html=(visit_attributetable_node, depart_attributetable_node))
     app.add_node(

--- a/docs/extensions/exception_hierarchy.py
+++ b/docs/extensions/exception_hierarchy.py
@@ -1,6 +1,5 @@
 from docutils import nodes
-from docutils.parsers.rst import Directive, directives, states  # type: ignore
-from docutils.parsers.rst.roles import set_classes
+from docutils.parsers.rst import Directive
 from sphinx.locale import _
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,4 @@ reportInvalidTypeVarUse = true
 reportUnnecessaryCast = true
 reportSelfClsParameterName = true
 reportUnsupportedDunderAll = true
+reportUnusedImport = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,4 @@ reportSelfClsParameterName = true
 reportUnsupportedDunderAll = true
 reportUnusedImport = true
 reportUnusedVariable = true
+reportUntypedNamedTuple = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,4 @@ reportUnsupportedDunderAll = true
 reportUnusedImport = true
 reportUnusedVariable = true
 reportUntypedNamedTuple = true
+reportUnnecessaryComparison = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,4 @@ reportUnusedImport = true
 reportUnusedVariable = true
 reportUntypedNamedTuple = true
 reportUnnecessaryComparison = true
+reportUnnecessaryTypeIgnoreComment = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,4 @@ reportUnnecessaryCast = true
 reportSelfClsParameterName = true
 reportUnsupportedDunderAll = true
 reportUnusedImport = true
+reportUnusedVariable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,4 @@ reportUnusedVariable = true
 reportUntypedNamedTuple = true
 reportUnnecessaryComparison = true
 reportUnnecessaryTypeIgnoreComment = true
+reportUnknownLambdaType = true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,4 +4,4 @@ slotscheck~=0.13.0
 mypy~=0.910
 python-dotenv[cli]~=0.19.2
 # this is not pyright itself, but the python wrapper
-pyright==1.1.225
+pyright==1.1.226

--- a/test_bot/cogs/events.py
+++ b/test_bot/cogs/events.py
@@ -1,4 +1,3 @@
-import disnake
 from disnake.ext import commands
 
 

--- a/test_bot/cogs/injections.py
+++ b/test_bot/cogs/injections.py
@@ -1,3 +1,5 @@
+# pyright: reportUnknownLambdaType=false
+
 from __future__ import annotations
 
 from pprint import pformat

--- a/test_bot/cogs/slash_commands.py
+++ b/test_bot/cogs/slash_commands.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import disnake
 from disnake.ext import commands
 

--- a/test_launcher.py
+++ b/test_launcher.py
@@ -6,4 +6,4 @@ if __name__ == "__main__":
 
     os.environ["BOT_TOKEN"] = token
 
-    import test_bot.main
+    import test_bot.main  # type: ignore


### PR DESCRIPTION
## Summary

Enables a few additional pyright diagnostics and changes the code accordingly (see individual commits).
This also uncovered two minor bugs:
- `AuditLogDiff.overwrites` target would always be an `Object`, since the target type check used strings instead of ints
- the websocket close handler for autosharded clients wouldn't handle a specific error code on close and instead raise a generic error

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
