### PR TITLE
feat: implement `StageInstance.guild_scheduled_event[_id]`

### DIFF
--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -978,6 +978,7 @@ class Intents(BaseFlags):
 
         - :attr:`Guild.scheduled_events`
         - :meth:`Guild.get_scheduled_event`
+        - :attr:`StageInstance.guild_scheduled_event`
         """
         return 1 << 16
 

--- a/disnake/stage_instance.py
+++ b/disnake/stage_instance.py
@@ -148,7 +148,8 @@ class StageInstance(Hashable):
         """Optional[:class:`GuildScheduledEvent`]: The stage instance's scheduled event.
 
         This is only set if this stage instance has an associated scheduled event,
-        and requires that event to be cached.
+        and requires that event to be cached
+        (which requires the :attr:`~Intents.guild_scheduled_events` intent).
         """
         if self.guild_scheduled_event_id is None:
             return None

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -168,6 +168,7 @@ class StageInstance(TypedDict):
     topic: str
     privacy_level: PrivacyLevel
     discoverable_disabled: bool
+    guild_scheduled_event_id: Optional[Snowflake]
 
 
 class GuildDirectory(_BaseChannel):


### PR DESCRIPTION
## Summary

This PR adds `StageInstance.guild_scheduled_event_id`, as well as a `.guild_scheduled_event` property which works as long as the proper intents are enabled.

ref: https://github.com/discord/discord-api-docs/pull/4583

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
