### PR TITLE
fix(converter): move import for `commands.clean_content`

### DIFF
--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -54,6 +54,7 @@ from .errors import *
 if TYPE_CHECKING:
     from disnake.message import MessageableChannel
 
+    # TODO: don't use unbound generic `Context`
     from .core import AnyContext
 
 # TODO: USE ACTUAL FUNCTIONS INSTEAD OF USELESS CLASSES
@@ -1015,9 +1016,10 @@ class clean_content(Converter[str]):
 
     async def convert(self, ctx: AnyContext, argument: str) -> str:
         msg = ctx.message if isinstance(ctx, Context) else None
+        bot: disnake.Client = ctx.bot
 
         def resolve_user(id: int) -> str:
-            m = (msg and _utils_get(msg.mentions, id=id)) or ctx.bot.get_user(id)
+            m = (msg and _utils_get(msg.mentions, id=id)) or bot.get_user(id)
             if m is None and ctx.guild:
                 m = ctx.guild.get_member(id)
             return f"@{m.display_name if self.use_nicknames else m.name}" if m else "@deleted-user"

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -48,12 +48,12 @@ from typing import (
 
 import disnake
 
+from .context import Context
 from .errors import *
 
 if TYPE_CHECKING:
     from disnake.message import MessageableChannel
 
-    from .context import Context
     from .core import AnyContext
 
 # TODO: USE ACTUAL FUNCTIONS INSTEAD OF USELESS CLASSES

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -208,7 +208,7 @@ class MemberConverter(IDConverter[disnake.Member]):
         if len(argument) > 5 and argument[-5] == "#":
             username, _, discriminator = argument.rpartition("#")
             members = await guild.query_members(username, limit=100, cache=cache)
-            return disnake.utils.get(members, name=username, discriminator=discriminator)
+            return _utils_get(members, name=username, discriminator=discriminator)
         else:
             members = await guild.query_members(argument, limit=100, cache=cache)
             return disnake.utils.find(lambda m: m.name == argument or m.nick == argument, members)
@@ -457,7 +457,7 @@ class GuildChannelConverter(IDConverter[disnake.abc.GuildChannel]):
             # not a mention
             if guild:
                 iterable: Iterable[CT] = getattr(guild, attribute)
-                result = disnake.utils.get(iterable, name=argument)
+                result = _utils_get(iterable, name=argument)
             else:
                 result = disnake.utils.find(
                     lambda c: isinstance(c, type) and c.name == argument, bot.get_all_channels()
@@ -484,7 +484,7 @@ class GuildChannelConverter(IDConverter[disnake.abc.GuildChannel]):
             # not a mention
             if guild:
                 iterable: Iterable[TT] = getattr(guild, attribute)
-                result = disnake.utils.get(iterable, name=argument)
+                result = _utils_get(iterable, name=argument)
         else:
             thread_id = int(match.group(1))
             if guild:
@@ -735,7 +735,7 @@ class RoleConverter(IDConverter[disnake.Role]):
         if match:
             result = guild.get_role(int(match.group(1)))
         else:
-            result = disnake.utils.get(guild._roles.values(), name=argument)
+            result = _utils_get(guild._roles.values(), name=argument)
 
         if result is None:
             raise RoleNotFound(argument)
@@ -786,7 +786,7 @@ class GuildConverter(IDConverter[disnake.Guild]):
             result = bot.get_guild(guild_id)
 
         if result is None:
-            result = disnake.utils.get(bot.guilds, name=argument)
+            result = _utils_get(bot.guilds, name=argument)
 
             if result is None:
                 raise GuildNotFound(argument)
@@ -820,10 +820,10 @@ class EmojiConverter(IDConverter[disnake.Emoji]):
         if match is None:
             # Try to get the emoji by name. Try local guild first.
             if guild:
-                result = disnake.utils.get(guild.emojis, name=argument)
+                result = _utils_get(guild.emojis, name=argument)
 
             if result is None:
-                result = disnake.utils.get(bot.emojis, name=argument)
+                result = _utils_get(bot.emojis, name=argument)
         else:
             # Try to look up emoji by id.
             result = bot.get_emoji(int(match.group(1)))
@@ -881,10 +881,10 @@ class GuildStickerConverter(IDConverter[disnake.GuildSticker]):
         if match is None:
             # Try to get the sticker by name. Try local guild first.
             if guild:
-                result = disnake.utils.get(guild.stickers, name=argument)
+                result = _utils_get(guild.stickers, name=argument)
 
             if result is None:
-                result = disnake.utils.get(bot.stickers, name=argument)
+                result = _utils_get(bot.stickers, name=argument)
         else:
             # Try to look up sticker by id.
             result = bot.get_sticker(int(match.group(1)))
@@ -973,7 +973,7 @@ class GuildScheduledEventConverter(IDConverter[disnake.GuildScheduledEvent]):
 
         # 3.
         if not result and guild:
-            result = disnake.utils.get(guild.scheduled_events, name=argument)
+            result = _utils_get(guild.scheduled_events, name=argument)
 
         if not result:
             raise GuildScheduledEventNotFound(argument)


### PR DESCRIPTION
## Summary

Fixes an import issue in the `clean_content` converter. Also improves typing a tiny bit and makes more use of the `_utils_get` shorthand.

resolves #392

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
