### PR TITLE
fix: correct NameError by moving import out of type checking clause 

### DIFF
--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -32,6 +32,8 @@ import disnake.abc
 import disnake.utils
 from disnake.message import Message
 
+from ... import ApplicationCommandInteraction
+
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
@@ -409,3 +411,6 @@ class GuildContext(Context):
     channel: Union[TextChannel, Thread, VoiceChannel]
     author: Member
     me: Member
+
+
+AnyContext = Union[Context, ApplicationCommandInteraction]

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -30,9 +30,8 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, List, Optional, TypeVar, U
 
 import disnake.abc
 import disnake.utils
+from disnake import ApplicationCommandInteraction
 from disnake.message import Message
-
-from ... import ApplicationCommandInteraction
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -48,14 +48,13 @@ from typing import (
 
 import disnake
 
-from .context import Context
+from .context import AnyContext, Context
 from .errors import *
 
 if TYPE_CHECKING:
     from disnake.message import MessageableChannel
 
     # TODO: don't use unbound generic `Context`
-    from .core import AnyContext
 
 # TODO: USE ACTUAL FUNCTIONS INSTEAD OF USELESS CLASSES
 

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -54,7 +54,6 @@ from .errors import *
 if TYPE_CHECKING:
     from disnake.message import MessageableChannel
 
-    # TODO: don't use unbound generic `Context`
 
 # TODO: USE ACTUAL FUNCTIONS INSTEAD OF USELESS CLASSES
 

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -48,11 +48,10 @@ from typing import (
 )
 
 import disnake
-from disnake.interactions import ApplicationCommandInteraction
 
 from ._types import _BaseCommand
 from .cog import Cog
-from .context import Context
+from .context import AnyContext, Context
 from .converter import Greedy, get_converter, run_converters
 from .cooldowns import BucketType, Cooldown, CooldownMapping, DynamicCooldownMapping, MaxConcurrency
 from .errors import *
@@ -98,7 +97,6 @@ T = TypeVar("T")
 CogT = TypeVar("CogT", bound="Cog")
 CommandT = TypeVar("CommandT", bound="Command")
 ContextT = TypeVar("ContextT", bound="Context")
-AnyContext = Union[Context, ApplicationCommandInteraction]
 GroupT = TypeVar("GroupT", bound="Group")
 HookT = TypeVar("HookT", bound="Hook")
 ErrorT = TypeVar("ErrorT", bound="Error")

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -44,6 +44,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
     get_origin,
     get_type_hints,
     overload,
@@ -95,7 +96,15 @@ __all__ = (
 
 
 def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[TypeT]:
-    if not isinstance(obj, type) or not isinstance(tp, (type, tuple)):
+    if not isinstance(obj, type):
+        # Assume we have a type hint
+        if get_origin(obj) in (Union, UnionType, Optional):
+            obj = get_args(obj)
+            return any(issubclass(o, tp) for o in obj)
+        else:
+            # Other type hint specializations are not supported
+            return False
+    elif not isinstance(tp, (type, tuple)):
         return False
     return issubclass(obj, tp)
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -96,7 +96,9 @@ __all__ = (
 
 
 def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[TypeT]:
-    if not isinstance(obj, type):
+    if not isinstance(tp, (type, tuple)):
+        return False
+    elif not isinstance(obj, type):
         # Assume we have a type hint
         if get_origin(obj) in (Union, UnionType, Optional):
             obj = get_args(obj)
@@ -104,8 +106,6 @@ def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[Type
         else:
             # Other type hint specializations are not supported
             return False
-    elif not isinstance(tp, (type, tuple)):
-        return False
     return issubclass(obj, tp)
 
 


### PR DESCRIPTION
## Summary

This PR fixes #384, correcting an import cycle as well as adding support for Union[] inside the self and cog extractor function `isolate_self`. 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue (#384)
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
