### PR TITLE
Improve semantics

### DIFF
--- a/examples/basic_bot.py
+++ b/examples/basic_bot.py
@@ -71,7 +71,7 @@ async def cool(ctx):
 
 
 @cool.command(name="bot")
-async def _bot(ctx):
+async def bot_(ctx):
     """Is the bot cool?"""
     await ctx.send("Yes, the bot is cool.")
 


### PR DESCRIPTION
`_var` is meant to show that a name is *private*.
`var_` should be used if `var` name is already taken.
Reference: [PEP8](https://pep8.org/#descriptive-naming-styles)

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
