### PR TITLE
feat: add session start limit data

### DIFF
--- a/disnake/client.py
+++ b/disnake/client.py
@@ -143,7 +143,8 @@ def _cleanup_loop(loop: asyncio.AbstractEventLoop) -> None:
 
 
 class SessionStartLimit:
-    """A class that contains information about the current session start limit.
+    """A class that contains information about the current session start limit,
+    at the time when the client connected.
 
     .. versionadded:: 2.5
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -144,7 +144,7 @@ def _cleanup_loop(loop: asyncio.AbstractEventLoop) -> None:
 
 class SessionStartLimit:
     """A class that contains information about the current session start limit,
-    at the time when the client connected.
+    at the time when the client connected for the first time.
 
     .. versionadded:: 2.5
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -94,6 +94,7 @@ if TYPE_CHECKING:
     from .member import Member
     from .message import Message
     from .role import Role
+    from .shard import SessionStartLimit
     from .voice_client import VoiceProtocol
 
 
@@ -265,6 +266,11 @@ class Client:
     asyncio_debug: :class:`bool`
         Whether to enable asyncio debugging when the client starts.
         Defaults to False.
+    session_start_limit: Optional[:class:`SessionStartLimit`]
+        Information about the current session start limit,
+        only set in sharded clients/bots.
+
+        .. versionadded:: 2.5
     """
 
     def __init__(
@@ -281,6 +287,7 @@ class Client:
         self._listeners: Dict[str, List[Tuple[asyncio.Future, Callable[..., bool]]]] = {}
         self.shard_id: Optional[int] = options.get("shard_id")
         self.shard_count: Optional[int] = options.get("shard_count")
+        self.session_start_limit: Optional[SessionStartLimit] = None
 
         connector: Optional[aiohttp.BaseConnector] = options.pop("connector", None)
         proxy: Optional[str] = options.pop("proxy", None)

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -182,7 +182,7 @@ class SessionStartLimit:
     def __repr__(self):
         return (
             f"<SessionStartLimit total={self.total!r} remaining={self.remaining!r} "
-            f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time}"
+            f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time!s}"
         )
 
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -99,7 +99,7 @@ if TYPE_CHECKING:
     from .voice_client import VoiceProtocol
 
 
-__all__ = ("Client",)
+__all__ = ("Client", "SessionStartLimit")
 
 Coro = TypeVar("Coro", bound=Callable[..., Coroutine[Any, Any, Any]])
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -183,7 +183,7 @@ class SessionStartLimit:
     def __repr__(self):
         return (
             f"<SessionStartLimit total={self.total!r} remaining={self.remaining!r} "
-            f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time!s}"
+            f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time!s}>"
         )
 
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
         components,
         embed,
         emoji,
+        gateway,
         guild,
         guild_scheduled_event,
         integration,
@@ -2407,7 +2408,7 @@ class HTTPClient:
 
     async def get_gateway(self, *, encoding: str = "json", zlib: bool = True) -> str:
         try:
-            data = await self.request(Route("GET", "/gateway"))
+            data: gateway.Gateway = await self.request(Route("GET", "/gateway"))
         except HTTPException as exc:
             raise GatewayNotFound() from exc
         if zlib:
@@ -2418,9 +2419,9 @@ class HTTPClient:
 
     async def get_bot_gateway(
         self, *, encoding: str = "json", zlib: bool = True
-    ) -> Tuple[int, str]:
+    ) -> Tuple[int, str, gateway.SessionStartLimit]:
         try:
-            data = await self.request(Route("GET", "/gateway/bot"))
+            data: gateway.GatewayBot = await self.request(Route("GET", "/gateway/bot"))
         except HTTPException as exc:
             raise GatewayNotFound() from exc
 
@@ -2428,7 +2429,7 @@ class HTTPClient:
             value = "{0}?encoding={1}&v=9&compress=zlib-stream"
         else:
             value = "{0}?encoding={1}&v=9"
-        return data["shards"], value.format(data["url"], encoding)
+        return data["shards"], value.format(data["url"], encoding), data["session_start_limit"]
 
     def get_user(self, user_id: Snowflake) -> Response[user.User]:
         return self.request(Route("GET", "/users/{user_id}", user_id=user_id))

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -27,14 +27,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar
 
 import aiohttp
 
-from . import utils
 from .backoff import ExponentialBackoff
-from .client import Client
+from .client import Client, SessionStartLimit
 from .enums import Status
 from .errors import (
     ClientException,
@@ -50,13 +48,11 @@ if TYPE_CHECKING:
     from .activity import BaseActivity
     from .enums import Status
     from .gateway import DiscordWebSocket
-    from .types.gateway import SessionStartLimit as SessionStartLimitPayload
 
     EI = TypeVar("EI", bound="EventItem")
 
 __all__ = (
     "AutoShardedClient",
-    "SessionStartLimit",
     "ShardInfo",
 )
 
@@ -92,50 +88,6 @@ class EventItem:
 
     def __hash__(self) -> int:
         return hash(self.type)
-
-
-class SessionStartLimit:
-    """A class that contains information about the current session start limit.
-
-    .. versionadded:: 2.5
-
-    Attributes
-    ----------
-    total: :class:`int`
-        The total number of allowed session starts.
-    remaining: :class:`int`
-        The remaining number of allowed session starts.
-    reset_after: :class:`int`
-        The number of milliseconds after which the :attr:`.remaining` limit resets,
-        relative to when the client connected.
-        See also :attr:`reset_time`.
-    max_concurrency: :class:`int`
-        The number of allowed ``IDENTIFY`` requests per 5 seconds.
-    reset_time: :class:`datetime.datetime`
-        The approximate time at which which the :attr:`.remaining` limit resets.
-    """
-
-    __slots__: Tuple[str, ...] = (
-        "total",
-        "remaining",
-        "reset_after",
-        "max_concurrency",
-        "reset_time",
-    )
-
-    def __init__(self, data: SessionStartLimitPayload):
-        self.total: int = data["total"]
-        self.remaining: int = data["remaining"]
-        self.reset_after: int = data["reset_after"]
-        self.max_concurrency: int = data["max_concurrency"]
-
-        self.reset_time: datetime = utils.utcnow() + timedelta(milliseconds=self.reset_after)
-
-    def __repr__(self):
-        return (
-            f"<SessionStartLimit total={self.total!r} remaining={self.remaining!r} "
-            f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time}"
-        )
 
 
 class Shard:

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -131,6 +131,12 @@ class SessionStartLimit:
 
         self.reset_time: datetime = utils.utcnow() + timedelta(milliseconds=self.reset_after)
 
+    def __repr__(self):
+        return (
+            f"<SessionStartLimit total={self.total!r} remaining={self.remaining!r} "
+            f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time}"
+        )
+
 
 class Shard:
     def __init__(

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4843,6 +4843,14 @@ ShardInfo
 .. autoclass:: ShardInfo()
     :members:
 
+SessionStartLimit
+~~~~~~~~~~~~~~~~~
+
+.. attributetable:: SessionStartLimit
+
+.. autoclass:: SessionStartLimit()
+    :members:
+
 SystemChannelFlags
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Pretty self-explanatory; adds session start limit data to the client object, which was previously just dropped.
The contained `max_concurrency` value isn't being used, but given how the shard launching process currently works it's not really necessary.

resolves #390

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
    - `HTTPClient.get_bot_gateway` return type changed
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
