### PR TITLE
fix: update types according to latest api-docs changes

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -1339,7 +1339,7 @@ class StageChannel(VocalGuildChannel):
 
     def _update(self, guild: Guild, data: StageChannelPayload) -> None:
         super()._update(guild, data)
-        self.topic = data.get("topic")
+        self.topic: Optional[str] = data.get("topic")
 
     @property
     def requesting_to_speak(self) -> List[Member]:

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -42,7 +42,6 @@ from typing import (
     Set,
     Tuple,
     Union,
-    cast,
     overload,
 )
 
@@ -402,11 +401,10 @@ class Guild(Hashable):
         return f"<Guild {inner}>"
 
     def _update_voice_state(
-        self, data: GuildVoiceState, channel_id: int
+        self, data: GuildVoiceState, channel_id: Optional[int]
     ) -> Tuple[Optional[Member], VoiceState, VoiceState]:
         user_id = int(data["user_id"])
-        channel = self.get_channel(channel_id)
-        channel = cast(Optional[VocalGuildChannel], channel)
+        channel: Optional[VocalGuildChannel] = self.get_channel(channel_id)  # type: ignore
         try:
             # check if we should remove the voice state from cache
             if channel is None:
@@ -585,7 +583,7 @@ class Guild(Hashable):
         self.afk_channel: Optional[VocalGuildChannel] = self.get_channel(utils._get_as_snowflake(guild, "afk_channel_id"))  # type: ignore
 
         for obj in guild.get("voice_states", []):
-            self._update_voice_state(obj, int(obj["channel_id"]))
+            self._update_voice_state(obj, utils._get_as_snowflake(obj, "channel_id"))
 
     # TODO: refactor/remove?
     def _sync(self, data: GuildPayload) -> None:

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1930,6 +1930,12 @@ class Guild(Hashable):
 
         Creates a :class:`GuildScheduledEvent`.
 
+        If ``entity_type`` is :class:`GuildScheduledEventEntityType.external`:
+
+        - ``channel_id`` should be not be set
+        - ``entity_metadata`` with a location field must be provided
+        - ``scheduled_end_time`` must be provided
+
         .. versionadded:: 2.3
 
         Parameters
@@ -2864,8 +2870,8 @@ class Guild(Hashable):
         color: Union[Colour, int] = MISSING,
         colour: Union[Colour, int] = MISSING,
         hoist: bool = MISSING,
-        icon: bytes = MISSING,
-        emoji: str = MISSING,
+        icon: Optional[bytes] = MISSING,
+        emoji: Optional[str] = MISSING,
         mentionable: bool = MISSING,
         reason: Optional[str] = None,
     ) -> Role:

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -264,14 +264,14 @@ class GuildScheduledEvent(Hashable):
         self,
         *,
         name: str = MISSING,
-        description: str = MISSING,
+        description: Optional[str] = MISSING,
         image: Optional[bytes] = MISSING,
         channel_id: Optional[int] = MISSING,
         privacy_level: GuildScheduledEventPrivacyLevel = MISSING,
         scheduled_start_time: datetime = MISSING,
         scheduled_end_time: datetime = MISSING,
         entity_type: GuildScheduledEventEntityType = MISSING,
-        entity_metadata: GuildScheduledEventMetadata = MISSING,
+        entity_metadata: Optional[GuildScheduledEventMetadata] = MISSING,
         status: GuildScheduledEventStatus = MISSING,
         reason: Optional[str] = None,
     ) -> GuildScheduledEvent:
@@ -289,7 +289,7 @@ class GuildScheduledEvent(Hashable):
         ----------
         name: :class:`str`
             The name of the guild scheduled event.
-        description: :class:`str`
+        description: Optional[:class:`str`]
             The description of the guild scheduled event.
         image: Optional[:class:`bytes`]
             The cover image of the guild scheduled event. Set to ``None`` to remove the image.
@@ -307,7 +307,7 @@ class GuildScheduledEvent(Hashable):
             The time when the guild scheduled event is scheduled to end.
         entity_type: :class:`GuildScheduledEventEntityType`
             The entity type of the guild scheduled event.
-        entity_metadata: :class:`GuildScheduledEventMetadata`
+        entity_metadata: Optional[:class:`GuildScheduledEventMetadata`]
             The entity metadata of the guild scheduled event.
         status: :class:`GuildScheduledEventStatus`
             The status of the guild scheduled event.

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -403,8 +403,8 @@ class Role(Hashable):
         colour: Union[Colour, int] = MISSING,
         color: Union[Colour, int] = MISSING,
         hoist: bool = MISSING,
-        icon: bytes = MISSING,
-        emoji: str = MISSING,
+        icon: Optional[bytes] = MISSING,
+        emoji: Optional[str] = MISSING,
         mentionable: bool = MISSING,
         position: int = MISSING,
         reason: Optional[str] = MISSING,
@@ -434,9 +434,9 @@ class Role(Hashable):
             The new colour to change to. (aliased to ``color`` as well)
         hoist: :class:`bool`
             Indicates if the role should be shown separately in the member list.
-        icon: :class:`bytes`
+        icon: Optional[:class:`bytes`]
             The role's new icon image (if the guild has the ``ROLE_ICONS`` feature).
-        emoji: :class:`str`
+        emoji: Optional[:class:`str`]
             The role's new unicode emoji.
         mentionable: :class:`bool`
             Indicates if the role should be mentionable by others.

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1694,7 +1694,7 @@ class ConnectionState:
                         logging_coroutine(coro, info="Voice Protocol voice state update handler")
                     )
 
-            member, before, after = guild._update_voice_state(data, channel_id)  # type: ignore
+            member, before, after = guild._update_voice_state(data, channel_id)
             if member is not None:
                 if flags.voice:
                     if channel_id is None and flags._voice_only and member.id != self_id:

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -60,7 +60,7 @@ class PartialChannel(_BaseChannel):
 
 
 class _TextChannelOptional(TypedDict, total=False):
-    topic: str
+    topic: Optional[str]
     last_message_id: Optional[Snowflake]
     last_pin_timestamp: str
     rate_limit_per_user: int
@@ -101,7 +101,7 @@ class StoreChannel(_BaseGuildChannel):
 
 class _StageChannelOptional(TypedDict, total=False):
     rtc_region: Optional[str]
-    topic: str
+    topic: Optional[str]
 
 
 class StageChannel(_BaseGuildChannel, _StageChannelOptional):

--- a/disnake/types/guild_scheduled_event.py
+++ b/disnake/types/guild_scheduled_event.py
@@ -47,9 +47,10 @@ class GuildScheduledEventEntityMetadata(TypedDict, total=False):
 
 
 class _GuildScheduledEventOptional(TypedDict, total=False):
-    description: str
+    description: Optional[str]
     creator: User
     user_count: int
+    image: Optional[str]
 
 
 class GuildScheduledEvent(_GuildScheduledEventOptional):
@@ -65,4 +66,3 @@ class GuildScheduledEvent(_GuildScheduledEventOptional):
     entity_type: GuildScheduledEventEntityType
     entity_id: Optional[Snowflake]
     entity_metadata: Optional[GuildScheduledEventEntityMetadata]
-    image: Optional[str]

--- a/disnake/types/voice.py
+++ b/disnake/types/voice.py
@@ -48,7 +48,7 @@ class _VoiceState(_PartialVoiceStateOptional):
 
 
 class GuildVoiceState(_VoiceState):
-    channel_id: Snowflake
+    channel_id: Optional[Snowflake]
 
 
 class VoiceState(_VoiceState, total=False):


### PR DESCRIPTION
## Summary

This PR updates a few field types and parameters of roles, scheduled events, and voice states, according to this api-docs commit: https://github.com/discord/discord-api-docs/commit/074e9305b45f3102266e79513c9f84ddb5697a05

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
