### PR TITLE
fix: remove awkword and sketchy_artist activities

### DIFF
--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -253,8 +253,6 @@ class PartyType(Enum):
     doodle_crew = 878067389634314250
     checkers = 832013003968348200
     spellcast = 852509694341283871
-    awkword = 879863881349087252
-    sketchy_artist = 879864070101172255
     watch_together = 880218394199220334
     sketch_heads = 902271654783242291
     ocho = 832025144389533716

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1613,16 +1613,6 @@ of :class:`enum.Enum`.
         The "SpellCast" activity.
 
         .. versionadded:: 2.3
-    .. attribute:: awkword
-
-        The "Awkword" activity.
-
-        .. versionadded:: 2.3
-    .. attribute:: sketchy_artist
-
-        The "Sketchy Artist" activity.
-
-        .. versionadded:: 2.3
     .. attribute:: watch_together
 
         The "Watch Together" activity, a Youtube application.


### PR DESCRIPTION
## Summary

The `awkword` and `sketchy_artist` activities appear to be removed/disabled as well, similar to `youtube` in #408.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
