### PR TITLE
fix: allow most `content` parameters to be positional, change types to `Optional[str]`

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1222,7 +1222,7 @@ class Messageable:
     @overload
     async def send(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         tts: bool = ...,
         embed: Embed = ...,
@@ -1241,7 +1241,7 @@ class Messageable:
     @overload
     async def send(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         tts: bool = ...,
         embed: Embed = ...,
@@ -1260,7 +1260,7 @@ class Messageable:
     @overload
     async def send(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         tts: bool = ...,
         embeds: List[Embed] = ...,
@@ -1279,7 +1279,7 @@ class Messageable:
     @overload
     async def send(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         tts: bool = ...,
         embeds: List[Embed] = ...,
@@ -1297,7 +1297,7 @@ class Messageable:
 
     async def send(
         self,
-        content: Any = None,
+        content: Optional[str] = None,
         *,
         tts: bool = False,
         embed: Embed = None,

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1319,8 +1319,9 @@ class Messageable:
         Sends a message to the destination with the content given.
 
         The content must be a type that can convert to a string through ``str(content)``.
-        If the content is set to ``None`` (the default), then the ``embed`` parameter must
-        be provided.
+
+        At least one of ``content``, ``embed``/``embeds``, ``file``/``files``
+        or ``stickers`` must be provided.
 
         To upload a single file, the ``file`` parameter should be used with a
         single :class:`.File` object. To upload multiple files, the ``files``

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -665,7 +665,7 @@ class HTTPClient:
         channel_id: Snowflake,
         message_id: Snowflake,
         *,
-        files: Optional[List[File]],
+        files: Optional[List[File]] = None,
         **fields: Any,
     ) -> Response[message.Message]:
         r = Route(

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -350,8 +350,8 @@ class Interaction:
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
-            The content to edit the message with or ``None`` to clear it.
+        content: :class:`Any`
+            The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
             ``embeds`` parameter.
@@ -526,7 +526,7 @@ class Interaction:
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
+        content: :class:`Any`
             The content of the message to send.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with the
@@ -717,7 +717,7 @@ class InteractionResponse:
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
+        content: :class:`Any`
             The content of the message to send.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with the
@@ -883,7 +883,7 @@ class InteractionResponse:
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
+        content: :class:`Any`
             The new content to replace the message with. ``None`` removes the content.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
@@ -1230,8 +1230,8 @@ class InteractionMessage(Message):
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
-            The content to edit the message with or ``None`` to clear it.
+        content: :class:`Any`
+            The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
             ``embeds`` parameter.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -321,7 +321,7 @@ class Interaction:
 
     async def edit_original_message(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
@@ -350,7 +350,7 @@ class Interaction:
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
@@ -498,7 +498,7 @@ class Interaction:
 
     async def send(
         self,
-        content: Any = None,
+        content: Optional[str] = None,
         *,
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
@@ -526,7 +526,7 @@ class Interaction:
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content of the message to send.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with the
@@ -698,7 +698,7 @@ class InteractionResponse:
 
     async def send_message(
         self,
-        content: Any = None,
+        content: Optional[str] = None,
         *,
         embed: Embed = MISSING,
         embeds: List[Embed] = MISSING,
@@ -717,7 +717,7 @@ class InteractionResponse:
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content of the message to send.
         embed: :class:`Embed`
             The rich embed for the content to send. This cannot be mixed with the
@@ -854,7 +854,7 @@ class InteractionResponse:
 
     async def edit_message(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
@@ -883,7 +883,7 @@ class InteractionResponse:
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The new content to replace the message with. ``None`` removes the content.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
@@ -1208,7 +1208,7 @@ class InteractionMessage(Message):
 
     async def edit(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -1230,7 +1230,7 @@ class InteractionMessage(Message):
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -321,8 +321,8 @@ class Interaction:
 
     async def edit_original_message(
         self,
+        content: Any = MISSING,
         *,
-        content: Optional[str] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -578,7 +578,7 @@ class Interaction:
         else:
             sender = self.response.send_message
         await sender(
-            content=content,  # type: ignore
+            content=content,
             embed=embed,
             embeds=embeds,
             file=file,
@@ -854,8 +854,8 @@ class InteractionResponse:
 
     async def edit_message(
         self,
-        *,
         content: Any = MISSING,
+        *,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -1208,7 +1208,7 @@ class InteractionMessage(Message):
 
     async def edit(
         self,
-        content: Optional[str] = MISSING,
+        content: Any = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1481,7 +1481,7 @@ class Message(Hashable):
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
+        content: :class:`Any`
             The new content to replace the message with.
             Could be ``None`` to remove the content.
         embed: Optional[:class:`Embed`]
@@ -2049,7 +2049,7 @@ class PartialMessage(Hashable):
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
+        content: :class:`Any`
             The new content to replace the message with.
             Could be ``None`` to remove the content.
         embed: Optional[:class:`Embed`]

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -129,7 +129,7 @@ async def _edit_handler(
     *,
     default_flags: int,
     previous_allowed_mentions: Optional[AllowedMentions],
-    content: Optional[str] = MISSING,
+    content: Any = MISSING,
     embed: Optional[Embed] = MISSING,
     embeds: List[Embed] = MISSING,
     file: File = MISSING,
@@ -1402,8 +1402,8 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
+        content: Any = ...,
         *,
-        content: Optional[str] = ...,
         embed: Optional[Embed] = ...,
         file: File = ...,
         attachments: List[Attachment] = ...,
@@ -1418,8 +1418,8 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
+        content: Any = ...,
         *,
-        content: Optional[str] = ...,
         embed: Optional[Embed] = ...,
         files: List[File] = ...,
         attachments: List[Attachment] = ...,
@@ -1434,8 +1434,8 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
+        content: Any = ...,
         *,
-        content: Optional[str] = ...,
         embeds: List[Embed] = ...,
         file: File = ...,
         attachments: List[Attachment] = ...,
@@ -1450,8 +1450,8 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
+        content: Any = ...,
         *,
-        content: Optional[str] = ...,
         embeds: List[Embed] = ...,
         files: List[File] = ...,
         attachments: List[Attachment] = ...,
@@ -1463,7 +1463,7 @@ class Message(Hashable):
     ) -> Message:
         ...
 
-    async def edit(self, **fields: Any) -> Message:
+    async def edit(self, content: Any = MISSING, **fields: Any) -> Message:
         """|coro|
 
         Edits the message.
@@ -1574,6 +1574,7 @@ class Message(Hashable):
             self,
             default_flags=self.flags.value,
             previous_allowed_mentions=previous_allowed_mentions,
+            content=content,
             **fields,
         )
 
@@ -2030,7 +2031,7 @@ class PartialMessage(Hashable):
         data = await self._state.http.get_message(self.channel.id, self.id)
         return self._state.create_message(channel=self.channel, data=data)
 
-    async def edit(self, **fields: Any) -> Message:
+    async def edit(self, content: Any = MISSING, **fields: Any) -> Message:
         """|coro|
 
         Edits the message.
@@ -2139,5 +2140,6 @@ class PartialMessage(Hashable):
             self,
             default_flags=0,
             previous_allowed_mentions=None,
+            content=content,
             **fields,
         )

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -129,7 +129,7 @@ async def _edit_handler(
     *,
     default_flags: int,
     previous_allowed_mentions: Optional[AllowedMentions],
-    content: Any = MISSING,
+    content: Optional[str] = MISSING,
     embed: Optional[Embed] = MISSING,
     embeds: List[Embed] = MISSING,
     file: File = MISSING,
@@ -1402,7 +1402,7 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         embed: Optional[Embed] = ...,
         file: File = ...,
@@ -1418,7 +1418,7 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         embed: Optional[Embed] = ...,
         files: List[File] = ...,
@@ -1434,7 +1434,7 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         embeds: List[Embed] = ...,
         file: File = ...,
@@ -1450,7 +1450,7 @@ class Message(Hashable):
     @overload
     async def edit(
         self,
-        content: Any = ...,
+        content: Optional[str] = ...,
         *,
         embeds: List[Embed] = ...,
         files: List[File] = ...,
@@ -1463,7 +1463,7 @@ class Message(Hashable):
     ) -> Message:
         ...
 
-    async def edit(self, content: Any = MISSING, **fields: Any) -> Message:
+    async def edit(self, content: Optional[str] = MISSING, **fields: Any) -> Message:
         """|coro|
 
         Edits the message.
@@ -1481,7 +1481,7 @@ class Message(Hashable):
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The new content to replace the message with.
             Could be ``None`` to remove the content.
         embed: Optional[:class:`Embed`]
@@ -2031,7 +2031,7 @@ class PartialMessage(Hashable):
         data = await self._state.http.get_message(self.channel.id, self.id)
         return self._state.create_message(channel=self.channel, data=data)
 
-    async def edit(self, content: Any = MISSING, **fields: Any) -> Message:
+    async def edit(self, content: Optional[str] = MISSING, **fields: Any) -> Message:
         """|coro|
 
         Edits the message.
@@ -2049,7 +2049,7 @@ class PartialMessage(Hashable):
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The new content to replace the message with.
             Could be ``None`` to remove the content.
         embed: Optional[:class:`Embed`]

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -712,8 +712,8 @@ class WebhookMessage(Message):
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
-            The content to edit the message with or ``None`` to clear it.
+        content: :class:`Any`
+            The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the ``embeds`` parameter.
             Could be ``None`` to remove the embed.
@@ -1406,7 +1406,7 @@ class Webhook(BaseWebhook):
 
         Parameters
         ----------
-        content: :class:`str`
+        content: :class:`Any`
             The content of the message to send.
         username: :class:`str`
             The username to send with this message. If no username is provided
@@ -1646,8 +1646,8 @@ class Webhook(BaseWebhook):
         ----------
         message_id: :class:`int`
             The ID of the message to edit.
-        content: Optional[:class:`str`]
-            The content to edit the message with or ``None`` to clear it.
+        content: :class:`Any`
+            The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
             ``embeds`` parameter.

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -477,7 +477,7 @@ class ExecuteWebhookParameters(NamedTuple):
 
 
 def handle_message_parameters(
-    content: Optional[str] = MISSING,
+    content: Any = MISSING,
     *,
     username: str = MISSING,
     avatar_url: Any = MISSING,
@@ -685,7 +685,7 @@ class WebhookMessage(Message):
 
     async def edit(
         self,
-        content: Optional[str] = MISSING,
+        content: Any = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -1331,7 +1331,7 @@ class Webhook(BaseWebhook):
     @overload
     async def send(
         self,
-        content: str = MISSING,
+        content: Any = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -1353,7 +1353,7 @@ class Webhook(BaseWebhook):
     @overload
     async def send(
         self,
-        content: str = MISSING,
+        content: Any = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -1374,7 +1374,7 @@ class Webhook(BaseWebhook):
 
     async def send(
         self,
-        content: str = MISSING,
+        content: Any = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -1614,7 +1614,7 @@ class Webhook(BaseWebhook):
         self,
         message_id: int,
         *,
-        content: Optional[str] = MISSING,
+        content: Any = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -477,7 +477,7 @@ class ExecuteWebhookParameters(NamedTuple):
 
 
 def handle_message_parameters(
-    content: Any = MISSING,
+    content: Optional[str] = MISSING,
     *,
     username: str = MISSING,
     avatar_url: Any = MISSING,
@@ -685,7 +685,7 @@ class WebhookMessage(Message):
 
     async def edit(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -712,7 +712,7 @@ class WebhookMessage(Message):
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the ``embeds`` parameter.
@@ -1331,7 +1331,7 @@ class Webhook(BaseWebhook):
     @overload
     async def send(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -1353,7 +1353,7 @@ class Webhook(BaseWebhook):
     @overload
     async def send(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -1374,7 +1374,7 @@ class Webhook(BaseWebhook):
 
     async def send(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -1406,7 +1406,7 @@ class Webhook(BaseWebhook):
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content of the message to send.
         username: :class:`str`
             The username to send with this message. If no username is provided
@@ -1614,7 +1614,7 @@ class Webhook(BaseWebhook):
         self,
         message_id: int,
         *,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -1646,7 +1646,7 @@ class Webhook(BaseWebhook):
         ----------
         message_id: :class:`int`
             The ID of the message to edit.
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -420,7 +420,7 @@ class SyncWebhookMessage(Message):
 
         Parameters
         ----------
-        content: Optional[:class:`str`]
+        content: :class:`Any`
             The content to edit the message with or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
@@ -898,7 +898,7 @@ class SyncWebhook(BaseWebhook):
 
         Parameters
         ----------
-        content: :class:`str`
+        content: :class:`Any`
             The content of the message to send.
         username: :class:`str`
             The username to send with this message. If no username is provided
@@ -1065,8 +1065,8 @@ class SyncWebhook(BaseWebhook):
         ----------
         message_id: :class:`int`
             The ID of the message to edit.
-        content: Optional[:class:`str`]
-            The content to edit the message with or ``None`` to clear it.
+        content: :class:`Any`
+            The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
             ``embeds`` parameter.

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -402,7 +402,7 @@ class SyncWebhookMessage(Message):
 
     def edit(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -420,7 +420,7 @@ class SyncWebhookMessage(Message):
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content to edit the message with or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the
@@ -839,7 +839,7 @@ class SyncWebhook(BaseWebhook):
     @overload
     def send(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -856,7 +856,7 @@ class SyncWebhook(BaseWebhook):
     @overload
     def send(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -872,7 +872,7 @@ class SyncWebhook(BaseWebhook):
 
     def send(
         self,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -898,7 +898,7 @@ class SyncWebhook(BaseWebhook):
 
         Parameters
         ----------
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content of the message to send.
         username: :class:`str`
             The username to send with this message. If no username is provided
@@ -1040,7 +1040,7 @@ class SyncWebhook(BaseWebhook):
         self,
         message_id: int,
         *,
-        content: Any = MISSING,
+        content: Optional[str] = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -1065,7 +1065,7 @@ class SyncWebhook(BaseWebhook):
         ----------
         message_id: :class:`int`
             The ID of the message to edit.
-        content: :class:`Any`
+        content: Optional[:class:`str`]
             The content to edit the message with, or ``None`` to clear it.
         embed: Optional[:class:`Embed`]
             The new embed to replace the original with. This cannot be mixed with the

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -402,7 +402,7 @@ class SyncWebhookMessage(Message):
 
     def edit(
         self,
-        content: Optional[str] = MISSING,
+        content: Any = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,
@@ -839,7 +839,7 @@ class SyncWebhook(BaseWebhook):
     @overload
     def send(
         self,
-        content: str = MISSING,
+        content: Any = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -856,7 +856,7 @@ class SyncWebhook(BaseWebhook):
     @overload
     def send(
         self,
-        content: str = MISSING,
+        content: Any = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -872,7 +872,7 @@ class SyncWebhook(BaseWebhook):
 
     def send(
         self,
-        content: str = MISSING,
+        content: Any = MISSING,
         *,
         username: str = MISSING,
         avatar_url: Any = MISSING,
@@ -1040,7 +1040,7 @@ class SyncWebhook(BaseWebhook):
         self,
         message_id: int,
         *,
-        content: Optional[str] = MISSING,
+        content: Any = MISSING,
         embed: Optional[Embed] = MISSING,
         embeds: List[Embed] = MISSING,
         file: File = MISSING,


### PR DESCRIPTION
## Summary

The `content` parameter of `Message.edit` was unintentionally changed to be kwarg-only in a refactor a while ago, and while it has always been kwarg-only in the overloads (and any good IDE/linter/typechecker would've complained), some users seem to have relied on that.
This PR changes most `content` parameters of edit methods to support both positional and kwarg calls, and updates all types to `Optional[str]`. The serializing methods have always been calling `str()` anyway, but it's better to be explicit here, which helps avoid mistakes such as `.send(embed)` as well.
It also adds a default for the `files` parameter of `HTTPClient.edit_message`, which was changed some time ago as well.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
