### PR TITLE
refactor: rework untyped `Component._raw_construct`

### DIFF
--- a/disnake/components.py
+++ b/disnake/components.py
@@ -131,9 +131,9 @@ class ActionRow(Component):
 
     def to_dict(self) -> ActionRowPayload:
         return {
-            "type": int(self.type),
+            "type": self.type.value,
             "components": [child.to_dict() for child in self.children],
-        }  # type: ignore
+        }
 
 
 class Button(Component):
@@ -206,8 +206,8 @@ class Button(Component):
 
     def to_dict(self) -> ButtonComponentPayload:
         payload = {
-            "type": 2,
-            "style": int(self.style),
+            "type": self.type.value,
+            "style": self.style.value,
             "label": self.label,
             "disabled": self.disabled,
         }

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -75,10 +75,8 @@ class ActionRow:
 
             raw_components.append(component._underlying)
 
-        self._underlying = ActionRowComponent._raw_construct(
-            type=ComponentType.action_row,
-            children=raw_components,
-        )
+        self._underlying = ActionRowComponent._raw_construct(type=ComponentType.action_row)
+        self._underlying._update(children=raw_components)
 
     def __repr__(self) -> str:
         return f"<ActionRow children={self.children!r}>"

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -75,7 +75,7 @@ class ActionRow:
 
             raw_components.append(component._underlying)
 
-        self._underlying = ActionRowComponent._raw_construct(type=ComponentType.action_row)
+        self._underlying = ActionRowComponent._raw_construct(ComponentType.action_row)
         self._underlying._update(children=raw_components)
 
     def __repr__(self) -> str:

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -120,8 +120,8 @@ class Button(Item[V]):
                     f"expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__}"
                 )
 
-        self._underlying = ButtonComponent._raw_construct(
-            type=ComponentType.button,
+        self._underlying = ButtonComponent._raw_construct(type=ComponentType.button)
+        self._underlying._update(
             custom_id=custom_id,
             url=url,
             disabled=disabled,

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -120,7 +120,7 @@ class Button(Item[V]):
                     f"expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__}"
                 )
 
-        self._underlying = ButtonComponent._raw_construct(type=ComponentType.button)
+        self._underlying = ButtonComponent._raw_construct(ComponentType.button)
         self._underlying._update(
             custom_id=custom_id,
             url=url,

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -127,9 +127,9 @@ class Select(Item[V]):
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         options = [] if options is MISSING else _parse_select_options(options)
-        self._underlying = SelectMenu._raw_construct(
+        self._underlying = SelectMenu._raw_construct(ComponentType.select)
+        self._underlying._update(
             custom_id=custom_id,
-            type=ComponentType.select,
             placeholder=placeholder,
             min_values=min_values,
             max_values=max_values,

--- a/disnake/ui/text_input.py
+++ b/disnake/ui/text_input.py
@@ -85,8 +85,8 @@ class TextInput(WrappedComponent):
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
     ) -> None:
-        self._underlying = TextInputComponent._raw_construct(
-            type=ComponentType.text_input,
+        self._underlying = TextInputComponent._raw_construct(ComponentType.text_input)
+        self._underlying._update(
             style=style,
             label=label,
             custom_id=custom_id,


### PR DESCRIPTION
## Summary

Changes the entirely untyped `Component._raw_construct` implementation, improving typing by adding separate `_update` methods in concrete components.

Since `.ui` items need a way to construct a component without a payload dict, they previously called `_raw_construct` (untyped) with all the attributes, which would just `setattr()` them based on the type's slots.
Instead, ui items now need to call `_raw_construct` with just the type, and call `_update` (properly typed) on the created component with all the attributes, as seen here:
https://github.com/DisnakeDev/disnake/blob/314aa2b12ed176823505424ffd364e99719b5965/disnake/ui/action_row.py#L78-L79

The ideal solution for this would be having `__init__(arg1, arg2, ...)` and `@classmethod from_dict(data)` for every component, but I'd really like to avoid breaking changes here; the new implementation is fully typed, but slightly less intuitive to use than a trivial `from_dict` call.

While the previous implementation works alright, these changes are done in preparation for future updates.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
