### PR TITLE
fix: minor typing and documentation improvements

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -713,7 +713,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         self,
         *,
         name: str,
-        message: Snowflake = None,
+        message: Snowflake,
         auto_archive_duration: AnyThreadArchiveDuration = None,
         slowmode_delay: int = None,
         reason: Optional[str] = None,
@@ -727,7 +727,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         name: str,
         type: Literal[
             ChannelType.public_thread, ChannelType.private_thread, ChannelType.news_thread
-        ] = None,
+        ],
         auto_archive_duration: AnyThreadArchiveDuration = None,
         invitable: bool = None,
         slowmode_delay: int = None,
@@ -768,8 +768,6 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             The name of the thread.
         message: :class:`abc.Snowflake`
             A snowflake representing the message to create the thread with.
-            If ``None`` is passed then a private thread is created.
-            Defaults to ``None``.
 
             .. versionchanged:: 2.5
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1582,7 +1582,7 @@ class Client:
 
         .. note::
 
-            This method may fetch any guild that has ``DISCOVERABLE`` in :attr:`Guild.features`,
+            This method may fetch any guild that has ``DISCOVERABLE`` in :attr:`.Guild.features`,
             but this information can not be known ahead of time.
 
             This will work for any guild that you are in.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1043,7 +1043,7 @@ class Guild(Hashable):
         .. deprecated:: 2.5
 
             VoiceRegion is no longer set on the guild, and is set on the individual voice channels instead.
-            See :attr:`VoiceChannel.region` instead.
+            See :attr:`VoiceChannel.rtc_region` and :attr:`StageChannel.rtc_region` instead.
         """
         utils.warn_deprecated(
             "Guild.region is deprecated and will be removed in a future version.", stacklevel=2
@@ -1612,7 +1612,7 @@ class Guild(Hashable):
 
             .. deprecated:: 2.5
 
-                Use :attr:`VoiceChannel.region` or :attr:`StageChannel.region` instead.
+                Use :func:`VoiceChannel.edit` or :func:`StageChannel.edit` with ``rtc_region`` instead.
 
         afk_channel: Optional[:class:`VoiceChannel`]
             The new channel that is the AFK channel. Could be ``None`` for no AFK channel.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -409,7 +409,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     .. note::
 
         Not all messages will have ``content``. This is a Discord limitation.
-        See the docs of :attr:`Intents.messages_content` for more information.
+        See the docs of :attr:`Intents.message_content` for more information.
 
     :param message: The current message.
     :type message: :class:`Message`
@@ -429,7 +429,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     .. note::
 
         Not all messages will have ``content``. This is a Discord limitation.
-        See the docs of :attr:`Intents.messages_content` for more information.
+        See the docs of :attr:`Intents.message_content` for more information.
 
 
     :param message: The deleted message.
@@ -491,7 +491,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     .. note::
 
         Not all messages will have ``content``. This is a Discord limitation.
-        See the docs of :attr:`Intents.messages_content` for more information.
+        See the docs of :attr:`Intents.message_content` for more information.
 
     The following non-exhaustive cases trigger this event:
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -925,10 +925,10 @@ Exceptions
 .. autoexception:: disnake.ext.commands.GuildScheduledEventNotFound
     :members:
 
-.. autoexception:: disnake.ext.commands.LargeIntConversionFailure
+.. autoexception:: disnake.ext.commands.BadBoolArgument
     :members:
 
-.. autoexception:: disnake.ext.commands.BadBoolArgument
+.. autoexception:: disnake.ext.commands.LargeIntConversionFailure
     :members:
 
 .. autoexception:: disnake.ext.commands.MissingPermissions
@@ -1016,8 +1016,8 @@ Exception Hierarchy
                     - :exc:`~.commands.PartialEmojiConversionFailure`
                     - :exc:`~.commands.GuildStickerNotFound`
                     - :exc:`~.commands.GuildScheduledEventNotFound`
-                    - :exc:`~.commands.LargeIntConversionFailure`
                     - :exc:`~.commands.BadBoolArgument`
+                    - :exc:`~.commands.LargeIntConversionFailure`
                     - :exc:`~.commands.FlagError`
                         - :exc:`~.commands.BadFlagArgument`
                         - :exc:`~.commands.MissingFlagArgument`

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -1016,6 +1016,7 @@ Exception Hierarchy
                     - :exc:`~.commands.PartialEmojiConversionFailure`
                     - :exc:`~.commands.GuildStickerNotFound`
                     - :exc:`~.commands.GuildScheduledEventNotFound`
+                    - :exc:`~.commands.LargeIntConversionFailure`
                     - :exc:`~.commands.BadBoolArgument`
                     - :exc:`~.commands.FlagError`
                         - :exc:`~.commands.BadFlagArgument`

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -925,6 +925,9 @@ Exceptions
 .. autoexception:: disnake.ext.commands.GuildScheduledEventNotFound
     :members:
 
+.. autoexception:: disnake.ext.commands.LargeIntConversionFailure
+    :members:
+
 .. autoexception:: disnake.ext.commands.BadBoolArgument
     :members:
 


### PR DESCRIPTION
## Summary

- remove default values for `message` and `type` in `TextChannel.create_thread` overloads
- fix broken documentation references to `Intents.message_content` and voice regions
- add documentation for new `LargeIntConversionFailure` exception

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
