### PR TITLE
fix!: improve validation of application command/option names

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -100,11 +100,12 @@ def _validate_name(name: str) -> None:
     # used for slash command names and option names
     # see https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-naming
 
-    assert name == name.lower() and re.fullmatch(r"[\w-]{1,32}", name), (
-        f"Slash command or option name '{name}' should be lowercase, "
-        "between 1 and 32 characters long, and only consist of "
-        "these symbols: a-z, 0-9, -, _, and other languages'/scripts' symbols"
-    )
+    if name != name.lower() or not re.fullmatch(r"[\w-]{1,32}", name):
+        raise InvalidArgument(
+            f"Slash command or option name '{name}' should be lowercase, "
+            "between 1 and 32 characters long, and only consist of "
+            "these symbols: a-z, 0-9, -, _, and other languages'/scripts' symbols"
+        )
 
 
 class OptionChoice:
@@ -191,8 +192,8 @@ class Option:
         min_value: float = None,
         max_value: float = None,
     ):
-        self.name: str = name.lower()
-        _validate_name(self.name)
+        _validate_name(name)
+        self.name: str = name
         self.description: str = description or "-"
         self.type: OptionType = enum_if_int(OptionType, type) or OptionType.string
         self.required: bool = required
@@ -533,7 +534,6 @@ class SlashCommand(ApplicationCommand):
         options: List[Option] = None,
         default_permission: bool = True,
     ):
-        name = name.lower()
         _validate_name(name)
 
         super().__init__(

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -130,7 +130,6 @@ class SubCommandGroup(InvokableApplicationCommand):
         self.option = Option(
             name=self.name, description="-", type=OptionType.sub_command_group, options=[]
         )
-        self.name = self.option.name
         self.qualified_name: str = ""
 
     @property
@@ -226,7 +225,6 @@ class SubCommand(InvokableApplicationCommand):
             type=OptionType.sub_command,
             options=options,
         )
-        self.name = self.option.name
         self.qualified_name = ""
 
     @property
@@ -340,8 +338,6 @@ class InvokableSlashCommand(InvokableApplicationCommand):
             options=options or [],
             default_permission=default_permission,
         )
-        # `SlashCommand.__init__` converts names to lowercase, need to use that name here as well
-        self.qualified_name = self.name = self.body.name
 
     @property
     def description(self) -> str:


### PR DESCRIPTION
## Summary

Changes the slash command/option validation to raise an `InvalidArgument` exception instead of asserting.
Also removes the automatic `.lower()` calls on slash command and option names, which has led to bugs in the past, but that also makes this a breaking change.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
