### PR TITLE
fix: rebind guilds/channels of cached messages after receiving `GUILD_CREATE` events

### DIFF
--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1957,8 +1957,9 @@ class AutoShardedConnectionState(ConnectionState):
         self.shards_launched: asyncio.Event = asyncio.Event()
 
     def _update_guild_channel_references(self) -> None:
-        messages: Sequence[Message] = self._messages or []
-        for msg in messages:
+        if not self._messages:
+            return
+        for msg in self._messages:
             if not msg.guild:
                 continue
 

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1956,9 +1956,9 @@ class AutoShardedConnectionState(ConnectionState):
         self.shard_ids: Union[List[int], range] = []
         self.shards_launched: asyncio.Event = asyncio.Event()
 
-    def _update_message_references(self) -> None:
-        # self._messages won't be None when this is called
-        for msg in self._messages:  # type: ignore
+    def _update_guild_channel_references(self) -> None:
+        messages: Sequence[Message] = self._messages or []
+        for msg in messages:
             if not msg.guild:
                 continue
 
@@ -1966,7 +1966,7 @@ class AutoShardedConnectionState(ConnectionState):
             if new_guild is not None and new_guild is not msg.guild:
                 channel_id = msg.channel.id
                 channel = new_guild._resolve_channel(channel_id) or Object(id=channel_id)
-                # channel will either be a TextChannel, Thread or Object
+                # channel will either be a TextChannel, VoiceChannel, Thread or Object
                 msg._rebind_cached_references(new_guild, channel)  # type: ignore
 
     async def chunker(
@@ -2023,6 +2023,9 @@ class AutoShardedConnectionState(ConnectionState):
                     future.set_result([])
 
                 processed.append((guild, future))
+
+        # update references once the guild cache is repopulated
+        self._update_guild_channel_references()
 
         guilds = sorted(processed, key=lambda g: g[0].shard_id)
         for shard_id, info in itertools.groupby(guilds, key=lambda g: g[0].shard_id):
@@ -2086,9 +2089,6 @@ class AutoShardedConnectionState(ConnectionState):
 
         for guild_data in data["guilds"]:
             self._add_guild_from_data(guild_data)
-
-        if self._messages:
-            self._update_message_references()
 
         self.dispatch("connect")
         self.dispatch("shard_connect", data["__shard_id__"])


### PR DESCRIPTION
## Summary

Autosharded clients rebind guild/channel references of cached messages after reconnecting to avoid keeping references to old/outdated objects, as they don't clear/recreate the caches (unlike unsharded clients). This was previously done in the `READY` handler, which generally only receives guilds in the `unavailable` state.
These guilds are effectively empty, which resulted in all cached messages' channel references being rebound to `Object`s instead of proper channels; to solve this, references will now be rebound only once all `GUILD_CREATE` events were received.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
