### PR TITLE
fix: rebind additional cached references on shard reconnect

### DIFF
--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1117,6 +1117,8 @@ class Message(Hashable):
     ) -> None:
         self.guild = new_guild
         self.channel = new_channel
+        if isinstance(self.author, Member):
+            self.author.guild = new_guild
 
     @utils.cached_slot_property("_cs_raw_mentions")
     def raw_mentions(self) -> List[int]:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -2100,6 +2100,9 @@ class AutoShardedConnectionState(ConnectionState):
         self._ready_task = None
 
         # update member references once guilds are chunked
+        # note: this is always called regardless of whether chunking/caching is enabled;
+        #       the bot member is always cached, so if any of the bot's own messages are
+        #       cached, their `author` should be rebound to the new member object
         self._update_member_references()
 
         # dispatch the event

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -2097,9 +2097,7 @@ class AutoShardedConnectionState(ConnectionState):
         self._ready_task = None
 
         # update member references once guilds are chunked
-        # (if we're not chunking guilds, there's no use in trying to update member references)
-        if self._chunk_guilds:
-            self._update_member_references()
+        self._update_member_references()
 
         # dispatch the event
         self.call_handlers("ready")


### PR DESCRIPTION
## Summary

followup to #424
Some profiling showed that there are more references that weren't being updated when a shard reconnects, namely `message.author.guild` (in `_state._messages`), `voice_client.channel` (`_state._voice_clients`), and `message.author` (`_state._messages`, if guild chunking is enabled).

Example: in this image, `message.guild` was correctly updated to the new object (right) after reconnecting, while `message.author.guild` is the only reference to the previous guild object (left), keeping that guild and everything associated with it in memory until the message gets removed from the message cache
![image](https://user-images.githubusercontent.com/8530778/159279800-13e587f2-6fce-45dc-85fe-e9455ba207dd.png)


## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
