### PR TITLE
fix: improve `PartialMessageable` channel handling

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1211,6 +1211,7 @@ class Messageable:
     - :class:`~disnake.ext.commands.Context`
     - :class:`~disnake.Thread`
     - :class:`~disnake.VoiceChannel`
+    - :class:`~disnake.PartialMessageable`
     """
 
     __slots__ = ()

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -61,7 +61,6 @@ from .enums import (
 from .errors import ClientException, InvalidArgument
 from .iterators import ArchivedThreadIterator
 from .mixins import Hashable
-from .object import Object
 from .permissions import PermissionOverwrite, Permissions
 from .stage_instance import StageInstance
 from .threads import Thread
@@ -2316,12 +2315,11 @@ class PartialMessageable(disnake.abc.Messageable, Hashable):
 
     def __init__(self, state: ConnectionState, id: int, type: Optional[ChannelType] = None):
         self._state: ConnectionState = state
-        self._channel: Object = Object(id=id)
         self.id: int = id
         self.type: Optional[ChannelType] = type
 
-    async def _get_channel(self) -> Object:
-        return self._channel
+    async def _get_channel(self) -> PartialMessageable:
+        return self
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the given message ID.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1926,6 +1926,7 @@ class PartialMessage(Hashable):
     - :meth:`VoiceChannel.get_partial_message`
     - :meth:`Thread.get_partial_message`
     - :meth:`DMChannel.get_partial_message`
+    - :meth:`PartialMessageable.get_partial_message`
 
     Note that this class is trimmed down and has no rich attributes.
 
@@ -1947,7 +1948,7 @@ class PartialMessage(Hashable):
 
     Attributes
     ----------
-    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`VoiceChannel`]
+    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`VoiceChannel`, :class:`PartialMessageable`]
         The channel associated with this partial message.
     id: :class:`int`
         The message ID.
@@ -1979,7 +1980,8 @@ class PartialMessage(Hashable):
             ChannelType.voice,
         ):
             raise TypeError(
-                f"Expected TextChannel, DMChannel, VoiceChannel, or Thread not {type(channel)!r}"
+                f"Expected TextChannel, DMChannel, VoiceChannel, Thread, or PartialMessageable "
+                f"with a valid type, not {type(channel)!r} (type: {channel.type!r})"
             )
 
         self.channel: MessageableChannel = channel


### PR DESCRIPTION
## Summary

Changes `message.channel` in messages returned from `PartialMessageable`s to be that `PartialMessageable` instead of an `Object`, and improves the exception message for using `PartialMessage`s with an invalid channel type.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
