### PR TITLE
fix: support interactions in `UserConverter`/`MemberConverter`

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -207,7 +207,7 @@ class Option:
         self.max_value: Optional[float] = max_value
 
         if channel_types is not None and not all(isinstance(t, ChannelType) for t in channel_types):
-            raise InvalidArgument("channel_types must be instances of ChannelType")
+            raise InvalidArgument("channel_types must be a list of `ChannelType`s")
 
         self.channel_types: List[ChannelType] = channel_types or []
 

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -237,8 +237,7 @@ class MemberConverter(IDConverter[disnake.Member]):
             return None
         return members[0]
 
-    # note: this uses `Context` instead of `AnyContext`, as it's not used by application commands
-    async def convert(self, ctx: Context, argument: str) -> disnake.Member:
+    async def convert(self, ctx: AnyContext, argument: str) -> disnake.Member:
         bot: disnake.Client = ctx.bot
         match = self._get_id_match(argument) or re.match(r"<@!?([0-9]{15,20})>$", argument)
         guild = ctx.guild
@@ -254,9 +253,13 @@ class MemberConverter(IDConverter[disnake.Member]):
         else:
             user_id = int(match.group(1))
             if guild:
-                mentions = (
-                    user for user in ctx.message.mentions if isinstance(user, disnake.Member)
-                )
+                mentions: Iterable[disnake.Member]
+                if isinstance(ctx, Context):
+                    mentions = (
+                        user for user in ctx.message.mentions if isinstance(user, disnake.Member)
+                    )
+                else:
+                    mentions = []
                 result = guild.get_member(user_id) or _utils_get(mentions, id=user_id)
             else:
                 result = _get_from_guilds(bot, lambda g: g.get_member(user_id))
@@ -296,15 +299,22 @@ class UserConverter(IDConverter[disnake.User]):
         and it's not available in cache.
     """
 
-    # note: this uses `Context` instead of `AnyContext`, as it's not used by application commands
-    async def convert(self, ctx: Context, argument: str) -> disnake.User:
+    async def convert(self, ctx: AnyContext, argument: str) -> disnake.User:
         match = self._get_id_match(argument) or re.match(r"<@!?([0-9]{15,20})>$", argument)
         state = ctx._state
         bot: disnake.Client = ctx.bot
+        result: Optional[Union[disnake.User, disnake.Member]] = None
 
         if match is not None:
             user_id = int(match.group(1))
-            result = bot.get_user(user_id) or _utils_get(ctx.message.mentions, id=user_id)
+
+            mentions: Iterable[Union[disnake.User, disnake.Member]]
+            if isinstance(ctx, Context):
+                mentions = ctx.message.mentions
+            else:
+                mentions = []
+            result = bot.get_user(user_id) or _utils_get(mentions, id=user_id)
+
             if result is None:
                 try:
                     result = await bot.fetch_user(user_id)


### PR DESCRIPTION
## Summary

Adds support for `ApplicationCommandInteraction` to `commands.UserConverter` and `.MemberConverter`. While slash commands don't use these converters and instead use the builtin option type, these converters may still be called manually.

<sup>Also improves the `channel_types` error message, which is somewhat but not really related. I just didn't feel like opening a separate PR for a change of a few characters</sup>

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
