### PR TITLE
fix: pass connection state to activity emoji

### DIFF
--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -784,7 +784,7 @@ class CustomActivity(BaseActivity):
             self.emoji = emoji
         else:
             raise TypeError(
-                f"Expected dict, str, PartialEmoji, or None, received {type(emoji)!r} instead."
+                f"Expected str, PartialEmoji, or None, received {type(emoji)!r} instead."
             )
 
     @property

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -244,7 +244,7 @@ class Activity(BaseActivity):
         self.emoji: Optional[PartialEmoji] = (
             PartialEmoji.from_dict(emoji) if emoji is not None else None
         )
-        if self.emoji:
+        if self.emoji and _state:
             self.emoji._state = _state
 
     def __repr__(self) -> str:
@@ -790,7 +790,7 @@ class CustomActivity(BaseActivity):
                 f"Expected dict, str, PartialEmoji, or None, received {type(emoji)!r} instead."
             )
 
-        if self.emoji:
+        if self.emoji and _state:
             self.emoji._state = _state
 
     @property

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import io
 import os
-from typing import TYPE_CHECKING, Any, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 
 import yarl
 
@@ -37,6 +37,8 @@ from .errors import DiscordException, InvalidArgument
 __all__ = ("Asset",)
 
 if TYPE_CHECKING:
+    from .state import ConnectionState
+
     ValidStaticFormatTypes = Literal["webp", "jpeg", "jpg", "png"]
     ValidAssetFormatTypes = Literal["webp", "jpeg", "jpg", "png", "gif"]
 
@@ -49,7 +51,7 @@ MISSING = utils.MISSING
 
 class AssetMixin:
     url: str
-    _state: Optional[Any]
+    _state: Optional[ConnectionState]
 
     __slots__: Tuple[str, ...] = ("_state",)
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -873,7 +873,7 @@ class Client:
     @property
     def activity(self) -> Optional[ActivityTypes]:
         """Optional[:class:`.BaseActivity`]: The activity being used upon logging in."""
-        return create_activity(self._connection._activity)
+        return create_activity(self._connection._activity, state=self._connection)
 
     @activity.setter
     def activity(self, value: Optional[ActivityTypes]) -> None:

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -455,7 +455,7 @@ class Member(disnake.abc.Messageable, _UserTag):
     def _presence_update(
         self, data: PartialPresenceUpdate, user: UserPayload
     ) -> Optional[Tuple[User, User]]:
-        self.activities = tuple(map(create_activity, data["activities"]))
+        self.activities = tuple(create_activity(a, state=self._state) for a in data["activities"])
         self._client_status = {
             sys.intern(key): sys.intern(value) for key, value in data.get("client_status", {}).items()  # type: ignore
         }

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from .state import ConnectionState
+    from .types.activity import ActivityEmoji as ActivityEmojiPayload
     from .types.message import PartialEmoji as PartialEmojiPayload
 
 
@@ -104,10 +105,12 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         self.animated = animated
         self.name = name
         self.id = id
-        self._state: Optional[ConnectionState] = None
+        self._state = None
 
     @classmethod
-    def from_dict(cls: Type[PE], data: Union[PartialEmojiPayload, Dict[str, Any]]) -> PE:
+    def from_dict(
+        cls: Type[PE], data: Union[PartialEmojiPayload, ActivityEmojiPayload, Dict[str, Any]]
+    ) -> PE:
         return cls(
             animated=data.get("animated", False),
             id=utils._get_as_snowflake(data, "id"),

--- a/disnake/widget.py
+++ b/disnake/widget.py
@@ -190,7 +190,7 @@ class WidgetMember(BaseUser):
         except KeyError:
             activity = None
         else:
-            activity = create_activity(game)
+            activity = create_activity(game, state=state)
 
         self.activity: Optional[Union[BaseActivity, Spotify]] = activity
 


### PR DESCRIPTION
## Summary

Fixes an issue where you couldn't fetch the emoji data of an `Activity`/`CustomActivity` due to a missing `ConnectionState`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
