### PR TITLE
feat: add documentation search hotkeys

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -213,9 +213,36 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelector("#dark-mode-switch .knob").classList.add(color_scheme);
 });
 
-document.addEventListener('keydown', (event) => {
-  if (event.code == "Escape" && activeModal) {
-    activeModal.close();
+
+function focusSearch() {
+  $('input[name=q]').first().focus();
+}
+
+
+$(document).keydown((event) => {
+  if (event.altKey || event.metaKey)
+    return;
+
+  if (!event.ctrlKey) {
+    const activeElementType = document.activeElement.tagName;
+    if (["TEXTAREA", "INPUT", "SELECT", "BUTTON"].includes(activeElementType))
+      return;
+
+    if (!event.shiftKey && event.key === "Escape" && activeModal) {
+      activeModal.close();
+      return false;
+    }
+
+    // not checking `shiftKey` for `/` since some keyboards need it
+    if (event.key === "/" || (!event.shiftKey && event.key === "s")) {
+      focusSearch();
+      return false;
+    }
+  }
+
+  if (!event.shiftKey && event.ctrlKey && event.key == "k") {
+    focusSearch();
+    return false;
   }
 });
 

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -230,26 +230,31 @@ $(document).keydown((event) => {
 
   const focusedElement = document.activeElement;
   if (["TEXTAREA", "INPUT", "SELECT", "BUTTON"].includes(focusedElement.tagName)) {
+    // handle `escape` in search field
     if (!event.ctrlKey && !event.shiftKey && event.key === "Escape" && $('input[name=q]').first().is(focusedElement)) {
       unfocusSearch();
       return false;
     }
+    // otherwise, ignore all key presses in inputs
     return;
   }
 
   if (!event.ctrlKey) {
+    // close modal using `escape`, if modal exists
     if (!event.shiftKey && event.key === "Escape" && activeModal) {
       activeModal.close();
       return false;
     }
 
-    // not checking `shiftKey` for `/` since some keyboards need it
+    // focus search using `/` or `s`
+    // (not checking `shiftKey` for `/` since some keyboards need it)
     if (event.key === "/" || (!event.shiftKey && event.key === "s")) {
       focusSearch();
       return false;
     }
   }
 
+  // focus search using `ctrl+k`
   if (!event.shiftKey && event.ctrlKey && event.key == "k") {
     focusSearch();
     return false;

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -219,12 +219,23 @@ function focusSearch() {
 }
 
 
+function unfocusSearch() {
+  $('input[name=q]').first().blur();
+}
+
+
 $(document).keydown((event) => {
   if (event.altKey || event.metaKey)
     return;
 
-  if (["TEXTAREA", "INPUT", "SELECT", "BUTTON"].includes(document.activeElement.tagName))
+  const focusedElement = document.activeElement;
+  if (["TEXTAREA", "INPUT", "SELECT", "BUTTON"].includes(focusedElement.tagName)) {
+    if (!event.ctrlKey && !event.shiftKey && event.key === "Escape" && $('input[name=q]').first().is(focusedElement)) {
+      unfocusSearch();
+      return false;
+    }
     return;
+  }
 
   if (!event.ctrlKey) {
     if (!event.shiftKey && event.key === "Escape" && activeModal) {

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -223,11 +223,10 @@ $(document).keydown((event) => {
   if (event.altKey || event.metaKey)
     return;
 
-  if (!event.ctrlKey) {
-    const activeElementType = document.activeElement.tagName;
-    if (["TEXTAREA", "INPUT", "SELECT", "BUTTON"].includes(activeElementType))
-      return;
+  if (["TEXTAREA", "INPUT", "SELECT", "BUTTON"].includes(document.activeElement.tagName))
+    return;
 
+  if (!event.ctrlKey) {
     if (!event.shiftKey && event.key === "Escape" && activeModal) {
       activeModal.close();
       return false;

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -83,7 +83,7 @@
         <div class="header-breakpoint search-breakpoint">
           <form role="search" class="search" action="{{ pathto('search') }}" method="get">
             <div class="search-wrapper">
-              <input type="search" name="q" placeholder="{{ _('Search documentation') }}" placeholder-mobile="{{ _('Search') }}" placeholder-desktop="{{ _('Search documentation') }}" />
+              <input type="search" name="q" placeholder="{{ _('Search documentation') }}" placeholder-mobile="{{ _('Search') }}" placeholder-desktop="{{ _('Search documentation') }}" title="Keyboard Shortcuts: &quot;/&quot;, &quot;s&quot;, &quot;ctrl+k&quot;" />
               <button type="submit">
                 <span class="material-icons">search</span>
               </button>


### PR DESCRIPTION
## Summary

Adds a few common keyboard shortcuts for focusing the search bar in the documentation:
- `ctrl+k`: algolia/docsearch (hence also used by sites like [discord.dev](https://discord.dev) and [guide.disnake.dev](https://guide.disnake.dev))
- `/`: commonly seen in a few applications; Sphinx 4.5 will [support](https://github.com/sphinx-doc/sphinx/commit/799385f5558a888d1a143bf703d06b66d6717fe4) it, GitLab uses it, algolia/docsearch also appears to support it
- `s`: GitHub + GitLab

preview: https://disnake--434.org.readthedocs.build/en/434/

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
