### PR TITLE
docs: fix `invalid escape sequence` warnings

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -814,7 +814,7 @@ class GuildChannel(ABC):
         overwrite: Optional[:class:`.PermissionOverwrite`]
             The permissions to allow and deny to the target, or ``None`` to
             delete the overwrite.
-        \*\*permissions
+        **permissions
             A keyword argument list of permissions to set for ease of use.
             Cannot be mixed with ``overwrite``.
         reason: Optional[:class:`str`]

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -394,7 +394,7 @@ class AuditLogEntry(Hashable):
     action: :class:`AuditLogAction`
         The action that was done.
     user: :class:`abc.User`
-        The user who initiated this action. Usually a :class:`Member`\, unless gone
+        The user who initiated this action. Usually a :class:`Member`\\, unless gone
         then it's a :class:`User`.
     id: :class:`int`
         The entry ID.

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -173,9 +173,9 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
         ----------
         command: :class:`.Command`
             The command that is going to be called.
-        \*args
+        *args
             The arguments to use.
-        \*\*kwargs
+        **kwargs
             The keyword arguments to use.
 
         Raises

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -1739,7 +1739,7 @@ def check_any(*checks: Check) -> Callable[[T], T]:
 
     Parameters
     ----------
-    \*checks: Callable[[:class:`Context`], :class:`bool`]
+    *checks: Callable[[:class:`Context`], :class:`bool`]
         An argument list of checks that have been decorated with
         the :func:`check` decorator.
 

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -280,9 +280,9 @@ class Loop(Generic[LF]):
 
         Parameters
         ----------
-        \*args
+        *args
             The arguments to use.
-        \*\*kwargs
+        **kwargs
             The keyword arguments to use.
         """
         if self._injected is not None:
@@ -296,9 +296,9 @@ class Loop(Generic[LF]):
 
         Parameters
         ----------
-        \*args
+        *args
             The arguments to use.
-        \*\*kwargs
+        **kwargs
             The keyword arguments to use.
 
         Raises
@@ -364,9 +364,9 @@ class Loop(Generic[LF]):
 
         Parameters
         ----------
-        \*args
+        *args
             The arguments to use.
-        \*\*kwargs
+        **kwargs
             The keyword arguments to use.
         """
 
@@ -391,7 +391,7 @@ class Loop(Generic[LF]):
 
         Parameters
         ----------
-        \*exceptions: Type[:class:`BaseException`]
+        *exceptions: Type[:class:`BaseException`]
             An argument list of exception classes to handle.
 
         Raises
@@ -422,7 +422,7 @@ class Loop(Generic[LF]):
 
         Parameters
         ----------
-        \*exceptions: Type[:class:`BaseException`]
+        *exceptions: Type[:class:`BaseException`]
             An argument list of exception classes to handle.
 
         Returns

--- a/disnake/file.py
+++ b/disnake/file.py
@@ -39,7 +39,7 @@ class File:
     .. note::
 
         File objects are single use and are not meant to be reused in
-        multiple :meth:`abc.Messageable.send`\s.
+        multiple :meth:`abc.Messageable.send`\\s.
 
     Attributes
     ----------

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -165,7 +165,7 @@ class SystemChannelFlags(BaseFlags):
     """
     Wraps up a Discord system channel flag value.
 
-    Similar to :class:`Permissions`\, the properties provided are two way.
+    Similar to :class:`Permissions`\\, the properties provided are two way.
     You can set and retrieve individual bits using the properties as if they
     were regular bools. This allows you to edit the system flags easily.
 
@@ -481,7 +481,7 @@ class Intents(BaseFlags):
     """
     Wraps up a Discord gateway intent flag.
 
-    Similar to :class:`Permissions`\, the properties provided are two way.
+    Similar to :class:`Permissions`\\, the properties provided are two way.
     You can set and retrieve individual bits using the properties as if they
     were regular bools.
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1603,7 +1603,7 @@ class Guild(Hashable):
             splash. This is only available to guilds that contain ``DISCOVERABLE``
             in :attr:`Guild.features`.
         community: :class:`bool`
-            Whether the guild should be a Community guild. If set to ``True``\, both ``rules_channel``
+            Whether the guild should be a Community guild. If set to ``True``\\, both ``rules_channel``
             and ``public_updates_channel`` parameters are required.
         region: Union[:class:`str`, :class:`VoiceRegion`]
             The new region for the guild's voice communication.
@@ -2230,7 +2230,7 @@ class Guild(Hashable):
             Whether to compute the prune count. This defaults to ``True``
             which makes it prone to timeouts in very large guilds. In order
             to prevent timeouts, you must set this to ``False``. If this is
-            set to ``False``\, then this function will always return ``None``.
+            set to ``False``\\, then this function will always return ``None``.
         roles: List[:class:`abc.Snowflake`]
             A list of :class:`abc.Snowflake` that represent roles to include in the pruning process. If a member
             has a role that is not specified, they'll be excluded.
@@ -2487,7 +2487,7 @@ class Guild(Hashable):
     async def fetch_stickers(self) -> List[GuildSticker]:
         """|coro|
 
-        Retrieves a list of all :class:`Sticker`\s that the guild has.
+        Retrieves a list of all :class:`Sticker`\\s that the guild has.
 
         .. versionadded:: 2.0
 
@@ -2627,7 +2627,7 @@ class Guild(Hashable):
     async def fetch_emojis(self) -> List[Emoji]:
         """|coro|
 
-        Retrieves all custom :class:`Emoji`\s that the guild has.
+        Retrieves all custom :class:`Emoji`\\s that the guild has.
 
         .. note::
 
@@ -2711,7 +2711,7 @@ class Guild(Hashable):
             The :term:`py:bytes-like object` representing the image data to use.
             Only JPG, PNG and GIF images are supported.
         roles: List[:class:`Role`]
-            A :class:`list` of :class:`Role`\s that can use this emoji. Leave empty to make it available to everyone.
+            A :class:`list` of :class:`Role`\\s that can use this emoji. Leave empty to make it available to everyone.
         reason: Optional[:class:`str`]
             The reason for creating this emoji. Shows up on the audit log.
 

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -271,15 +271,15 @@ class Invite(Hashable):
     +------------------------------------+-------------------------------------------------------------------+
     |             Attribute              |                          Method                                   |
     +====================================+===================================================================+
-    | :attr:`max_age`                    | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`          |
+    | :attr:`max_age`                    | :meth:`abc.GuildChannel.invites`\\, :meth:`Guild.invites`          |
     +------------------------------------+-------------------------------------------------------------------+
-    | :attr:`max_uses`                   | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`          |
+    | :attr:`max_uses`                   | :meth:`abc.GuildChannel.invites`\\, :meth:`Guild.invites`          |
     +------------------------------------+-------------------------------------------------------------------+
-    | :attr:`created_at`                 | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`          |
+    | :attr:`created_at`                 | :meth:`abc.GuildChannel.invites`\\, :meth:`Guild.invites`          |
     +------------------------------------+-------------------------------------------------------------------+
-    | :attr:`temporary`                  | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`          |
+    | :attr:`temporary`                  | :meth:`abc.GuildChannel.invites`\\, :meth:`Guild.invites`          |
     +------------------------------------+-------------------------------------------------------------------+
-    | :attr:`uses`                       | :meth:`abc.GuildChannel.invites`\, :meth:`Guild.invites`          |
+    | :attr:`uses`                       | :meth:`abc.GuildChannel.invites`\\, :meth:`Guild.invites`          |
     +------------------------------------+-------------------------------------------------------------------+
     | :attr:`approximate_member_count`   | :meth:`Client.fetch_invite` with `with_counts` enabled            |
     +------------------------------------+-------------------------------------------------------------------+

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -946,15 +946,15 @@ class Member(disnake.abc.Messageable, _UserTag):
         """
         |coro|
 
-        Gives the member a number of :class:`Role`\s.
+        Gives the member a number of :class:`Role`\\s.
 
         You must have :attr:`~Permissions.manage_roles` permission to
-        use this, and the added :class:`Role`\s must appear lower in the list
+        use this, and the added :class:`Role`\\s must appear lower in the list
         of roles than the highest role of the member.
 
         Parameters
         ----------
-        \*roles: :class:`abc.Snowflake`
+        *roles: :class:`abc.Snowflake`
             An argument list of :class:`abc.Snowflake` representing a :class:`Role`
             to give to the member.
         reason: Optional[:class:`str`]
@@ -987,15 +987,15 @@ class Member(disnake.abc.Messageable, _UserTag):
         """
         |coro|
 
-        Removes :class:`Role`\s from this member.
+        Removes :class:`Role`\\s from this member.
 
         You must have :attr:`~Permissions.manage_roles` permission to
-        use this, and the removed :class:`Role`\s must appear lower in the list
+        use this, and the removed :class:`Role`\\s must appear lower in the list
         of roles than the highest role of the member.
 
         Parameters
         ----------
-        \*roles: :class:`abc.Snowflake`
+        *roles: :class:`abc.Snowflake`
             An argument list of :class:`abc.Snowflake` representing a :class:`Role`
             to remove from the member.
         reason: Optional[:class:`str`]

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -752,7 +752,7 @@ class Message(Hashable):
     mentions: List[:class:`abc.User`]
         A list of :class:`Member` that were mentioned. If the message is in a private message
         then the list will be of :class:`User` instead. For messages that are not of type
-        :attr:`MessageType.default`\, this array can be used to aid in system messages.
+        :attr:`MessageType.default`\\, this array can be used to aid in system messages.
         For more information, see :attr:`system_content`.
 
         .. warning::
@@ -1252,7 +1252,7 @@ class Message(Hashable):
         :class:`str`: A property that returns the content that is rendered
         regardless of the :attr:`Message.type`.
 
-        In the case of :attr:`MessageType.default` and :attr:`MessageType.reply`\,
+        In the case of :attr:`MessageType.default` and :attr:`MessageType.reply`\\,
         this just returns the regular :attr:`Message.content`. Otherwise this
         returns an English message denoting the contents of the system message.
         """

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -416,7 +416,7 @@ class Permissions(BaseFlags):
 
         Parameters
         ----------
-        \*\*kwargs
+        **kwargs
             A list of key/value pairs to bulk update permissions with.
         """
         for key, value in kwargs.items():
@@ -770,7 +770,7 @@ class PermissionOverwrite:
     """
     A type that is used to represent a channel specific permission.
 
-    Unlike a regular :class:`Permissions`\, the default value of a
+    Unlike a regular :class:`Permissions`\\, the default value of a
     permission is equivalent to ``None`` and not ``False``. Setting
     a value to ``False`` is **explicitly** denying that permission,
     while setting a value to ``True`` is **explicitly** allowing
@@ -795,7 +795,7 @@ class PermissionOverwrite:
 
     Parameters
     ----------
-    \*\*kwargs
+    **kwargs
         Set the value of permissions by their name.
     """
 
@@ -924,7 +924,7 @@ class PermissionOverwrite:
 
         Parameters
         ----------
-        \*\*kwargs
+        **kwargs
             A list of key/value pairs to bulk update with.
         """
         for key, value in kwargs.items():

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -83,7 +83,7 @@ class Select(Item[V]):
         The maximum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
     options: Union[List[:class:`disnake.SelectOption`], List[:class:`str`], Dict[:class:`str`, :class:`str`]]
-        A list of options that can be selected in this menu. Use explicit :class:`.SelectOption`\s
+        A list of options that can be selected in this menu. Use explicit :class:`.SelectOption`\\s
         for fine-grained control over the options. Alternatively, a list of strings will be treated
         as a list of labels, and a dict will be treated as a mapping of labels to values.
 
@@ -341,7 +341,7 @@ def select(
         The maximum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
     options: Union[List[:class:`disnake.SelectOption`], List[:class:`str`], Dict[:class:`str`, :class:`str`]]
-        A list of options that can be selected in this menu. Use explicit :class:`.SelectOption`\s
+        A list of options that can be selected in this menu. Use explicit :class:`.SelectOption`\\s
         for fine-grained control over the options. Alternatively, a list of strings will be treated
         as a list of labels, and a dict will be treated as a mapping of labels to values.
 

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -463,7 +463,7 @@ def get(iterable: Iterable[T], **attrs: Any) -> Optional[T]:
     ----------
     iterable
         An iterable to search through.
-    \*\*attrs
+    **attrs
         Keyword arguments that denote attributes to search with.
     """
 
@@ -826,8 +826,8 @@ def escape_markdown(text: str, *, as_needed: bool = False, ignore_links: bool = 
     as_needed: :class:`bool`
         Whether to escape the markdown characters as needed. This
         means that it does not escape extraneous characters if it's
-        not necessary, e.g. ``**hello**`` is escaped into ``\*\*hello**``
-        instead of ``\*\*hello\*\*``. Note however that this can open
+        not necessary, e.g. ``**hello**`` is escaped into ``\\*\\*hello**``
+        instead of ``\\*\\*hello\\*\\*``. Note however that this can open
         you up to some clever syntax abuse. Defaults to ``False``.
     ignore_links: :class:`bool`
         Whether to leave links alone when escaping markdown. For example,


### PR DESCRIPTION
## Summary

Fixes `DeprecationWarning: invalid escape sequence` warnings as seen e.g. in the `Run pytest` step of [this](https://github.com/DisnakeDev/disnake/runs/5711479026?check_suite_focus=true) workflow run.

The resulting documentation should be exactly the same, diffing the built docs of the master branch and this branch showed no changes.

(the table in `invite.py` unfortunately looks kinda borked, but it's correct after interpreting escaped chars)

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
