### PR TITLE
fix(listeners): improve listener unloading behaviour

### DIFF
--- a/disnake/ext/commands/cog.py
+++ b/disnake/ext/commands/cog.py
@@ -810,8 +810,8 @@ class Cog(metaclass=CogMeta):
                 elif isinstance(app_command, InvokableMessageCommand):
                     bot.remove_message_command(app_command.name)
 
-            for _, method_name in self.__cog_listeners__:
-                bot.remove_listener(getattr(self, method_name))
+            for name, method_name in self.__cog_listeners__:
+                bot.remove_listener(getattr(self, method_name), name)
 
             if cls.bot_check is not Cog.bot_check:
                 bot.remove_check(self.bot_check)  # type: ignore


### PR DESCRIPTION
## Summary

Currently, listeners are added to a dict by event name, then stored in a list of functions for that event. This dict can be found in `CommonBotBase.extra_events`. This is achieved as follows:
```py
# Cog._inject
for name, method_name in self.__cog_listeners__:
    bot.add_listener(getattr(self, method_name), name)

# CommonBotBase.add_listener
def add_listener(self, func: CoroFunc, name: str = MISSING) -> None:
    name = func.__name__ if name is MISSING else name
    ...
    if name in self.extra_events:
        self.extra_events[name].append(func)
    else:
        self.extra_events[name] = [func]
```
However, when they're unloaded, they suddenly ignore the name:
```py
# Cog._eject
for _, method_name in self.__cog_listeners__:
    bot.remove_listener(getattr(self, method_name))

# CommonBotBase.remove_listener
def remove_listener(self, func: CoroFunc, name: str = MISSING) -> None:
    name = func.__name__ if name is MISSING else name
    if name in self.extra_events:
        try:
            self.extra_events[name].remove(func)
        except ValueError:
            pass
```
This means that listeners defined with a name other than their event name, e.g.
```py
@commands.Cog.listener("on_button_click")
async def named_listener(...):
    ...
```
will not be removed properly. Now, this isn't necessarily a problem for normal listener coros, as these will just get garbage collected alongside the cog. However, for any custom implementation that would return an object other than the original function ~~mmlol~~, this would prevent the coro and the whole cog it is attached to from being garbage collected. By simply adding the name to the logic in `Cog._eject`, similarly to how it's done when adding listeners, everything will be removed properly, and we do not have to rely on gc being somewhat intelligent.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue (well yes but actually no)
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
