### PR TITLE
feat: add stage instance start notification

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -1404,7 +1404,7 @@ class StageChannel(VocalGuildChannel):
         *,
         topic: str,
         privacy_level: StagePrivacyLevel = MISSING,
-        notify: bool = False,
+        notify_everyone: bool = False,
         reason: Optional[str] = None,
     ) -> StageInstance:
         """|coro|
@@ -1424,7 +1424,7 @@ class StageChannel(VocalGuildChannel):
             The stage instance's privacy level. Defaults to :attr:`StagePrivacyLevel.guild_only`.
         reason: :class:`str`
             The reason the stage instance was created. Shows up on the audit log.
-        notify: :class:`bool`
+        notify_everyone: :class:`bool`
             Whether to notify ``@everyone`` that the stage instance has started.
             Requires the :attr:`~Permissions.mention_everyone` permission on the stage channel.
             Defaults to ``False``.
@@ -1446,7 +1446,7 @@ class StageChannel(VocalGuildChannel):
         payload: Dict[str, Any] = {
             "channel_id": self.id,
             "topic": topic,
-            "send_start_notification": notify,
+            "send_start_notification": notify_everyone,
         }
 
         if privacy_level is not MISSING:

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -1406,6 +1406,7 @@ class StageChannel(VocalGuildChannel):
         *,
         topic: str,
         privacy_level: StagePrivacyLevel = MISSING,
+        notify: bool = False,
         reason: Optional[str] = None,
     ) -> StageInstance:
         """|coro|
@@ -1425,6 +1426,10 @@ class StageChannel(VocalGuildChannel):
             The stage instance's privacy level. Defaults to :attr:`StagePrivacyLevel.guild_only`.
         reason: :class:`str`
             The reason the stage instance was created. Shows up on the audit log.
+        notify: :class:`bool`
+            Whether to notify ``@everyone`` that the stage instance has started.
+            Requires the :attr:`~Permissions.mention_everyone` permission on the stage channel.
+            Defaults to ``False``.
 
         Raises
         ------
@@ -1440,7 +1445,11 @@ class StageChannel(VocalGuildChannel):
         :class:`StageInstance`
             The newly created stage instance.
         """
-        payload: Dict[str, Any] = {"channel_id": self.id, "topic": topic}
+        payload: Dict[str, Any] = {
+            "channel_id": self.id,
+            "topic": topic,
+            "send_start_notification": notify,
+        }
 
         if privacy_level is not MISSING:
             if not isinstance(privacy_level, StagePrivacyLevel):

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -1429,6 +1429,8 @@ class StageChannel(VocalGuildChannel):
             Requires the :attr:`~Permissions.mention_everyone` permission on the stage channel.
             Defaults to ``False``.
 
+            .. versionadded:: 2.5
+
         Raises
         ------
         InvalidArgument

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1879,6 +1879,7 @@ class HTTPClient:
             "channel_id",
             "topic",
             "privacy_level",
+            "send_start_notification",
         )
         payload = {k: v for k, v in payload.items() if k in valid_keys}
 


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/68d862bb59c1482e49012f174cbce4a9bcc666e2?w=1

nb: without the `mention_everyone` permission, setting `notify_everyone=True` does nothing and currently doesn't result in a 403.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
