### PR TITLE
feat!: update bans to use AsyncIterator pagination

### DIFF
--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -24,6 +24,7 @@ from . import abc as abc, opus as opus, ui as ui, utils as utils  # explicitly r
 from .activity import *
 from .app_commands import *
 from .appinfo import *
+from .bans import *
 from .asset import *
 from .audit_logs import *
 from .channel import *

--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -24,9 +24,9 @@ from . import abc as abc, opus as opus, ui as ui, utils as utils  # explicitly r
 from .activity import *
 from .app_commands import *
 from .appinfo import *
-from .bans import *
 from .asset import *
 from .audit_logs import *
+from .bans import *
 from .channel import *
 from .client import *
 from .colour import *

--- a/disnake/bans.py
+++ b/disnake/bans.py
@@ -1,0 +1,35 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2022-present Disnake Development
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple, Optional
+
+__all__ = ("BanEntry",)
+
+if TYPE_CHECKING:
+    from .user import User
+
+
+class BanEntry(NamedTuple):
+    reason: Optional[str]
+    user: "User"

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2201,7 +2201,7 @@ class Guild(Hashable):
         limit: Optional[:class:`int`]
             The number of bans to retrieve.
             If ``None``, it retrieves every ban in the guild. Note, however,
-            that this would make a slow operation.
+            that this would make it a slow operation.
             Defaults to 1000.
         before: Optional[:class:`~disnake.abc.Snowflake`]
             Retrieve bans before this user.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2168,13 +2168,16 @@ class Guild(Hashable):
     def bans(
         self,
         *,
-        limit: Optional[int] = None,
-        before: Optional[SnowflakeTime] = None,
-        after: Optional[SnowflakeTime] = None,
+        limit: Optional[int] = 1000,
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
     ) -> BanIterator:
         """Returns an :class:`~disnake.AsyncIterator` that enables receiving the destination's bans.
 
         You must have the :attr:`~Permissions.ban_members` permission to get this information.
+
+        .. versionchanged:: 2.0
+            Due to a breaking change in Discord's API, this now returns an :class:`~disnake.AsyncIterator` instead of a :class:`list`.
 
         Examples
         ---------
@@ -2197,15 +2200,14 @@ class Guild(Hashable):
         -----------
 
         limit: Optional[:class:`int`]
-            The number of bans to retrieve (up to maximum 1000). Defaults to 1000.
-        before: Optional[Union[:class:`~disnake.abc.Snowflake`, :class:`datetime.datetime`]]
-            Retrieve bans before this date or user (by id).
-            If a datetime is provided, it is recommended to use a UTC aware datetime.
-            If the datetime is naive, it is assumed to be local time.
-        after: Optional[Union[:class:`~disnake.abc.Snowflake`, :class:`datetime.datetime`]]
-            Retrieve bans after this date or user (by id).
-            If a datetime is provided, it is recommended to use a UTC aware datetime.
-            If the datetime is naive, it is assumed to be local time.
+            The number of bans to retrieve.
+            If ``None``, it retrieves every ban in the guild. Note, however,
+            that this would make a slow operation.
+            Defaults to 1000.
+        before: Optional[:class:`~disnake.abc.Snowflake`]
+            Retrieve bans before this user.
+        after: Optional[:class:`~disnake.abc.Snowflake`]
+            Retrieve bans after this user.
 
         Raises
         ------

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2176,7 +2176,7 @@ class Guild(Hashable):
 
         You must have the :attr:`~Permissions.ban_members` permission to get this information.
 
-        .. versionchanged:: 2.0
+        .. versionchanged:: 2.5
             Due to a breaking change in Discord's API, this now returns an :class:`~disnake.AsyncIterator` instead of a :class:`list`.
 
         Examples

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -76,7 +76,7 @@ from .flags import SystemChannelFlags
 from .guild_scheduled_event import GuildScheduledEvent, GuildScheduledEventMetadata
 from .integrations import Integration, _integration_factory
 from .invite import Invite
-from .iterators import AuditLogIterator, MemberIterator, BanIterator
+from .iterators import AuditLogIterator, BanIterator, MemberIterator
 from .member import Member, VoiceState
 from .mixins import Hashable
 from .permissions import PermissionOverwrite

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2197,8 +2197,7 @@ class Guild(Hashable):
         All parameters are optional.
 
         Parameters
-        -----------
-
+        ----------
         limit: Optional[:class:`int`]
             The number of bans to retrieve.
             If ``None``, it retrieves every ban in the guild. Note, however,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1335,8 +1335,25 @@ class HTTPClient:
     def get_guild_preview(self, guild_id: Snowflake) -> Response[guild.GuildPreview]:
         return self.request(Route("GET", "/guilds/{guild_id}/preview", guild_id=guild_id))
 
-    def get_bans(self, guild_id: Snowflake) -> Response[List[guild.Ban]]:
-        return self.request(Route("GET", "/guilds/{guild_id}/bans", guild_id=guild_id))
+    def get_bans(
+        self,
+        guild_id: Snowflake,
+        limit: Optional[int] = None,
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
+    ) -> Response[List[guild.Ban]]:
+        params: Dict[str, Any] = {}
+
+        if limit is not None:
+            params["limit"] = limit
+        if before is not None:
+            params["before"] = before
+        if after is not None:
+            params["after"] = after
+
+        return self.request(
+            Route("GET", "/guilds/{guild_id}/bans", guild_id=guild_id), params=params
+        )
 
     def get_ban(self, user_id: Snowflake, guild_id: Snowflake) -> Response[guild.Ban]:
         return self.request(

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -402,6 +402,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
 
 class BanIterator(_AsyncIterator["BanEntry"]):
     """Iterator for receiving a guild's bans.
+
     The bans endpoint has two behaviours we care about here:
     If ``before`` is specified, the bans endpoint returns the ``limit``
     bans with user ids before ``before``, sorted with smallest first. For filling over
@@ -409,17 +410,19 @@ class BanIterator(_AsyncIterator["BanEntry"]):
     If ``after`` is specified, it returns the ``limit`` bans with user ids after
     ``after``, sorted with smallest first. For filling over 1000 bans, update the
     ``after`` parameter to the smallest user id received.
+
     A note that if both ``before`` and ``after`` are specified, ``after`` is ignored by the
     bans endpoint.
+
     Parameters
     -----------
     guild: :class:`~disnake.Guild`
         The guild to get bans from.
     limit: Optional[:class:`int`]
         Maximum number of bans to retrieve.
-    before: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
+    before: Optional[:class:`abc.Snowflake`]
         Date or user id before which all bans must be.
-    after: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
+    after: Optional[:class:`abc.Snowflake`]
         Date or user id after which all bans must be.
     """
 
@@ -427,27 +430,22 @@ class BanIterator(_AsyncIterator["BanEntry"]):
         self,
         guild: Guild,
         limit: Optional[int] = None,
-        before: Optional[Union[Snowflake, datetime.datetime]] = None,
-        after: Optional[Union[Snowflake, datetime.datetime]] = None,
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
     ):
-        if isinstance(before, datetime.datetime):
-            before = Object(id=time_snowflake(before, high=False))
-        if isinstance(after, datetime.datetime):
-            after = Object(id=time_snowflake(after, high=True))
-
         self.guild = guild
         self.limit = limit
         self.before = before
         self.after = after or OLDEST_OBJECT
 
-        self._filter: Optional[Callable[[BanPayload], bool]] = None
-
         self.state = self.guild._state
         self.get_bans = self.state.http.get_bans
         self.bans = asyncio.Queue()
 
-        if self.after and self.after != OLDEST_OBJECT:
-            self._filter = lambda b: int(b["user"]["id"]) > self.after.id
+        if self.before:
+            self._retrieve_bans = self._retrieve_bans_before_strategy
+        else:
+            self._retrieve_bans = self._retrieve_bans_after_strategy
 
     async def next(self) -> BanEntry:
         if self.bans.empty():
@@ -459,8 +457,8 @@ class BanIterator(_AsyncIterator["BanEntry"]):
             raise NoMoreItems()
 
     def _get_retrieve(self) -> bool:
-        self.retrieve = min(self.limit, 1000) if self.limit is not None else None
-        return self.retrieve is None or self.retrieve > 0
+        self.retrieve = min(self.limit, 1000) if self.limit is not None else 1000
+        return self.retrieve > 0
 
     async def fill_bans(self):
         from .user import User
@@ -470,9 +468,6 @@ class BanIterator(_AsyncIterator["BanEntry"]):
             if len(data) < 1000:
                 self.limit = 0  # terminate the infinite loop
 
-            if self._filter:
-                data: List[BanPayload] = list(filter(self._filter, data))
-
             for element in data:
                 await self.bans.put(
                     BanEntry(
@@ -481,16 +476,24 @@ class BanIterator(_AsyncIterator["BanEntry"]):
                     )
                 )
 
-    async def _retrieve_bans(self, retrieve: Optional[int]) -> List[BanPayload]:
+    async def _retrieve_bans_before_strategy(self, retrieve: int) -> List[BanPayload]:
         """Retrieve bans using before parameter."""
-        if retrieve == 0:
-            return []
         before = self.before.id if self.before else None
         data: List[BanPayload] = await self.get_bans(self.guild.id, retrieve, before=before)
         if len(data):
             if self.limit is not None:
-                self.limit -= retrieve if retrieve is not None else 1000
-            self.before = Object(id=int(data[-1]["user"]["id"]))
+                self.limit -= len(data)
+            self.before = Object(id=int(data[0]["user"]["id"]))
+        return data
+
+    async def _retrieve_bans_after_strategy(self, retrieve: int) -> List[BanPayload]:
+        """Retrieve bans using after parameter."""
+        after = self.after.id if self.after else None
+        data: List[BanPayload] = await self.get_bans(self.guild.id, retrieve, after=after)
+        if len(data):
+            if self.limit is not None:
+                self.limit -= len(data)
+            self.after = Object(id=int(data[-1]["user"]["id"]))
         return data
 
 

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     from .message import Message
     from .threads import Thread
     from .types.audit_log import AuditLog as AuditLogPayload, AuditLogEntry as AuditLogEntryPayload
-    from .types.guild import Guild as GuildPayload, Ban as BanPayload
+    from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.message import Message as MessagePayload
     from .types.threads import Thread as ThreadPayload
     from .types.user import PartialUser as PartialUserPayload

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -421,9 +421,9 @@ class BanIterator(_AsyncIterator["BanEntry"]):
     limit: Optional[:class:`int`]
         Maximum number of bans to retrieve.
     before: Optional[:class:`abc.Snowflake`]
-        Date or user id before which all bans must be.
+        Object before which all bans must be.
     after: Optional[:class:`abc.Snowflake`]
-        Date or user id after which all bans must be.
+        Object after which all bans must be.
     """
 
     def __init__(

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -402,11 +402,11 @@ class BanIterator(_AsyncIterator["BanEntry"]):
 
     The bans endpoint has two behaviours we care about here:
     If ``before`` is specified, the bans endpoint returns the ``limit``
-    bans with user ids before ``before``, sorted with smallest first. For filling over
-    1000 bans, update the ``before`` parameter to the largest user id received.
+    bans with user ids before ``before``, sorted with the oldest first. For filling over
+    1000 bans, update the ``before`` parameter to the newest user received.
     If ``after`` is specified, it returns the ``limit`` bans with user ids after
-    ``after``, sorted with smallest first. For filling over 1000 bans, update the
-    ``after`` parameter to the smallest user id received.
+    ``after``, sorted with the oldest first. For filling over 1000 bans, update the
+    ``after`` parameter to the oldest user received.
 
     A note that if both ``before`` and ``after`` are specified, ``after`` is ignored by the
     bans endpoint.


### PR DESCRIPTION
## Summary

Discord changed the [Get Guild Bans](https://discord.com/developers/docs/resources/guild#get-guild-bans) API endpoint to support pagination.

This implements that change by making `Guild.bans` return an `AsyncIterator` supporting limit, before, and after.

`BanEntry` was moved from `disnake.guild` to `disnake.bans` to avoid circular imports.

## Breaking changes

`Guild.bans` is no longer a coroutine and returns an `AsyncIterator` of bans instead of a list.

```py
# before
bans = await guild.bans()

# now
bans = await guild.bans(limit=None).flatten()
```

More examples:

https://paste.nextcord.dev/?id=1648774261939651

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
