### PR TITLE
feat(thread)!: support `newly_created`, add `on_thread_create` event

### DIFF
--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1079,7 +1079,10 @@ class ConnectionState:
         has_thread = guild.get_thread(thread.id)
         guild._add_thread(thread)
         if not has_thread:
-            self.dispatch("thread_join", thread)
+            if data.get("newly_created"):
+                self.dispatch("thread_create", thread)
+            else:
+                self.dispatch("thread_join", thread)
 
     def parse_thread_update(self, data) -> None:
         guild_id = int(data["guild_id"])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -827,23 +827,6 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param thread: The thread that got joined.
     :type thread: :class:`Thread`
 
-.. function:: on_thread_create(thread)
-
-    Called whenever a thread is created.
-
-    Note that you can get the guild from :attr:`Thread.guild`.
-
-    This requires :attr:`Intents.guilds` to be enabled.
-
-    .. note::
-        This only works for threads created in channels the bot already has access to,
-        and only for public threads unless the bot has the :attr:`~Permissions.manage_threads` permission.
-
-    .. versionadded:: 2.5
-
-    :param thread: The thread that got created.
-    :type thread: :class:`Thread`
-
 .. function:: on_thread_remove(thread)
 
     Called whenever a thread is removed. This is different from a thread being deleted.
@@ -862,6 +845,23 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     .. versionadded:: 2.0
 
     :param thread: The thread that got removed.
+    :type thread: :class:`Thread`
+
+.. function:: on_thread_create(thread)
+
+    Called whenever a thread is created.
+
+    Note that you can get the guild from :attr:`Thread.guild`.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. note::
+        This only works for threads created in channels the bot already has access to,
+        and only for public threads unless the bot has the :attr:`~Permissions.manage_threads` permission.
+
+    .. versionadded:: 2.5
+
+    :param thread: The thread that got created.
     :type thread: :class:`Thread`
 
 .. function:: on_thread_delete(thread)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -812,8 +812,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
 .. function:: on_thread_join(thread)
 
-    Called whenever a thread is joined or created. Note that from the API's perspective there is no way to
-    differentiate between a thread being created or the bot joining a thread.
+    Called whenever the bot joins a thread or gets access to a thread
+    (for example, by gaining access to the parent channel).
 
     Note that you can get the guild from :attr:`Thread.guild`.
 
@@ -821,7 +821,27 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     .. versionadded:: 2.0
 
+    .. versionchanged:: 2.5
+        This is no longer being called when a thread is created, see :func:`on_thread_create` instead.
+
     :param thread: The thread that got joined.
+    :type thread: :class:`Thread`
+
+.. function:: on_thread_create(thread)
+
+    Called whenever a thread is created.
+
+    Note that you can get the guild from :attr:`Thread.guild`.
+
+    This requires :attr:`Intents.guilds` to be enabled.
+
+    .. note::
+        This only works for threads created in channels the bot already has access to,
+        and only for public threads unless the bot has the :attr:`~Permissions.manage_threads` permission.
+
+    .. versionadded:: 2.5
+
+    :param thread: The thread that got created.
     :type thread: :class:`Thread`
 
 .. function:: on_thread_remove(thread)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -819,6 +819,10 @@ to handle it, which defaults to print a traceback and ignoring the exception.
 
     This requires :attr:`Intents.guilds` to be enabled.
 
+    .. note::
+        This event will not be called for threads created by the bot or
+        threads created on one of the bot's messages.
+
     .. versionadded:: 2.0
 
     .. versionchanged:: 2.5


### PR DESCRIPTION
## Summary

Changes the `THREAD_CREATE` handling to dispatch a `thread_create` instead of `thread_join` event according to the `newly_created` field in the payload.

closes #323

ref: https://github.com/discord/discord-api-docs/commit/1875d80011ea62bf555ce807459ccf97950291e9

Previous attempt was #331, which partially changed how thread caching works. While this is certainly something that should be fixed, it should really be done separately.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
