### PR TITLE
chore: add workaround for missing message content intent

### DIFF
--- a/disnake/http.py
+++ b/disnake/http.py
@@ -38,6 +38,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
     Sequence,
     Tuple,
@@ -101,6 +102,23 @@ if TYPE_CHECKING:
     BE = TypeVar("BE", bound=BaseException)
     MU = TypeVar("MU", bound="MaybeUnlock")
     Response = Coroutine[Any, Any, T]
+
+_API_VERSION = 10
+
+
+def _workaround_set_api_version(version: Literal[9, 10]):
+    """Stopgap measure for verified bots without message content intent while intent is not enforced on api v9.
+
+
+    .. note::
+        This must be ran **before** connecting to the gateway.
+    """
+    if version not in (9, 10):
+        raise TypeError("version must be either 9 or 10")
+
+    global _API_VERSION
+    _API_VERSION = version
+    Route.BASE = f"https://discord.com/api/v{_API_VERSION}"
 
 
 async def json_or_text(response: aiohttp.ClientResponse) -> Union[Dict[str, Any], str]:
@@ -2438,10 +2456,10 @@ class HTTPClient:
         except HTTPException as exc:
             raise GatewayNotFound() from exc
         if zlib:
-            value = "{0}?encoding={1}&v=10&compress=zlib-stream"
+            value = "{url}?encoding={encoding}&v={version}&compress=zlib-stream"
         else:
-            value = "{0}?encoding={1}&v=10"
-        return value.format(data["url"], encoding)
+            value = "{url}?encoding={encoding}&v={version}"
+        return value.format(url=data["url"], encoding=encoding, version=_API_VERSION)
 
     async def get_bot_gateway(
         self, *, encoding: str = "json", zlib: bool = True
@@ -2452,10 +2470,14 @@ class HTTPClient:
             raise GatewayNotFound() from exc
 
         if zlib:
-            value = "{0}?encoding={1}&v=10&compress=zlib-stream"
+            value = "{url}?encoding={encoding}&v={version}&compress=zlib-stream"
         else:
-            value = "{0}?encoding={1}&v=10"
-        return data["shards"], value.format(data["url"], encoding), data["session_start_limit"]
+            value = "{url}?encoding={encoding}&v={version}"
+        return (
+            data["shards"],
+            value.format(url=data["url"], encoding=encoding, version=_API_VERSION),
+            data["session_start_limit"],
+        )
 
     def get_user(self, user_id: Snowflake) -> Response[user.User]:
         return self.request(Route("GET", "/users/{user_id}", user_id=user_id))

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -183,7 +183,7 @@ For example:
 Why do most messages have no content?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of August 31th, 2022, Discord has blocked message content from being sent to bots that do not declare the :attr:`Intents.message_content` intent when connecting to discord.
+As of August 31st, 2022, Discord has blocked message content from being sent to bots that do not declare the :attr:`Intents.message_content` intent when connecting to discord.
 
 If you are on version 2.4 or before, your bot will be able to access message content without the intent enabled in the code. However, as of version 2.5, it is required to enable :attr:`Intents.message_content` to receive message content over the gateway.
 

--- a/docs/intents.rst
+++ b/docs/intents.rst
@@ -183,7 +183,7 @@ For example:
 Why do most messages have no content?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of April 30th 2022, Discord has blocked message content from being sent to bots that do not declare the :attr:`Intents.message_content` intent when connecting to discord.
+As of August 31th, 2022, Discord has blocked message content from being sent to bots that do not declare the :attr:`Intents.message_content` intent when connecting to discord.
 
 If you are on version 2.4 or before, your bot will be able to access message content without the intent enabled in the code. However, as of version 2.5, it is required to enable :attr:`Intents.message_content` to receive message content over the gateway.
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Adds a workaround for api v9 to be used instead of api v10. Intentionally, this is undocumented and is for verified bots that have not yet been granted the message content intent. This will be removed after api v10 becomes stable, and the message content intent is required, whichever comes last.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
