### PR TITLE
feat: interaction expires and InteractionMessage.edit

### DIFF
--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -300,7 +300,7 @@ class Interaction:
 
         This does not take into account the 3 second limit for the initial response.
 
-        .. versionadded :: 2.5
+        .. versionadded:: 2.5
 
         :return type: :class:`bool`
         """

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1359,6 +1359,13 @@ class InteractionMessage(Message):
         """
         if self._state._interaction.is_expired():
             return await super().edit(content=content, **fields)
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        # this isn't necessary when using the superclass, as the implementation there takes care of attachments
+        if "attachments" not in fields and fields.get("file") or fields.get("files"):
+            fields["attachments"] = self.attachments
+
         return await self._state._interaction.edit_original_message(content=content, **fields)
 
     async def delete(self, *, delay: Optional[float] = None) -> None:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1234,18 +1234,63 @@ class InteractionMessage(Message):
     __slots__ = ()
     _state: _InteractionMessageState
 
+    @overload
     async def edit(
         self,
         content: Optional[str] = MISSING,
+        *,
         embed: Optional[Embed] = MISSING,
-        embeds: List[Embed] = MISSING,
         file: File = MISSING,
+        attachments: List[Attachment] = MISSING,
+        view: Optional[View] = MISSING,
+        components: Optional[Components] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
+    ) -> InteractionMessage:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        content: Optional[str] = MISSING,
+        *,
+        embed: Optional[Embed] = MISSING,
         files: List[File] = MISSING,
         attachments: List[Attachment] = MISSING,
         view: Optional[View] = MISSING,
         components: Optional[Components] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = None,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
     ) -> InteractionMessage:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        content: Optional[str] = MISSING,
+        *,
+        embeds: List[Embed] = MISSING,
+        file: File = MISSING,
+        attachments: List[Attachment] = MISSING,
+        view: Optional[View] = MISSING,
+        components: Optional[Components] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
+    ) -> InteractionMessage:
+        ...
+
+    @overload
+    async def edit(
+        self,
+        content: Optional[str] = MISSING,
+        *,
+        embeds: List[Embed] = MISSING,
+        files: List[File] = MISSING,
+        attachments: List[Attachment] = MISSING,
+        view: Optional[View] = MISSING,
+        components: Optional[Components] = MISSING,
+        allowed_mentions: Optional[AllowedMentions] = MISSING,
+    ) -> InteractionMessage:
+        ...
+
+    async def edit(self, content: Optional[str] = MISSING, **fields: Any) -> Message:
         """|coro|
 
         Edits the message.
@@ -1312,22 +1357,9 @@ class InteractionMessage(Message):
         :class:`InteractionMessage`
             The newly edited message.
         """
-        # if no attachment list was provided but we're uploading new files,
-        # use current attachments as the base
-        if attachments is MISSING and (file or files):
-            attachments = self.attachments
-
-        return await self._state._interaction.edit_original_message(
-            content=content,
-            embeds=embeds,
-            embed=embed,
-            file=file,
-            files=files,
-            attachments=attachments,
-            view=view,
-            components=components,
-            allowed_mentions=allowed_mentions,
-        )
+        if self._state._interaction.is_expired():
+            return await super().edit(content=content, **fields)
+        return await self._state._interaction.edit_original_message(content=content, **fields)
 
     async def delete(self, *, delay: Optional[float] = None) -> None:
         """|coro|
@@ -1349,6 +1381,8 @@ class InteractionMessage(Message):
         HTTPException
             Deleting the message failed.
         """
+        if self._state._interaction.is_expired():
+            return await super().delete(delay=delay)
         if delay is not None:
 
             async def inner_call(delay: float = delay):

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union, cast, overload
 
 from .. import utils
@@ -169,6 +170,7 @@ class Interaction:
         "_cs_followup",
         "_cs_channel",
         "_cs_me",
+        "_cs_expires_at",
     )
 
     def __init__(self, *, data: InteractionPayload, state: ConnectionState):
@@ -282,6 +284,27 @@ class Interaction:
             "token": self.token,
         }
         return Webhook.from_state(data=payload, state=self._state)
+
+    @utils.cached_slot_property("_cs_expires_at")
+    def expires_at(self) -> datetime:
+        """:class:`datetime.datetime`: Returns the interaction's expiration time in UTC.
+
+        This is exactly 15 minutes after the interaction was created.
+
+        .. versionadded:: 2.5
+        """
+        return self.created_at + timedelta(minutes=15)
+
+    def is_expired(self) -> bool:
+        """Whether the interaction is older than 15 minutes.
+
+        This does not take into account if the interaction was responded to within the 3 second limit.
+
+        .. versionadded :: 2.5
+
+        :return type: :class:`bool`
+        """
+        return self.expires_at <= utils.utcnow()
 
     async def original_message(self) -> InteractionMessage:
         """|coro|

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -296,9 +296,9 @@ class Interaction:
         return self.created_at + timedelta(minutes=15)
 
     def is_expired(self) -> bool:
-        """Whether the interaction is older than 15 minutes.
+        """Whether the interaction can still be used to make requests to Discord.
 
-        This does not take into account if the interaction was responded to within the 3 second limit.
+        This does not take into account the 3 second limit for the initial response.
 
         .. versionadded :: 2.5
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1237,56 +1237,56 @@ class InteractionMessage(Message):
     @overload
     async def edit(
         self,
-        content: Optional[str] = MISSING,
+        content: Optional[str] = ...,
         *,
-        embed: Optional[Embed] = MISSING,
-        file: File = MISSING,
-        attachments: List[Attachment] = MISSING,
-        view: Optional[View] = MISSING,
-        components: Optional[Components] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        embed: Optional[Embed] = ...,
+        file: File = ...,
+        attachments: List[Attachment] = ...,
+        view: Optional[View] = ...,
+        components: Optional[Components] = ...,
+        allowed_mentions: Optional[AllowedMentions] = ...,
     ) -> InteractionMessage:
         ...
 
     @overload
     async def edit(
         self,
-        content: Optional[str] = MISSING,
+        content: Optional[str] = ...,
         *,
-        embed: Optional[Embed] = MISSING,
-        files: List[File] = MISSING,
-        attachments: List[Attachment] = MISSING,
-        view: Optional[View] = MISSING,
-        components: Optional[Components] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        embed: Optional[Embed] = ...,
+        files: List[File] = ...,
+        attachments: List[Attachment] = ...,
+        view: Optional[View] = ...,
+        components: Optional[Components] = ...,
+        allowed_mentions: Optional[AllowedMentions] = ...,
     ) -> InteractionMessage:
         ...
 
     @overload
     async def edit(
         self,
-        content: Optional[str] = MISSING,
+        content: Optional[str] = ...,
         *,
-        embeds: List[Embed] = MISSING,
-        file: File = MISSING,
-        attachments: List[Attachment] = MISSING,
-        view: Optional[View] = MISSING,
-        components: Optional[Components] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        embeds: List[Embed] = ...,
+        file: File = ...,
+        attachments: List[Attachment] = ...,
+        view: Optional[View] = ...,
+        components: Optional[Components] = ...,
+        allowed_mentions: Optional[AllowedMentions] = ...,
     ) -> InteractionMessage:
         ...
 
     @overload
     async def edit(
         self,
-        content: Optional[str] = MISSING,
+        content: Optional[str] = ...,
         *,
-        embeds: List[Embed] = MISSING,
-        files: List[File] = MISSING,
-        attachments: List[Attachment] = MISSING,
-        view: Optional[View] = MISSING,
-        components: Optional[Components] = MISSING,
-        allowed_mentions: Optional[AllowedMentions] = MISSING,
+        embeds: List[Embed] = ...,
+        files: List[File] = ...,
+        attachments: List[Attachment] = ...,
+        view: Optional[View] = ...,
+        components: Optional[Components] = ...,
+        allowed_mentions: Optional[AllowedMentions] = ...,
     ) -> InteractionMessage:
         ...
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1363,7 +1363,7 @@ class InteractionMessage(Message):
         # if no attachment list was provided but we're uploading new files,
         # use current attachments as the base
         # this isn't necessary when using the superclass, as the implementation there takes care of attachments
-        if "attachments" not in fields and fields.get("file") or fields.get("files"):
+        if "attachments" not in fields and (fields.get("file") or fields.get("files")):
             fields["attachments"] = self.attachments
 
         return await self._state._interaction.edit_original_message(content=content, **fields)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4402,6 +4402,7 @@ InteractionMessage
 
 .. autoclass:: InteractionMessage()
     :members:
+    :inherited-members:
 
 ApplicationCommandInteractionData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

- feat: add interaction expires attributes
- fix: make InteractionMessage fallback to normal methods if the interaction is expired

closes #379
closes #459

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
