### PR TITLE
docs: fix several missing/broken entries

### DIFF
--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -157,7 +157,7 @@ class AppInfo:
     tags: Optional[List[:class:`str`]]
         The application's tags.
 
-        .. verisonadded:: 2.5
+        .. versionadded:: 2.5
 
     install_params: Optional[:class:`InstallParams`]
         The installation parameters for this application.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -860,7 +860,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
         Parameters
         ----------
-        limit: Optional[:class:`bool`]
+        limit: Optional[:class:`int`]
             The number of threads to retrieve.
             If ``None``, retrieves every archived thread in the channel. Note, however,
             that this would make it a slow operation.

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -107,6 +107,9 @@ class InvokableApplicationCommand(ABC):
     ----------
     name: :class:`str`
         The name of the command.
+    qualified_name: :class:`str`
+        The full command name, including parent names in the case of slash subcommands or groups.
+        For example, the qualified name for ``/one two three`` would be ``one two three``.
     body: :class:`.ApplicationCommand`
         An object being registered in the API.
     callback: :ref:`coroutine <coroutine>`

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -102,6 +102,28 @@ class InvokableApplicationCommand(ABC):
 
     These are not created manually, instead they are created via the
     decorator or functional interface.
+
+    Attributes
+    ----------
+    name: :class:`str`
+        The name of the command.
+    body: :class:`.ApplicationCommand`
+        An object being registered in the API.
+    callback: :ref:`coroutine <coroutine>`
+        The coroutine that is executed when the command is called.
+    cog: Optional[:class:`Cog`]
+        The cog that this command belongs to. ``None`` if there isn't one.
+    checks: List[Callable[[:class:`.ApplicationCommandInteraction`], :class:`bool`]]
+        A list of predicates that verifies if the command could be executed
+        with the given :class:`.ApplicationCommandInteraction` as the sole parameter. If an exception
+        is necessary to be thrown to signal failure, then one inherited from
+        :exc:`.CommandError` should be used. Note that if the checks fail then
+        :exc:`.CheckFailure` exception is raised to the :func:`.on_slash_command_error`
+        event.
+    guild_ids: Optional[List[:class:`int`]]
+        The list of IDs of the guilds where the command is synced. ``None`` if this command is global.
+    auto_sync: :class:`bool`
+        Whether to automatically register the command.
     """
 
     body: ApplicationCommand
@@ -160,7 +182,6 @@ class InvokableApplicationCommand(ABC):
 
     @property
     def callback(self) -> CommandCallback:
-        """Callable[..., Coroutine]: The callback associated with the interaction."""
         return self._callback
 
     def add_check(self, func: Check) -> None:

--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -49,6 +49,8 @@ class InvokableUserCommand(InvokableApplicationCommand):
     ----------
     name: :class:`str`
         The name of the user command.
+    qualified_name: :class:`str`
+        The full command name, equivalent to :attr:`.name` for this type of command.
     body: :class:`.UserCommand`
         An object being registered in the API.
     callback: :ref:`coroutine <coroutine>`
@@ -120,6 +122,8 @@ class InvokableMessageCommand(InvokableApplicationCommand):
     ----------
     name: :class:`str`
         The name of the message command.
+    qualified_name: :class:`str`
+        The full command name, equivalent to :attr:`.name` for this type of command.
     body: :class:`.MessageCommand`
         An object being registered in the API.
     callback: :ref:`coroutine <coroutine>`

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -929,7 +929,20 @@ def inject(function: Callable[..., Any]) -> Any:
 def option_enum(
     choices: Union[Dict[str, TChoice], List[TChoice]], **kwargs: TChoice
 ) -> Type[TChoice]:
-    """A utility function to create an enum type with the provided values."""
+    """
+    A utility function to create an enum type.
+    Returns a new :class:`~enum.Enum` based on the provided parameters.
+
+    .. versionadded:: 2.1
+
+    Parameters
+    ----------
+    choices: Union[Dict[:class:`str`, :class:`Any`], List[:class:`Any`]]
+        A name/value mapping of choices, or a list of values whose stringified representations
+        will be used as the names.
+    \\*\\*kwargs
+        Name/value pairs to use instead of the ``choices`` parameter.
+    """
     if isinstance(choices, list):
         choices = {str(i): i for i in choices}
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -940,7 +940,7 @@ def option_enum(
     choices: Union[Dict[:class:`str`, :class:`Any`], List[:class:`Any`]]
         A name/value mapping of choices, or a list of values whose stringified representations
         will be used as the names.
-    \\*\\*kwargs
+    **kwargs
         Name/value pairs to use instead of the ``choices`` parameter.
     """
     if isinstance(choices, list):

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -929,6 +929,7 @@ def inject(function: Callable[..., Any]) -> Any:
 def option_enum(
     choices: Union[Dict[str, TChoice], List[TChoice]], **kwargs: TChoice
 ) -> Type[TChoice]:
+    """A utility function to create an enum type with the provided values."""
     if isinstance(choices, list):
         choices = {str(i): i for i in choices}
 

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -109,6 +109,9 @@ class SubCommandGroup(InvokableApplicationCommand):
     ----------
     name: :class:`str`
         The name of the group.
+    qualified_name: :class:`str`
+        The full command name, including parent names in the case of slash subcommands or groups.
+        For example, the qualified name for ``/one two three`` would be ``one two three``.
     option: :class:`.Option`
         API representation of this subcommand.
     callback: :ref:`coroutine <coroutine>`
@@ -183,6 +186,9 @@ class SubCommand(InvokableApplicationCommand):
     ----------
     name: :class:`str`
         The name of the subcommand.
+    qualified_name: :class:`str`
+        The full command name, including parent names in the case of slash subcommands or groups.
+        For example, the qualified name for ``/one two three`` would be ``one two three``.
     option: :class:`.Option`
         API representation of this subcommand.
     callback: :ref:`coroutine <coroutine>`
@@ -287,6 +293,9 @@ class InvokableSlashCommand(InvokableApplicationCommand):
     ----------
     name: :class:`str`
         The name of the command.
+    qualified_name: :class:`str`
+        The full command name, including parent names in the case of slash subcommands or groups.
+        For example, the qualified name for ``/one two three`` would be ``one two three``.
     body: :class:`.SlashCommand`
         An object being registered in the API.
     callback: :ref:`coroutine <coroutine>`

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -130,7 +130,7 @@ class ApplicationCommandInteraction(Interaction):
         The wrapped interaction data.
     client: :class:`Client`
         The interaction client.
-    application_command: :class:`InvokableApplicationCommand`
+    application_command: :class:`.InvokableApplicationCommand`
         The command invoked by the interaction.
     command_failed: :class:`bool`
         Whether the command failed to be checked or invoked.

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -130,6 +130,10 @@ class ApplicationCommandInteraction(Interaction):
         The wrapped interaction data.
     client: :class:`Client`
         The interaction client.
+    application_command: :class:`InvokableApplicationCommand`
+        The command invoked by the interaction.
+    command_failed: :class:`bool`
+        Whether the command failed to be checked or invoked.
     """
 
     def __init__(self, *, data: ApplicationCommandInteractionPayload, state: ConnectionState):

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1206,6 +1206,66 @@ class InteractionMessage(Message):
     :meth:`edit` and :meth:`delete` to work.
 
     .. versionadded:: 2.0
+
+    Attributes
+    ----------
+    type: :class:`MessageType`
+        The type of message.
+    author: Union[:class:`Member`, :class:`abc.User`]
+        A :class:`Member` that sent the message. If :attr:`channel` is a
+        private channel, then it is a :class:`User` instead.
+    content: :class:`str`
+        The actual contents of the message.
+    embeds: List[:class:`Embed`]
+        A list of embeds the message has.
+    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
+        The :class:`TextChannel` or :class:`Thread` that the message was sent from.
+        Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
+    reference: Optional[:class:`~disnake.MessageReference`]
+        The message that this message references. This is only applicable to message replies.
+    interaction: Optional[:class:`~disnake.InteractionReference`]
+        The interaction that this message references.
+        This exists only when the message is a response to an interaction without an existing message.
+
+        .. versionadded:: 2.1
+
+    mention_everyone: :class:`bool`
+        Specifies if the message mentions everyone.
+
+        .. note::
+
+            This does not check if the ``@everyone`` or the ``@here`` text is in the message itself.
+            Rather this boolean indicates if either the ``@everyone`` or the ``@here`` text is in the message
+            **and** it did end up mentioning.
+    mentions: List[:class:`abc.User`]
+        A list of :class:`Member` that were mentioned. If the message is in a private message
+        then the list will be of :class:`User` instead.
+
+        .. warning::
+
+            The order of the mentions list is not in any particular order so you should
+            not rely on it. This is a Discord limitation, not one with the library.
+    role_mentions: List[:class:`Role`]
+        A list of :class:`Role` that were mentioned. If the message is in a private message
+        then the list is always empty.
+    id: :class:`int`
+        The message ID.
+    webhook_id: Optional[:class:`int`]
+        The ID of the application that sent this message.
+    attachments: List[:class:`Attachment`]
+        A list of attachments given to a message.
+    pinned: :class:`bool`
+        Specifies if the message is currently pinned.
+    flags: :class:`MessageFlags`
+        Extra features of the message.
+    reactions : List[:class:`Reaction`]
+        Reactions to a message. Reactions can be either custom emoji or standard unicode emoji.
+    stickers: List[:class:`StickerItem`]
+        A list of sticker items given to the message.
+    components: List[:class:`Component`]
+        A list of components in the message.
+    guild: Optional[:class:`Guild`]
+        The guild that the message belongs to, if applicable.
     """
 
     __slots__ = ()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -91,6 +91,14 @@ TeamMember
 .. autoclass:: TeamMember()
     :members:
 
+InstallParams
+~~~~~~~~~~~~~
+
+.. attributetable:: InstallParams
+
+.. autoclass:: InstallParams()
+    :members:
+
 Voice Related
 ---------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4402,6 +4402,7 @@ InteractionMessage
 
 .. autoclass:: InteractionMessage()
     :members:
+    :inherited-members:
 
 ApplicationCommandInteractionData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -326,6 +326,8 @@ Helper Functions
 
 .. autofunction:: disnake.ext.commands.Param
 
+.. autofunction:: disnake.ext.commands.option_enum
+
 .. autofunction:: disnake.ext.commands.inject
 
 .. autofunction:: disnake.ext.commands.register_injection


### PR DESCRIPTION
## Summary

- adds previously missing `application_command` and `command_failed` attributes to `ApplicationCommandInteraction` docs
- adds `qualified_name` to `InvokableApplicationCommand` (+ subclasses) docs
- adds `:inherited-members:` to `InteractionMessage`
- fixes missing `InstallParams` docs and broken `versionadded` directive
- adds `disnake.ext.commands.option_enum`

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
