### PR TITLE
feat!: replace InvalidArgument with TypeError and ValueError

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1348,10 +1348,8 @@ class Messageable:
         parameter should be used with a :class:`list` of :class:`.Embed` objects.
         **Specifying both parameters will lead to an exception**.
 
-
         .. versionchanged:: 2.6
             Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
-
 
         Parameters
         ----------
@@ -1437,7 +1435,7 @@ class Messageable:
             or the ``reference`` object is not a :class:`.Message`,
             :class:`.MessageReference` or :class:`.PartialMessage`.
         ValueError
-            The ``files`` list is not of the appropriate size.
+            The ``files`` or ``embeds`` list is too large.
 
         Returns
         -------
@@ -1465,7 +1463,7 @@ class Messageable:
         embeds_payload = None
         if embeds is not None:
             if len(embeds) > 10:
-                raise TypeError("embeds parameter must be a list of up to 10 elements")
+                raise ValueError("embeds parameter must be a list of up to 10 elements")
             for embed in embeds:
                 if embed._files:
                     files = files or []

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -834,8 +834,10 @@ class GuildChannel(ABC):
         NotFound
             The role or member being edited is not part of the guild.
         TypeError
-            The overwrite parameter invalid or the target type was not
-            :class:`.Role` or :class:`.Member`.
+            ``overwrite`` is invalid,
+            the target type was not :class:`.Role` or :class:`.Member`,
+            both keyword arguments and ``overwrite`` were provided,
+            or invalid permissions were provided as keyword arguments.
         """
         http = self._state.http
 

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -37,7 +37,6 @@ from .enums import (
     try_enum,
     try_enum_to_int,
 )
-from .errors import InvalidArgument
 from .i18n import Localized
 from .permissions import Permissions
 from .utils import MISSING, _get_as_snowflake, _maybe_cast
@@ -98,7 +97,7 @@ def _validate_name(name: str) -> None:
     # see https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-naming
 
     if name != name.lower() or not re.fullmatch(r"[\w-]{1,32}", name):
-        raise InvalidArgument(
+        raise ValueError(
             f"Slash command or option name '{name}' should be lowercase, "
             "between 1 and 32 characters long, and only consist of "
             "these symbols: a-z, 0-9, -, _, and other languages'/scripts' symbols"
@@ -174,6 +173,7 @@ class OptionChoice:
 
 class Option:
     """Represents a slash command option.
+
 
     Parameters
     ----------
@@ -259,14 +259,14 @@ class Option:
         self.max_value: Optional[float] = max_value
 
         if channel_types is not None and not all(isinstance(t, ChannelType) for t in channel_types):
-            raise InvalidArgument("channel_types must be a list of `ChannelType`s")
+            raise TypeError("channel_types must be a list of `ChannelType`s")
 
         self.channel_types: List[ChannelType] = channel_types or []
 
         self.choices: List[OptionChoice] = []
         if choices is not None:
             if autocomplete:
-                raise InvalidArgument("can not specify both choices and autocomplete args")
+                raise TypeError("can not specify both choices and autocomplete args")
 
             if isinstance(choices, Mapping):
                 self.choices = [OptionChoice(name, value) for name, value in choices.items()]

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -174,7 +174,6 @@ class OptionChoice:
 class Option:
     """Represents a slash command option.
 
-
     Parameters
     ----------
     name: Union[:class:`str`, :class:`.Localized`]

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -378,7 +378,7 @@ class Asset(AssetMixin):
 
         Raises
         ------
-        TypeError
+        ValueError
             An invalid size or format was passed.
 
         Returns
@@ -392,15 +392,15 @@ class Asset(AssetMixin):
         if format is not MISSING:
             if self._animated:
                 if format not in VALID_ASSET_FORMATS:
-                    raise TypeError(f"format must be one of {VALID_ASSET_FORMATS}")
+                    raise ValueError(f"format must be one of {VALID_ASSET_FORMATS}")
             else:
                 if format not in VALID_STATIC_FORMATS:
-                    raise TypeError(f"format must be one of {VALID_STATIC_FORMATS}")
+                    raise ValueError(f"format must be one of {VALID_STATIC_FORMATS}")
             url = url.with_path(f"{path}.{format}")
 
         if static_format is not MISSING and not self._animated:
             if static_format not in VALID_STATIC_FORMATS:
-                raise TypeError(f"static_format must be one of {VALID_STATIC_FORMATS}")
+                raise ValueError(f"static_format must be one of {VALID_STATIC_FORMATS}")
             url = url.with_path(f"{path}.{static_format}")
 
         if size is not MISSING:

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -363,7 +363,7 @@ class Asset(AssetMixin):
         """Returns a new asset with the passed components replaced.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
 import yarl
 
 from . import utils
-from .errors import DiscordException, InvalidArgument
+from .errors import DiscordException
 from .file import File
 
 __all__ = ("Asset",)
@@ -137,6 +137,9 @@ class AssetMixin:
 
         .. versionadded:: 2.5
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         -----------
         spoiler: :class:`bool`
@@ -151,14 +154,12 @@ class AssetMixin:
         ------
         DiscordException
             The asset does not have an associated state.
-        InvalidArgument
-            The asset is a unicode emoji.
-        TypeError
-            The asset is a sticker with lottie type.
         HTTPException
             Downloading the asset failed.
         NotFound
             The asset was deleted.
+        TypeError
+            The asset is a unicode emoji or a sticker with lottie type.
 
         Returns
         -------
@@ -361,6 +362,9 @@ class Asset(AssetMixin):
     ) -> Asset:
         """Returns a new asset with the passed components replaced.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         size: :class:`int`
@@ -374,7 +378,7 @@ class Asset(AssetMixin):
 
         Raises
         ------
-        InvalidArgument
+        TypeError
             An invalid size or format was passed.
 
         Returns
@@ -388,20 +392,20 @@ class Asset(AssetMixin):
         if format is not MISSING:
             if self._animated:
                 if format not in VALID_ASSET_FORMATS:
-                    raise InvalidArgument(f"format must be one of {VALID_ASSET_FORMATS}")
+                    raise TypeError(f"format must be one of {VALID_ASSET_FORMATS}")
             else:
                 if format not in VALID_STATIC_FORMATS:
-                    raise InvalidArgument(f"format must be one of {VALID_STATIC_FORMATS}")
+                    raise TypeError(f"format must be one of {VALID_STATIC_FORMATS}")
             url = url.with_path(f"{path}.{format}")
 
         if static_format is not MISSING and not self._animated:
             if static_format not in VALID_STATIC_FORMATS:
-                raise InvalidArgument(f"static_format must be one of {VALID_STATIC_FORMATS}")
+                raise TypeError(f"static_format must be one of {VALID_STATIC_FORMATS}")
             url = url.with_path(f"{path}.{static_format}")
 
         if size is not MISSING:
             if not utils.valid_icon_size(size):
-                raise InvalidArgument("size must be a power of 2 between 16 and 4096")
+                raise ValueError("size must be a power of 2 between 16 and 4096")
             url = url.with_query(size=size)
         else:
             url = url.with_query(url.raw_query_string)
@@ -412,6 +416,9 @@ class Asset(AssetMixin):
     def with_size(self, size: int, /) -> Asset:
         """Returns a new asset with the specified size.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         size: :class:`int`
@@ -419,7 +426,7 @@ class Asset(AssetMixin):
 
         Raises
         ------
-        InvalidArgument
+        ValueError
             The asset had an invalid size.
 
         Returns
@@ -428,13 +435,16 @@ class Asset(AssetMixin):
             The newly updated asset.
         """
         if not utils.valid_icon_size(size):
-            raise InvalidArgument("size must be a power of 2 between 16 and 4096")
+            raise ValueError("size must be a power of 2 between 16 and 4096")
 
         url = str(yarl.URL(self._url).with_query(size=size))
         return Asset(state=self._state, url=url, key=self._key, animated=self._animated)
 
     def with_format(self, format: ValidAssetFormatTypes, /) -> Asset:
         """Returns a new asset with the specified format.
+
+        .. versionchanged:: 2.6
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -443,7 +453,7 @@ class Asset(AssetMixin):
 
         Raises
         ------
-        InvalidArgument
+        ValueError
             The asset had an invalid format.
 
         Returns
@@ -453,10 +463,10 @@ class Asset(AssetMixin):
         """
         if self._animated:
             if format not in VALID_ASSET_FORMATS:
-                raise InvalidArgument(f"format must be one of {VALID_ASSET_FORMATS}")
+                raise ValueError(f"format must be one of {VALID_ASSET_FORMATS}")
         else:
             if format not in VALID_STATIC_FORMATS:
-                raise InvalidArgument(f"format must be one of {VALID_STATIC_FORMATS}")
+                raise ValueError(f"format must be one of {VALID_STATIC_FORMATS}")
 
         url = yarl.URL(self._url)
         path, _ = os.path.splitext(url.path)
@@ -469,6 +479,9 @@ class Asset(AssetMixin):
         This only changes the format if the underlying asset is
         not animated. Otherwise, the asset is not changed.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         format: :class:`str`
@@ -476,7 +489,7 @@ class Asset(AssetMixin):
 
         Raises
         ------
-        InvalidArgument
+        ValueError
             The asset had an invalid format.
 
         Returns

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2646,10 +2646,10 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
             Specified both ``file`` and ``files``,
             or you specified both ``embed`` and ``embeds``,
             or you specified both ``view`` and ``components``.
+            or you have passed an object that is not :class:`File` to ``file`` or ``files``.
         ValueError
             Specified more than 10 embeds,
-            or more than 10 files,
-            or you have passed an object that is not :class:`File`.
+            or more than 10 files.
 
         Returns
         -------

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -54,7 +54,7 @@ from . import utils
 from .asset import Asset
 from .context_managers import Typing
 from .enums import ChannelType, StagePrivacyLevel, VideoQualityMode, try_enum, try_enum_to_int
-from .errors import ClientException, InvalidArgument
+from .errors import ClientException
 from .file import File
 from .flags import MessageFlags
 from .iterators import ArchivedThreadIterator
@@ -340,6 +340,9 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         .. versionchanged:: 2.0
             Edits are no longer in-place, the newly edited channel is returned instead.
 
+        .. versionchanged:: 2.6
+                Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -374,9 +377,10 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
         Raises
         ------
-        InvalidArgument
-            If position is less than 0 or greater than the number of channels, or if
-            the permission overwrite information is not in proper form.
+        TypeError
+            The permission overwrite information is not in proper form.
+        ValueError
+            If position is less than 0 or greater than the number of channels
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException
@@ -654,6 +658,9 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
         .. versionadded:: 1.3
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``
+
         Parameters
         ----------
         destination: :class:`TextChannel`
@@ -669,6 +676,8 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             Following the channel failed.
         Forbidden
             You do not have the permissions to create a webhook.
+        TypeError
+            The current or provided channel is not of the correct type.
 
         Returns
         -------
@@ -676,10 +685,10 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             The newly created webhook.
         """
         if not self.is_news():
-            raise ClientException("The channel must be a news channel.")
+            raise TypeError("This channel must be a news channel.")
 
         if not isinstance(destination, TextChannel):
-            raise InvalidArgument(f"Expected TextChannel received {destination.__class__.__name__}")
+            raise TypeError(f"Expected TextChannel received {destination.__class__.__name__}")
 
         from .webhook import Webhook
 
@@ -1225,6 +1234,9 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
         .. versionchanged:: 2.0
             Edits are no longer in-place, the newly edited channel is returned instead.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``
+
         Parameters
         ----------
         name: :class:`str`
@@ -1270,7 +1282,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
 
         Raises
         ------
-        InvalidArgument
+        TypeError
             If the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
@@ -1694,6 +1706,9 @@ class StageChannel(VocalGuildChannel):
 
         .. versionadded:: 2.0
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``
+
         Parameters
         ----------
         topic: :class:`str`
@@ -1711,7 +1726,7 @@ class StageChannel(VocalGuildChannel):
 
         Raises
         ------
-        InvalidArgument
+        TypeError
             If the ``privacy_level`` parameter is not the proper type.
         Forbidden
             You do not have permissions to create a stage instance.
@@ -1731,7 +1746,7 @@ class StageChannel(VocalGuildChannel):
 
         if privacy_level is not MISSING:
             if not isinstance(privacy_level, StagePrivacyLevel):
-                raise InvalidArgument("privacy_level field must be of type PrivacyLevel")
+                raise TypeError("privacy_level field must be of type PrivacyLevel")
             if privacy_level is StagePrivacyLevel.public:
                 utils.warn_deprecated(
                     "Setting privacy_level to public is deprecated and will be removed in a future version.",
@@ -1799,6 +1814,9 @@ class StageChannel(VocalGuildChannel):
         .. versionchanged:: 2.0
             Edits are no longer in-place, the newly edited channel is returned instead.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``
+
         Parameters
         ----------
         name: :class:`str`
@@ -1827,7 +1845,7 @@ class StageChannel(VocalGuildChannel):
 
         Raises
         ------
-        InvalidArgument
+        TypeError
             If the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
@@ -1958,6 +1976,9 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         .. versionchanged:: 2.0
             Edits are no longer in-place, the newly edited channel is returned instead.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``
+
         Parameters
         ----------
         name: :class:`str`
@@ -1974,12 +1995,12 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
 
         Raises
         ------
-        InvalidArgument
-            If position is less than 0 or greater than the number of categories.
         Forbidden
             You do not have permissions to edit the category.
         HTTPException
             Editing the category failed.
+        ValueError
+            If position is less than 0 or greater than the number of categories.
 
         Returns
         -------
@@ -2421,13 +2442,14 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
 
         Raises
         ------
-        InvalidArgument
-            If position is less than 0 or greater than the number of channels, or if
-            the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException
             Editing the channel failed.
+        TypeError
+            If the permission overwrite information is not in proper form.
+        ValueError
+            If the position is less than 0 or greater than the number of channels.
 
         Returns
         -------
@@ -2624,7 +2646,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
             Specified both ``file`` and ``files``,
             or you specified both ``embed`` and ``embeds``,
             or you specified both ``view`` and ``components``.
-        InvalidArgument
+        ValueError
             Specified more than 10 embeds,
             or more than 10 files,
             or you have passed an object that is not :class:`File`.
@@ -2657,9 +2679,9 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
             )
 
         if params.files and len(params.files) > 10:
-            raise InvalidArgument("files parameter must be a list of up to 10 elements")
+            raise ValueError("files parameter must be a list of up to 10 elements")
         elif params.files and not all(isinstance(file, File) for file in params.files):
-            raise InvalidArgument("files parameter must be a list of File")
+            raise TypeError("files parameter must be a list of File")
 
         if suppress_embeds:
             flags = MessageFlags.suppress_embeds.flag

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -377,14 +377,14 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
         Raises
         ------
-        TypeError
-            The permission overwrite information is not in proper form.
-        ValueError
-            The position is less than 0 or greater than the number of channels.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException
             Editing the channel failed.
+        TypeError
+            The permission overwrite information is not in proper form.
+        ValueError
+            The position is less than 0 or greater than the number of channels.
 
         Returns
         -------
@@ -1235,7 +1235,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
             Edits are no longer in-place, the newly edited channel is returned instead.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1282,12 +1282,14 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
 
         Raises
         ------
-        TypeError
-            If the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException
             Editing the channel failed.
+        TypeError
+            The permission overwrite information is not in proper form.
+        ValueError
+            The position is less than 0 or greater than the number of channels.
 
         Returns
         -------
@@ -1726,12 +1728,12 @@ class StageChannel(VocalGuildChannel):
 
         Raises
         ------
-        TypeError
-            If the ``privacy_level`` parameter is not the proper type.
         Forbidden
             You do not have permissions to create a stage instance.
         HTTPException
             Creating a stage instance failed.
+        TypeError
+            If the ``privacy_level`` parameter is not the proper type.
 
         Returns
         -------
@@ -1815,7 +1817,7 @@ class StageChannel(VocalGuildChannel):
             Edits are no longer in-place, the newly edited channel is returned instead.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1845,12 +1847,14 @@ class StageChannel(VocalGuildChannel):
 
         Raises
         ------
-        TypeError
-            If the permission overwrite information is not in proper form.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException
             Editing the channel failed.
+        TypeError
+            The permission overwrite information is not in proper form.
+        ValueError
+            The position is less than 0 or greater than the number of channels.
 
         Returns
         -------
@@ -1977,7 +1981,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
             Edits are no longer in-place, the newly edited channel is returned instead.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1999,8 +2003,10 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
             You do not have permissions to edit the category.
         HTTPException
             Editing the category failed.
+        TypeError
+            The permission overwrite information is not in proper form.
         ValueError
-            If position is less than 0 or greater than the number of categories.
+            The position is less than 0 or greater than the number of channels.
 
         Returns
         -------
@@ -2412,6 +2418,10 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         You must have :attr:`~Permissions.manage_channels` permission to
         do this.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
+
+
         Parameters
         ----------
         name: :class:`str`
@@ -2447,9 +2457,9 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         HTTPException
             Editing the channel failed.
         TypeError
-            If the permission overwrite information is not in proper form.
+            The permission overwrite information is not in proper form.
         ValueError
-            If the position is less than 0 or greater than the number of channels.
+            The position is less than 0 or greater than the number of channels.
 
         Returns
         -------

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -659,7 +659,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         .. versionadded:: 1.3
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1235,7 +1235,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
             Edits are no longer in-place, the newly edited channel is returned instead.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1707,7 +1707,7 @@ class StageChannel(VocalGuildChannel):
         .. versionadded:: 2.0
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1815,7 +1815,7 @@ class StageChannel(VocalGuildChannel):
             Edits are no longer in-place, the newly edited channel is returned instead.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1977,7 +1977,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
             Edits are no longer in-place, the newly edited channel is returned instead.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -384,7 +384,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         TypeError
             The permission overwrite information is not in proper form.
         ValueError
-            The position is less than 0 or greater than the number of channels.
+            The position is less than 0.
 
         Returns
         -------
@@ -1289,7 +1289,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
         TypeError
             The permission overwrite information is not in proper form.
         ValueError
-            The position is less than 0 or greater than the number of channels.
+            The position is less than 0.
 
         Returns
         -------
@@ -1854,7 +1854,7 @@ class StageChannel(VocalGuildChannel):
         TypeError
             The permission overwrite information is not in proper form.
         ValueError
-            The position is less than 0 or greater than the number of channels.
+            The position is less than 0.
 
         Returns
         -------
@@ -2006,7 +2006,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         TypeError
             The permission overwrite information is not in proper form.
         ValueError
-            The position is less than 0 or greater than the number of channels.
+            The position is less than 0.
 
         Returns
         -------
@@ -2459,7 +2459,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         TypeError
             The permission overwrite information is not in proper form.
         ValueError
-            The position is less than 0 or greater than the number of channels.
+            The position is less than 0.
 
         Returns
         -------

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -341,7 +341,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             Edits are no longer in-place, the newly edited channel is returned instead.
 
         .. versionchanged:: 2.6
-                Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -380,7 +380,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         TypeError
             The permission overwrite information is not in proper form.
         ValueError
-            If position is less than 0 or greater than the number of channels
+            The position is less than 0 or greater than the number of channels.
         Forbidden
             You do not have permissions to edit the channel.
         HTTPException

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2457,7 +2457,6 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         .. versionchanged:: 2.6
             Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
 
-
         Parameters
         ----------
         name: :class:`str`

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2637,6 +2637,9 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
 
         You must have the :attr:`~Permissions.create_forum_threads` permission to do this.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1486,6 +1486,9 @@ class Client:
 
         Changes the client's presence.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Example
         ---------
 
@@ -1507,7 +1510,7 @@ class Client:
 
         Raises
         ------
-        InvalidArgument
+        TypeError
             If the ``activity`` parameter is not the proper type.
         """
         if status is None:
@@ -1706,6 +1709,9 @@ class Client:
         .. versionchanged:: 2.5
             Removed the ``region`` parameter.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -1728,7 +1734,7 @@ class Client:
             The ``icon`` asset couldn't be found.
         HTTPException
             Guild creation failed.
-        InvalidArgument
+        TypeError
             Invalid icon image format given. Must be PNG or JPG.
         TypeError
             The ``icon`` asset is a lottie sticker (see :func:`Sticker.read <disnake.Sticker.read>`).

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1710,7 +1710,7 @@ class Client:
             Removed the ``region`` parameter.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1734,7 +1734,7 @@ class Client:
             The ``icon`` asset couldn't be found.
         HTTPException
             Guild creation failed.
-        TypeError
+        ValueError
             Invalid icon image format given. Must be PNG or JPG.
         TypeError
             The ``icon`` asset is a lottie sticker (see :func:`Sticker.read <disnake.Sticker.read>`).

--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -49,7 +49,7 @@ __all__ = (
     "NotFound",
     "DiscordServerError",
     "InvalidData",
-    "InvalidArgument",
+    "WebhookMissingToken",
     "LoginFailure",
     "ConnectionClosed",
     "PrivilegedIntentsRequired",
@@ -194,13 +194,10 @@ class InvalidData(ClientException):
     pass
 
 
-class InvalidArgument(ClientException):
-    """Exception that's raised when an argument to a function
-    is invalid some way (e.g. wrong value or wrong type).
+class WebhookMissingToken(DiscordException):
+    """Exception that's raised when a :class:`Webhook` or :class:`SyncWebhook` is missing a token to make requests with.
 
-    This could be considered the analogous of ``ValueError`` and
-    ``TypeError`` except inherited from :exc:`ClientException` and thus
-    :exc:`DiscordException`.
+    .. versionadded :: 2.6
     """
 
     pass

--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -49,7 +49,7 @@ __all__ = (
     "NotFound",
     "DiscordServerError",
     "InvalidData",
-    "WebhookMissingToken",
+    "WebhookTokenMissing",
     "LoginFailure",
     "ConnectionClosed",
     "PrivilegedIntentsRequired",
@@ -194,7 +194,7 @@ class InvalidData(ClientException):
     pass
 
 
-class WebhookMissingToken(DiscordException):
+class WebhookTokenMissing(DiscordException):
     """Exception that's raised when a :class:`Webhook` or :class:`SyncWebhook` is missing a token to make requests with.
 
     .. versionadded :: 2.6

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -57,7 +57,7 @@ import aiohttp
 from . import utils
 from .activity import BaseActivity
 from .enums import SpeakingState
-from .errors import ConnectionClosed, InvalidArgument
+from .errors import ConnectionClosed
 
 if TYPE_CHECKING:
     from .client import Client
@@ -754,7 +754,7 @@ class DiscordWebSocket:
     ) -> None:
         if activity is not None:
             if not isinstance(activity, BaseActivity):
-                raise InvalidArgument("activity must derive from BaseActivity.")
+                raise TypeError("activity must derive from BaseActivity.")
             activity_data = (activity.to_dict(),)
         else:
             activity_data = ()

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1531,6 +1531,9 @@ class Guild(Hashable):
 
         .. versionadded:: 2.5
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1841,13 +1841,13 @@ class Guild(Hashable):
         HTTPException
             Editing the guild failed.
         TypeError
-            The image format passed in to ``icon`` is invalid. It must be
-            PNG or JPG. This is also raised if you are not the owner of the
+            The image format passed in to ``icon`` is invalid.
+            This is also raised if you are not the owner of the
             guild and request an ownership transfer, or at least one of the assets
             (``icon``, ``banner``, ``splash`` or ``discovery_splash``)
             is a lottie sticker (see :func:`Sticker.read`).
         ValueError
-            ``Community`` was set without setting both ``rules_channel`` and ``public_updates_channel`` parameters.
+            ``community`` was set without setting both ``rules_channel`` and ``public_updates_channel`` parameters.
 
         Returns
         -------

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1842,12 +1842,12 @@ class Guild(Hashable):
             Editing the guild failed.
         TypeError
             The image format passed in to ``icon`` is invalid.
-            This is also raised if you are not the owner of the
-            guild and request an ownership transfer, or at least one of the assets
+            This is also raised if at least one of the assets
             (``icon``, ``banner``, ``splash`` or ``discovery_splash``)
             is a lottie sticker (see :func:`Sticker.read`).
         ValueError
-            ``community`` was set without setting both ``rules_channel`` and ``public_updates_channel`` parameters.
+            ``community`` was set without setting both ``rules_channel`` and ``public_updates_channel`` parameters,
+            or if you are not the owner of the guild and request an ownership transfer.
 
         Returns
         -------
@@ -3040,6 +3040,8 @@ class Guild(Hashable):
             An error occurred creating an emoji.
         TypeError
             The ``image`` asset is a lottie sticker (see :func:`Sticker.read`).
+        ValueError
+            Wrong image format passed for ``image``.
 
         Returns
         -------

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3245,7 +3245,6 @@ class Guild(Hashable):
             Creating the role failed.
         TypeError
             An invalid keyword argument was given.
-        TypeError
             The ``icon`` asset is a lottie sticker (see :func:`Sticker.read`).
 
         Returns

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1841,13 +1841,14 @@ class Guild(Hashable):
         HTTPException
             Editing the guild failed.
         TypeError
-            The image format passed in to ``icon`` is invalid.
-            This is also raised if at least one of the assets
-            (``icon``, ``banner``, ``splash`` or ``discovery_splash``)
-            is a lottie sticker (see :func:`Sticker.read`).
+            At least one of the assets (``icon``, ``banner``, ``splash`` or ``discovery_splash``)
+            is a lottie sticker (see :func:`Sticker.read`),
+            or one of the parameters ``default_notifications``, ``verification_level``,
+            ``explicit_content_filter``, or ``system_channel_flags`` was of the incorrect type.
         ValueError
             ``community`` was set without setting both ``rules_channel`` and ``public_updates_channel`` parameters,
-            or if you are not the owner of the guild and request an ownership transfer.
+            or if you are not the owner of the guild and request an ownership transfer,
+            or the image format passed in to ``icon`` is invalid.
 
         Returns
         -------
@@ -3244,8 +3245,8 @@ class Guild(Hashable):
         HTTPException
             Creating the role failed.
         TypeError
-            An invalid keyword argument was given.
-            The ``icon`` asset is a lottie sticker (see :func:`Sticker.read`).
+            An invalid keyword argument was given,
+            or the ``icon`` asset is a lottie sticker (see :func:`Sticker.read`).
 
         Returns
         -------

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -68,7 +68,7 @@ from .enums import (
     try_enum,
     try_enum_to_int,
 )
-from .errors import ClientException, HTTPException, InvalidArgument, InvalidData
+from .errors import ClientException, HTTPException, InvalidData
 from .file import File
 from .flags import SystemChannelFlags
 from .guild_scheduled_event import GuildScheduledEvent, GuildScheduledEventMetadata
@@ -1146,14 +1146,12 @@ class Guild(Hashable):
         if overwrites is MISSING:
             overwrites = {}
         elif not isinstance(overwrites, dict):
-            raise InvalidArgument("overwrites parameter expects a dict.")
+            raise TypeError("overwrites parameter expects a dict.")
 
         perms = []
         for target, perm in overwrites.items():
             if not isinstance(perm, PermissionOverwrite):
-                raise InvalidArgument(
-                    f"Expected PermissionOverwrite received {perm.__class__.__name__}"
-                )
+                raise TypeError(f"Expected PermissionOverwrite received {perm.__class__.__name__}")
 
             allow, deny = perm.pair()
             payload = {"allow": allow.value, "deny": deny.value, "id": target.id}
@@ -1206,6 +1204,9 @@ class Guild(Hashable):
             Creating a channel of a specified position will not update the position of
             other channels to follow suit. A follow-up call to :meth:`~TextChannel.edit`
             will be required to update the position of the channel in the channel list.
+
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
 
         Examples
         --------
@@ -1271,7 +1272,7 @@ class Guild(Hashable):
             You do not have the proper permissions to create this channel.
         HTTPException
             Creating the channel failed.
-        InvalidArgument
+        TypeError
             The permission overwrite information is not in proper form.
 
         Returns
@@ -1334,6 +1335,9 @@ class Guild(Hashable):
 
         This is similar to :meth:`create_text_channel` except makes a :class:`VoiceChannel` instead.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -1378,7 +1382,7 @@ class Guild(Hashable):
             You do not have the proper permissions to create this channel.
         HTTPException
             Creating the channel failed.
-        InvalidArgument
+        TypeError
             The permission overwrite information is not in proper form.
 
         Returns
@@ -1436,6 +1440,9 @@ class Guild(Hashable):
 
         .. versionadded:: 1.7
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -1472,7 +1479,7 @@ class Guild(Hashable):
             You do not have the proper permissions to create this channel.
         HTTPException
             Creating the channel failed.
-        InvalidArgument
+        TypeError
             The permission overwrite information is not in proper form.
 
         Returns
@@ -1559,7 +1566,7 @@ class Guild(Hashable):
             You do not have the proper permissions to create this channel.
         HTTPException
             Creating the channel failed.
-        InvalidArgument
+        TypeError
             The permission overwrite information is not in proper form.
 
         Returns
@@ -1616,6 +1623,9 @@ class Guild(Hashable):
             The ``category`` parameter is not supported in this function since categories
             cannot have categories.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -1635,7 +1645,7 @@ class Guild(Hashable):
             You do not have the proper permissions to create this channel.
         HTTPException
             Creating the channel failed.
-        InvalidArgument
+        TypeError
             The permission overwrite information is not in proper form.
 
         Returns
@@ -1736,6 +1746,9 @@ class Guild(Hashable):
             Removed the ``region`` parameter.
             Use :func:`VoiceChannel.edit` or :func:`StageChannel.edit` with ``rtc_region`` instead.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -1827,12 +1840,14 @@ class Guild(Hashable):
             You do not have permissions to edit the guild.
         HTTPException
             Editing the guild failed.
-        InvalidArgument
+        TypeError
             The image format passed in to ``icon`` is invalid. It must be
             PNG or JPG. This is also raised if you are not the owner of the
-            guild and request an ownership transfer.
-        TypeError
-            At least one of the assets (``icon``, ``banner``, ``splash`` or ``discovery_splash``) is a lottie sticker (see :func:`Sticker.read`).
+            guild and request an ownership transfer, or at least one of the assets
+            (``icon``, ``banner``, ``splash`` or ``discovery_splash``)
+            is a lottie sticker (see :func:`Sticker.read`).
+        ValueError
+            ``Community`` was set without setting both ``rules_channel`` and ``public_updates_channel`` parameters.
 
         Returns
         -------
@@ -1872,9 +1887,7 @@ class Guild(Hashable):
 
         if default_notifications is not MISSING:
             if not isinstance(default_notifications, NotificationLevel):
-                raise InvalidArgument(
-                    "default_notifications field must be of type NotificationLevel"
-                )
+                raise TypeError("default_notifications field must be of type NotificationLevel")
             fields["default_message_notifications"] = default_notifications.value
 
         if afk_channel is not MISSING:
@@ -1903,27 +1916,25 @@ class Guild(Hashable):
 
         if owner is not MISSING:
             if self.owner_id != self._state.self_id:
-                raise InvalidArgument("To transfer ownership you must be the owner of the guild.")
+                raise ValueError("To transfer ownership you must be the owner of the guild.")
 
             fields["owner_id"] = owner.id
 
         if verification_level is not MISSING:
             if not isinstance(verification_level, VerificationLevel):
-                raise InvalidArgument("verification_level field must be of type VerificationLevel")
+                raise TypeError("verification_level field must be of type VerificationLevel")
 
             fields["verification_level"] = verification_level.value
 
         if explicit_content_filter is not MISSING:
             if not isinstance(explicit_content_filter, ContentFilter):
-                raise InvalidArgument("explicit_content_filter field must be of type ContentFilter")
+                raise TypeError("explicit_content_filter field must be of type ContentFilter")
 
             fields["explicit_content_filter"] = explicit_content_filter.value
 
         if system_channel_flags is not MISSING:
             if not isinstance(system_channel_flags, SystemChannelFlags):
-                raise InvalidArgument(
-                    "system_channel_flags field must be of type SystemChannelFlags"
-                )
+                raise TypeError("system_channel_flags field must be of type SystemChannelFlags")
 
             fields["system_channel_flags"] = system_channel_flags.value
 
@@ -1933,7 +1944,7 @@ class Guild(Hashable):
                 if "rules_channel_id" in fields and "public_updates_channel_id" in fields:
                     features.append("COMMUNITY")
                 else:
-                    raise InvalidArgument(
+                    raise ValueError(
                         "community field requires both rules_channel and public_updates_channel fields to be provided"
                     )
 
@@ -2516,6 +2527,9 @@ class Guild(Hashable):
         .. versionchanged:: 1.4
             The ``roles`` keyword-only parameter was added.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         days: :class:`int`
@@ -2537,7 +2551,7 @@ class Guild(Hashable):
             You do not have permissions to prune members.
         HTTPException
             An error occurred while pruning members.
-        InvalidArgument
+        TypeError
             An integer was not passed for ``days``.
 
         Returns
@@ -2547,7 +2561,7 @@ class Guild(Hashable):
             then this returns ``None``.
         """
         if not isinstance(days, int):
-            raise InvalidArgument(
+            raise TypeError(
                 f"Expected int for ``days``, received {days.__class__.__name__} instead."
             )
 
@@ -2616,6 +2630,9 @@ class Guild(Hashable):
         pruning members, it returns how many members it would prune
         from the guild had it been called.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         days: :class:`int`
@@ -2632,7 +2649,7 @@ class Guild(Hashable):
             You do not have permissions to prune members.
         HTTPException
             An error occurred while fetching the prune members estimate.
-        InvalidArgument
+        TypeError
             An integer was not passed for ``days``.
 
         Returns
@@ -2641,7 +2658,7 @@ class Guild(Hashable):
             The number of members estimated to be pruned.
         """
         if not isinstance(days, int):
-            raise InvalidArgument(
+            raise TypeError(
                 f"Expected int for ``days``, received {days.__class__.__name__} instead."
             )
 
@@ -3187,6 +3204,9 @@ class Guild(Hashable):
         .. versionchanged:: 1.6
             Can now pass ``int`` to ``colour`` keyword-only parameter.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -3221,7 +3241,7 @@ class Guild(Hashable):
             You do not have permissions to create the role.
         HTTPException
             Creating the role failed.
-        InvalidArgument
+        TypeError
             An invalid keyword argument was given.
         TypeError
             The ``icon`` asset is a lottie sticker (see :func:`Sticker.read`).
@@ -3276,6 +3296,9 @@ class Guild(Hashable):
 
         .. versionadded:: 1.4
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Example:
 
         .. code-block:: python3
@@ -3302,7 +3325,7 @@ class Guild(Hashable):
             You do not have permissions to move the roles.
         HTTPException
             Moving the roles failed.
-        InvalidArgument
+        TypeError
             An invalid keyword argument was given.
 
         Returns
@@ -3311,7 +3334,7 @@ class Guild(Hashable):
             A list of all the roles in the guild.
         """
         if not isinstance(positions, dict):
-            raise InvalidArgument("positions parameter expects a dict.")
+            raise TypeError("positions parameter expects a dict.")
 
         role_positions: List[Any] = []
         for role, position in positions.items():

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1536,7 +1536,7 @@ class HTTPClient:
 
         try:
             mime_type = utils._get_mime_type_for_image(initial_bytes)
-        except TypeError:
+        except ValueError:
             if initial_bytes.startswith(b"{"):
                 mime_type = "application/json"
             else:

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -57,7 +57,6 @@ from .errors import (
     Forbidden,
     GatewayNotFound,
     HTTPException,
-    InvalidArgument,
     LoginFailure,
     NotFound,
 )
@@ -1537,7 +1536,7 @@ class HTTPClient:
 
         try:
             mime_type = utils._get_mime_type_for_image(initial_bytes)
-        except InvalidArgument:
+        except TypeError:
             if initial_bytes.startswith(b"{"):
                 mime_type = "application/json"
             else:

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -29,7 +29,6 @@ import datetime
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type
 
 from .enums import ExpireBehaviour, try_enum
-from .errors import InvalidArgument
 from .user import User
 from .utils import MISSING, _get_as_snowflake, deprecated, parse_time, warn_deprecated
 
@@ -242,6 +241,9 @@ class StreamIntegration(Integration):
         You must have :attr:`~Permissions.manage_guild` permission to
         use this.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         expire_behaviour: :class:`ExpireBehaviour`
@@ -257,13 +259,13 @@ class StreamIntegration(Integration):
             You do not have permission to edit the integration.
         HTTPException
             Editing the guild failed.
-        InvalidArgument
+        TypeError
             ``expire_behaviour`` did not receive a :class:`ExpireBehaviour`.
         """
         payload: Dict[str, Any] = {}
         if expire_behaviour is not MISSING:
             if not isinstance(expire_behaviour, ExpireBehaviour):
-                raise InvalidArgument("expire_behaviour field must be of type ExpireBehaviour")
+                raise TypeError("expire_behaviour field must be of type ExpireBehaviour")
 
             payload["expire_behavior"] = expire_behaviour.value
 

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1586,7 +1586,7 @@ class Message(Hashable):
             Tried to suppress embeds on a message without permissions or
             edited a message's content or embed that isn't yours.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
+            You specified both ``embed`` and ``embeds``, or ``file`` and ``files``, or ``view`` and ``components``.
 
         Returns
         -------
@@ -2249,7 +2249,7 @@ class PartialMessage(Hashable):
             Tried to suppress embeds on a message without permissions or
             edited a message's content or embed that isn't yours.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
+            You specified both ``embed`` and ``embeds``, or ``file`` and ``files``, or ``view`` and ``components``.
 
         Returns
         -------

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1898,7 +1898,7 @@ class Message(Hashable):
             Added ``fail_if_not_exists`` keyword argument. Defaults to ``True``.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -51,7 +51,7 @@ from .components import _component_factory
 from .embeds import Embed
 from .emoji import Emoji
 from .enums import ChannelType, InteractionType, MessageType, try_enum, try_enum_to_int
-from .errors import HTTPException, InvalidArgument
+from .errors import HTTPException
 from .file import File
 from .flags import MessageFlags
 from .guild import Guild
@@ -119,7 +119,7 @@ def convert_emoji_reaction(emoji):
         # No existing emojis have <> in them, so this should be okay.
         return emoji.strip("<>")
 
-    raise InvalidArgument(
+    raise TypeError(
         f"emoji argument must be str, Emoji, or Reaction not {emoji.__class__.__name__}."
     )
 
@@ -143,15 +143,15 @@ async def _edit_handler(
     components: Optional[Components] = MISSING,
 ) -> Message:
     if embed is not MISSING and embeds is not MISSING:
-        raise InvalidArgument("Cannot mix embed and embeds keyword arguments.")
+        raise TypeError("Cannot mix embed and embeds keyword arguments.")
     if file is not MISSING and files is not MISSING:
-        raise InvalidArgument("Cannot mix file and files keyword arguments.")
+        raise TypeError("Cannot mix file and files keyword arguments.")
     if view is not MISSING and components is not MISSING:
-        raise InvalidArgument("Cannot mix view and components keyword arguments.")
+        raise TypeError("Cannot mix view and components keyword arguments.")
     if suppress is not MISSING:
         suppress_deprecated_msg = "'suppress' is deprecated in favour of 'suppress_embeds'."
         if suppress_embeds is not MISSING:
-            raise InvalidArgument(
+            raise TypeError(
                 "Cannot mix suppress and suppress_embeds keyword arguments.\n"
                 + suppress_deprecated_msg
             )
@@ -1503,6 +1503,12 @@ class Message(Hashable):
             those images will be removed if the message's attachments are edited in any way
             (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
 
+        .. versionchanged:: 1.3
+            The ``suppress`` keyword-only parameter was added.
+
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         content: Optional[:class:`str`]
@@ -1579,7 +1585,7 @@ class Message(Hashable):
         Forbidden
             Tried to suppress embeds on a message without permissions or
             edited a message's content or embed that isn't yours.
-        ~disnake.InvalidArgument
+        TypeError
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
 
         Returns
@@ -1691,6 +1697,9 @@ class Message(Hashable):
         to use this. If nobody else has reacted to the message using this
         emoji, the :attr:`~Permissions.add_reactions` permission is required.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
@@ -1704,7 +1713,7 @@ class Message(Hashable):
             You do not have the proper permissions to react to the message.
         NotFound
             The emoji you specified was not found.
-        InvalidArgument
+        TypeError
             The emoji parameter is invalid.
         """
         emoji = convert_emoji_reaction(emoji)
@@ -1725,6 +1734,9 @@ class Message(Hashable):
         The ``member`` parameter must represent a member and meet
         the :class:`abc.Snowflake` abc.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
@@ -1740,7 +1752,7 @@ class Message(Hashable):
             You do not have the proper permissions to remove the reaction.
         NotFound
             The member or emoji you specified was not found.
-        InvalidArgument
+        TypeError
             The emoji parameter is invalid.
         """
         emoji = convert_emoji_reaction(emoji)
@@ -1761,6 +1773,9 @@ class Message(Hashable):
 
         .. versionadded:: 1.3
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         emoji: Union[:class:`Emoji`, :class:`Reaction`, :class:`PartialEmoji`, :class:`str`]
@@ -1774,7 +1789,7 @@ class Message(Hashable):
             You do not have the proper permissions to clear the reaction.
         NotFound
             The emoji you specified was not found.
-        InvalidArgument
+        TypeError
             The emoji parameter is invalid.
         """
         emoji = convert_emoji_reaction(emoji)
@@ -1815,6 +1830,9 @@ class Message(Hashable):
 
         .. versionadded:: 2.0
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -1841,7 +1859,7 @@ class Message(Hashable):
             You do not have permissions to create a thread.
         HTTPException
             Creating the thread failed.
-        InvalidArgument
+        TypeError
             This message does not have guild info attached.
 
         Returns
@@ -1850,7 +1868,7 @@ class Message(Hashable):
             The created thread.
         """
         if self.guild is None:
-            raise InvalidArgument("This message does not have guild info attached.")
+            raise TypeError("This message does not have guild info attached.")
 
         if auto_archive_duration is not None:
             auto_archive_duration = cast(
@@ -1883,6 +1901,9 @@ class Message(Hashable):
         .. versionchanged:: 2.3
             Added ``fail_if_not_exists`` keyword argument. Defaults to ``True``.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         fail_if_not_exists: :class:`bool`
@@ -1893,11 +1914,11 @@ class Message(Hashable):
 
         Raises
         ------
-        ~disnake.HTTPException
+        HTTPException
             Sending the message failed.
-        ~disnake.Forbidden
+        Forbidden
             You do not have the proper permissions to send the message.
-        ~disnake.InvalidArgument
+        TypeError
             The ``files`` list is not of the appropriate size or
             you specified both ``file`` and ``files``.
 
@@ -2139,6 +2160,9 @@ class PartialMessage(Hashable):
             The ``suppress`` keyword-only parameter was deprecated
             in favor of ``suppress_embeds``.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         .. note::
             If the original message has embeds with images that were created from local files
             (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
@@ -2224,7 +2248,7 @@ class PartialMessage(Hashable):
         Forbidden
             Tried to suppress embeds on a message without permissions or
             edited a message's content or embed that isn't yours.
-        ~disnake.InvalidArgument
+        TypeError
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
 
         Returns

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1915,8 +1915,9 @@ class Message(Hashable):
         Forbidden
             You do not have the proper permissions to send the message.
         TypeError
-            The ``files`` list is not of the appropriate size or
-            you specified both ``file`` and ``files``.
+            You specified both ``embed`` and ``embeds``, or ``file`` and ``files``, or ``view`` and ``components``.
+        ValueError
+            The ``files`` or ``embeds`` list is too large.
 
         Returns
         -------

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1490,13 +1490,6 @@ class Message(Hashable):
 
         The content must be able to be transformed into a string via ``str(content)``.
 
-        .. versionchanged:: 1.3
-            The ``suppress`` keyword-only parameter was added.
-
-        .. versionchanged:: 2.5
-            The ``suppress`` keyword-only parameter was deprecated
-            in favor of ``suppress_embeds``.
-
         .. note::
             If the original message has embeds with images that were created from local files
             (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
@@ -1505,6 +1498,10 @@ class Message(Hashable):
 
         .. versionchanged:: 1.3
             The ``suppress`` keyword-only parameter was added.
+
+        .. versionchanged:: 2.5
+            The ``suppress`` keyword-only parameter was deprecated
+            in favor of ``suppress_embeds``.
 
         .. versionchanged:: 2.6
             Raises :exc:`TypeError` instead of ``InvalidArgument``.

--- a/disnake/opus.py
+++ b/disnake/opus.py
@@ -47,7 +47,7 @@ from typing import (
     overload,
 )
 
-from .errors import DiscordException, InvalidArgument
+from .errors import DiscordException
 from .utils import MISSING
 
 if TYPE_CHECKING:
@@ -496,7 +496,7 @@ class Decoder(_OpusStruct):
 
     def decode(self, data: Optional[bytes], *, fec: bool = False) -> bytes:
         if data is None and fec:
-            raise InvalidArgument("Invalid arguments: FEC cannot be used with null data")
+            raise TypeError("Invalid arguments: FEC cannot be used with null data")
 
         if data is None:
             frame_size = self._get_last_packet_duration() or self.SAMPLES_PER_FRAME

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -30,7 +30,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar, Union
 
 from . import utils
 from .asset import Asset, AssetMixin
-from .errors import InvalidArgument
 
 __all__ = ("PartialEmoji",)
 
@@ -249,9 +248,12 @@ class PartialEmoji(_EmojiTag, AssetMixin):
 
         Retrieves the data of this emoji as a :class:`bytes` object.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Raises
         ------
-        InvalidArgument
+        TypeError
             The emoji is not a custom emoji.
         DiscordException
             There was no internal connection state.
@@ -266,6 +268,6 @@ class PartialEmoji(_EmojiTag, AssetMixin):
             The content of the asset.
         """
         if self.is_unicode_emoji():
-            raise InvalidArgument("PartialEmoji is not a custom emoji")
+            raise TypeError("PartialEmoji is not a custom emoji")
 
         return await super().read()

--- a/disnake/reaction.py
+++ b/disnake/reaction.py
@@ -154,6 +154,9 @@ class Reaction:
 
         .. versionadded:: 1.3
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Raises
         ------
         HTTPException
@@ -162,7 +165,7 @@ class Reaction:
             You do not have the proper permissions to clear the reaction.
         NotFound
             The emoji you specified was not found.
-        InvalidArgument
+        TypeError
             The emoji parameter is invalid.
         """
         await self.message.clear_reaction(self.emoji)

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -29,7 +29,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
 
 from .asset import Asset
 from .colour import Colour
-from .errors import InvalidArgument
 from .mixins import Hashable
 from .partial_emoji import PartialEmoji
 from .permissions import Permissions
@@ -371,10 +370,10 @@ class Role(Hashable):
 
     async def _move(self, position: int, reason: Optional[str]) -> None:
         if position <= 0:
-            raise InvalidArgument("Cannot move role to position 0 or below")
+            raise ValueError("Cannot move role to position 0 or below")
 
         if self.is_default():
-            raise InvalidArgument("Cannot move default role")
+            raise TypeError("Cannot move default role")
 
         if self.position == position:
             return  # Save Discord the extra request.
@@ -425,6 +424,9 @@ class Role(Hashable):
         .. versionchanged:: 2.0
             Edits are no longer in-place, the newly edited role is returned instead.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` or :exc:`ValueError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -459,11 +461,13 @@ class Role(Hashable):
             You do not have permissions to change the role.
         HTTPException
             Editing the role failed.
-        InvalidArgument
-            An invalid position was given or the default
-            role was asked to be moved.
+        ValueError
+            An invalid position was given.
         TypeError
-            The ``icon`` asset is a lottie sticker (see :func:`Sticker.read`).
+            The default role was asked to be moved or the ``icon``
+            asset is a lottie sticker (see :func:`Sticker.read`)
+        ValueError
+            An invalid position was provided.
 
         Returns
         -------

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -461,8 +461,6 @@ class Role(Hashable):
             You do not have permissions to change the role.
         HTTPException
             Editing the role failed.
-        ValueError
-            An invalid position was given.
         TypeError
             The default role was asked to be moved or the ``icon``
             asset is a lottie sticker (see :func:`Sticker.read`)

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -513,6 +513,9 @@ class AutoShardedClient(Client):
         .. versionchanged:: 2.0
             Removed the ``afk`` keyword-only parameter.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         activity: Optional[:class:`BaseActivity`]
@@ -527,7 +530,7 @@ class AutoShardedClient(Client):
 
         Raises
         ------
-        InvalidArgument
+        TypeError
             If the ``activity`` parameter is not of proper type.
         """
         if status is None:

--- a/disnake/stage_instance.py
+++ b/disnake/stage_instance.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .enums import StagePrivacyLevel, try_enum
-from .errors import InvalidArgument
 from .mixins import Hashable
 from .utils import MISSING, _get_as_snowflake, cached_slot_property, warn_deprecated
 
@@ -169,6 +168,9 @@ class StageInstance(Hashable):
         You must have the :attr:`~Permissions.manage_channels` permission to
         use this.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         topic: :class:`str`
@@ -180,7 +182,7 @@ class StageInstance(Hashable):
 
         Raises
         ------
-        InvalidArgument
+        TypeError
             If the ``privacy_level`` parameter is not the proper type.
         Forbidden
             You do not have permissions to edit the stage instance.
@@ -194,7 +196,7 @@ class StageInstance(Hashable):
 
         if privacy_level is not MISSING:
             if not isinstance(privacy_level, StagePrivacyLevel):
-                raise InvalidArgument("privacy_level field must be of type PrivacyLevel")
+                raise TypeError("privacy_level field must be of type PrivacyLevel")
             if privacy_level is StagePrivacyLevel.public:
                 warn_deprecated(
                     "Setting privacy_level to public is deprecated and will be removed in a future version.",

--- a/disnake/template.py
+++ b/disnake/template.py
@@ -201,9 +201,9 @@ class Template:
         HTTPException
             Guild creation failed.
         TypeError
-            Invalid icon image format given. Must be PNG or JPG.
-        TypeError
             The ``icon`` asset is a lottie sticker (see :func:`Sticker.read`).
+        ValueError
+            Invalid icon image format given. Must be PNG or JPG.
 
         Returns
         -------

--- a/disnake/template.py
+++ b/disnake/template.py
@@ -180,7 +180,7 @@ class Template:
             Removed the ``region`` parameter.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/disnake/template.py
+++ b/disnake/template.py
@@ -179,6 +179,9 @@ class Template:
         .. versionchanged:: 2.5
             Removed the ``region`` parameter.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         name: :class:`str`
@@ -197,7 +200,7 @@ class Template:
             The ``icon`` asset couldn't be found.
         HTTPException
             Guild creation failed.
-        InvalidArgument
+        TypeError
             Invalid icon image format given. Must be PNG or JPG.
         TypeError
             The ``icon`` asset is a lottie sticker (see :func:`Sticker.read`).

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -371,6 +371,9 @@ class ClientUser(BaseUser):
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited client user is returned.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         username: :class:`str`
@@ -388,7 +391,7 @@ class ClientUser(BaseUser):
             The ``avatar`` asset couldn't be found.
         HTTPException
             Editing your profile failed.
-        InvalidArgument
+        TypeError
             Wrong image format passed for ``avatar``.
         TypeError
             The ``avatar`` asset is a lottie sticker (see :func:`Sticker.read`).

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -372,7 +372,7 @@ class ClientUser(BaseUser):
             The edit is no longer in-place, instead the newly edited client user is returned.
 
         .. versionchanged:: 2.6
-            Raises :exc:`TypeError` instead of ``InvalidArgument``.
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -392,9 +392,9 @@ class ClientUser(BaseUser):
         HTTPException
             Editing your profile failed.
         TypeError
-            Wrong image format passed for ``avatar``.
-        TypeError
             The ``avatar`` asset is a lottie sticker (see :func:`Sticker.read`).
+        ValueError
+            Wrong image format passed for ``avatar``.
 
         Returns
         -------

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -65,7 +65,6 @@ from typing import (
 from urllib.parse import parse_qs, urlencode
 
 from .enums import Locale
-from .errors import InvalidArgument
 
 try:
     import orjson
@@ -520,7 +519,7 @@ def _get_mime_type_for_image(data: bytes):
     elif data.startswith(b"RIFF") and data[8:12] == b"WEBP":
         return "image/webp"
     else:
-        raise InvalidArgument("Unsupported image type given")
+        raise TypeError("Unsupported image type given")
 
 
 def _bytes_to_base64_data(data: bytes) -> str:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -519,7 +519,7 @@ def _get_mime_type_for_image(data: bytes):
     elif data.startswith(b"RIFF") and data[8:12] == b"WEBP":
         return "image/webp"
     else:
-        raise TypeError("Unsupported image type given")
+        raise ValueError("Unsupported image type given")
 
 
 def _bytes_to_base64_data(data: bytes) -> str:

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -52,7 +52,7 @@ from .. import utils
 from ..asset import Asset
 from ..channel import PartialMessageable
 from ..enums import WebhookType, try_enum
-from ..errors import DiscordServerError, Forbidden, HTTPException, NotFound, WebhookMissingToken
+from ..errors import DiscordServerError, Forbidden, HTTPException, NotFound, WebhookTokenMissing
 from ..flags import MessageFlags
 from ..http import Route, set_attachments, to_multipart, to_multipart_with_attachments
 from ..message import Message
@@ -831,7 +831,7 @@ class WebhookMessage(Message):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
 
         Returns
@@ -1235,7 +1235,7 @@ class Webhook(BaseWebhook):
             Could not fetch the webhook
         NotFound
             Could not find the webhook by this ID
-        WebhookMissingToken
+        WebhookTokenMissing
             This webhook does not have a token associated with it.
 
         Returns
@@ -1250,7 +1250,7 @@ class Webhook(BaseWebhook):
         elif self.token:
             data = await adapter.fetch_webhook_with_token(self.id, self.token, session=self.session)
         else:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         return Webhook(data, self.session, token=self.auth_token, state=self._state)
 
@@ -1280,11 +1280,11 @@ class Webhook(BaseWebhook):
             This webhook does not exist.
         Forbidden
             You do not have permissions to delete this webhook.
-        WebhookMissingToken
+        WebhookTokenMissing
             This webhook does not have a token associated with it.
         """
         if self.token is None and self.auth_token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         adapter = async_context.get()
 
@@ -1344,7 +1344,7 @@ class Webhook(BaseWebhook):
             Editing the webhook failed.
         NotFound
             This webhook does not exist.
-        WebhookMissingToken
+        WebhookTokenMissing
             This webhook does not have a token associated with it
             or it tried editing a channel without authentication.
         TypeError
@@ -1356,7 +1356,7 @@ class Webhook(BaseWebhook):
             The newly edited webhook.
         """
         if self.token is None and self.auth_token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         payload = {}
         if name is not MISSING:
@@ -1371,7 +1371,7 @@ class Webhook(BaseWebhook):
         # If a channel is given, always use the authenticated endpoint
         if channel is not None:
             if self.auth_token is None:
-                raise WebhookMissingToken("Editing channel requires authenticated webhook")
+                raise WebhookTokenMissing("Editing channel requires authenticated webhook")
 
             payload["channel_id"] = channel.id
             data = await adapter.edit_webhook(
@@ -1479,7 +1479,7 @@ class Webhook(BaseWebhook):
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
 
         .. versionchanged:: 2.6
-            Raises :exc:`WebhookMissingToken` instead of ``InvalidArgument``.
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1570,7 +1570,7 @@ class Webhook(BaseWebhook):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         ValueError
             The length of ``embeds`` was invalid.
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
         TypeError
             ``ephemeral`` was passed with the improper webhook type or there was no state
@@ -1582,7 +1582,7 @@ class Webhook(BaseWebhook):
             If ``wait`` is ``True`` then the message that was sent, otherwise ``None``.
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         previous_mentions: Optional[AllowedMentions] = getattr(
             self._state, "allowed_mentions", None
@@ -1675,7 +1675,7 @@ class Webhook(BaseWebhook):
             You do not have the permissions required to get a message.
         HTTPException
             Retrieving the message failed.
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
 
         Returns
@@ -1684,7 +1684,7 @@ class Webhook(BaseWebhook):
             The message asked for.
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         adapter = async_context.get()
         data = await adapter.get_webhook_message(
@@ -1728,7 +1728,7 @@ class Webhook(BaseWebhook):
             The edit is no longer in-place, instead the newly edited message is returned.
 
         .. versionchanged:: 2.6
-            Raises :exc:`WebhookMissingToken` instead of ``InvalidArgument``.
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1795,7 +1795,7 @@ class Webhook(BaseWebhook):
             or there is no associated state when sending a view.
         ValueError
             The length of ``embeds`` was invalid
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
 
         Returns
@@ -1804,7 +1804,7 @@ class Webhook(BaseWebhook):
             The newly edited webhook message.
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         if view is not MISSING:
             if isinstance(self._state, _WebhookState):
@@ -1864,7 +1864,7 @@ class Webhook(BaseWebhook):
         .. versionadded:: 1.6
 
         .. versionchanged:: 2.6
-            Raises :exc:`WebhookMissingToken` instead of ``InvalidArgument``.
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1877,11 +1877,11 @@ class Webhook(BaseWebhook):
             Deleting the message failed.
         Forbidden
             Deleted a message that is not yours.
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         adapter = async_context.get()
         await adapter.delete_webhook_message(

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -52,7 +52,7 @@ from .. import utils
 from ..asset import Asset
 from ..channel import PartialMessageable
 from ..enums import WebhookType, try_enum
-from ..errors import DiscordServerError, Forbidden, HTTPException, InvalidArgument, NotFound
+from ..errors import DiscordServerError, Forbidden, HTTPException, NotFound, WebhookMissingToken
 from ..flags import MessageFlags
 from ..http import Route, set_attachments, to_multipart, to_multipart_with_attachments
 from ..message import Message
@@ -521,7 +521,7 @@ def handle_message_parameters_dict(
         embeds = [embed] if embed else []
     if embeds is not MISSING:
         if len(embeds) > 10:
-            raise InvalidArgument("embeds has a maximum of 10 elements.")
+            raise ValueError("embeds has a maximum of 10 elements.")
         payload["embeds"] = [e.to_dict() for e in embeds]
         for embed in embeds:
             if embed._files:
@@ -831,7 +831,7 @@ class WebhookMessage(Message):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
-        InvalidArgument
+        WebhookMissingToken
             There was no token associated with this webhook.
 
         Returns
@@ -1162,7 +1162,7 @@ class Webhook(BaseWebhook):
 
         Raises
         ------
-        InvalidArgument
+        ValueError
             The URL is invalid.
 
         Returns
@@ -1176,7 +1176,7 @@ class Webhook(BaseWebhook):
             url,
         )
         if m is None:
-            raise InvalidArgument("Invalid webhook URL given.")
+            raise ValueError("Invalid webhook URL given.")
 
         data: Dict[str, Any] = m.groupdict()
         data["type"] = 1
@@ -1235,7 +1235,7 @@ class Webhook(BaseWebhook):
             Could not fetch the webhook
         NotFound
             Could not find the webhook by this ID
-        InvalidArgument
+        WebhookMissingToken
             This webhook does not have a token associated with it.
 
         Returns
@@ -1250,7 +1250,7 @@ class Webhook(BaseWebhook):
         elif self.token:
             data = await adapter.fetch_webhook_with_token(self.id, self.token, session=self.session)
         else:
-            raise InvalidArgument("This webhook does not have a token associated with it")
+            raise WebhookMissingToken("This webhook does not have a token associated with it")
 
         return Webhook(data, self.session, token=self.auth_token, state=self._state)
 
@@ -1280,11 +1280,11 @@ class Webhook(BaseWebhook):
             This webhook does not exist.
         Forbidden
             You do not have permissions to delete this webhook.
-        InvalidArgument
+        WebhookMissingToken
             This webhook does not have a token associated with it.
         """
         if self.token is None and self.auth_token is None:
-            raise InvalidArgument("This webhook does not have a token associated with it")
+            raise WebhookMissingToken("This webhook does not have a token associated with it")
 
         adapter = async_context.get()
 
@@ -1342,7 +1342,9 @@ class Webhook(BaseWebhook):
             This webhook does not exist or the ``avatar`` asset couldn't be found.
         HTTPException
             Editing the webhook failed.
-        InvalidArgument
+        NotFound
+            This webhook does not exist.
+        WebhookMissingToken
             This webhook does not have a token associated with it
             or it tried editing a channel without authentication.
         TypeError
@@ -1354,7 +1356,7 @@ class Webhook(BaseWebhook):
             The newly edited webhook.
         """
         if self.token is None and self.auth_token is None:
-            raise InvalidArgument("This webhook does not have a token associated with it")
+            raise WebhookMissingToken("This webhook does not have a token associated with it")
 
         payload = {}
         if name is not MISSING:
@@ -1369,7 +1371,7 @@ class Webhook(BaseWebhook):
         # If a channel is given, always use the authenticated endpoint
         if channel is not None:
             if self.auth_token is None:
-                raise InvalidArgument("Editing channel requires authenticated webhook")
+                raise WebhookMissingToken("Editing channel requires authenticated webhook")
 
             payload["channel_id"] = channel.id
             data = await adapter.edit_webhook(
@@ -1476,6 +1478,9 @@ class Webhook(BaseWebhook):
         it must be a rich embed type. You cannot mix the ``embed`` parameter with the
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookMissingToken` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         content: Optional[:class:`str`]
@@ -1565,9 +1570,10 @@ class Webhook(BaseWebhook):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         ValueError
             The length of ``embeds`` was invalid.
-        InvalidArgument
-            There was no token associated with this webhook or ``ephemeral``
-            was passed with the improper webhook type or there was no state
+        WebhookMissingToken
+            There was no token associated with this webhook
+        TypeError
+            ``ephemeral`` was passed with the improper webhook type or there was no state
             attached with this webhook when giving it a view.
 
         Returns
@@ -1576,7 +1582,7 @@ class Webhook(BaseWebhook):
             If ``wait`` is ``True`` then the message that was sent, otherwise ``None``.
         """
         if self.token is None:
-            raise InvalidArgument("This webhook does not have a token associated with it")
+            raise WebhookMissingToken("This webhook does not have a token associated with it")
 
         previous_mentions: Optional[AllowedMentions] = getattr(
             self._state, "allowed_mentions", None
@@ -1586,17 +1592,17 @@ class Webhook(BaseWebhook):
 
         application_webhook = self.type is WebhookType.application
         if ephemeral and not application_webhook:
-            raise InvalidArgument("ephemeral messages can only be sent from application webhooks")
+            raise TypeError("ephemeral messages can only be sent from application webhooks")
 
         if delete_after is not MISSING and ephemeral:
-            raise InvalidArgument("ephemeral messages can not be deleted via endpoints")
+            raise TypeError("ephemeral messages can not be deleted via endpoints")
 
         if application_webhook or delete_after is not MISSING:
             wait = True
 
         if view is not MISSING:
             if isinstance(self._state, _WebhookState):
-                raise InvalidArgument("Webhook views require an associated state with the webhook")
+                raise TypeError("Webhook views require an associated state with the webhook")
             if ephemeral is True and view.timeout is None:
                 view.timeout = 15 * 60.0
 
@@ -1669,7 +1675,7 @@ class Webhook(BaseWebhook):
             You do not have the permissions required to get a message.
         HTTPException
             Retrieving the message failed.
-        InvalidArgument
+        WebhookMissingToken
             There was no token associated with this webhook.
 
         Returns
@@ -1678,7 +1684,7 @@ class Webhook(BaseWebhook):
             The message asked for.
         """
         if self.token is None:
-            raise InvalidArgument("This webhook does not have a token associated with it")
+            raise WebhookMissingToken("This webhook does not have a token associated with it")
 
         adapter = async_context.get()
         data = await adapter.get_webhook_message(
@@ -1710,16 +1716,19 @@ class Webhook(BaseWebhook):
         This is a lower level interface to :meth:`WebhookMessage.edit` in case
         you only have an ID.
 
-        .. versionadded:: 1.6
-
-        .. versionchanged:: 2.0
-            The edit is no longer in-place, instead the newly edited message is returned.
-
         .. note::
             If the original message has embeds with images that were created from local files
             (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
             those images will be removed if the message's attachments are edited in any way
             (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
+
+        .. versionadded:: 1.6
+
+        .. versionchanged:: 2.0
+            The edit is no longer in-place, instead the newly edited message is returned.
+
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookMissingToken` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1783,11 +1792,11 @@ class Webhook(BaseWebhook):
             Edited a message that is not yours.
         TypeError
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
+            or there is no associated state when sending a view.
         ValueError
             The length of ``embeds`` was invalid
-        InvalidArgument
-            There was no token associated with this webhook or the webhook had
-            no state.
+        WebhookMissingToken
+            There was no token associated with this webhook.
 
         Returns
         -------
@@ -1795,11 +1804,11 @@ class Webhook(BaseWebhook):
             The newly edited webhook message.
         """
         if self.token is None:
-            raise InvalidArgument("This webhook does not have a token associated with it")
+            raise WebhookMissingToken("This webhook does not have a token associated with it")
 
         if view is not MISSING:
             if isinstance(self._state, _WebhookState):
-                raise InvalidArgument("This webhook does not have state associated with it")
+                raise TypeError("This webhook does not have state associated with it")
 
             self._state.prevent_view_updates_for(message_id)
 
@@ -1854,6 +1863,9 @@ class Webhook(BaseWebhook):
 
         .. versionadded:: 1.6
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookMissingToken` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         message_id: :class:`int`
@@ -1865,9 +1877,11 @@ class Webhook(BaseWebhook):
             Deleting the message failed.
         Forbidden
             Deleted a message that is not yours.
+        WebhookMissingToken
+            There was no token associated with this webhook
         """
         if self.token is None:
-            raise InvalidArgument("This webhook does not have a token associated with it")
+            raise WebhookMissingToken("This webhook does not have a token associated with it")
 
         adapter = async_context.get()
         await adapter.delete_webhook_message(

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1143,6 +1143,10 @@ class Webhook(BaseWebhook):
     ) -> Webhook:
         """Creates a partial :class:`Webhook` from a webhook URL.
 
+
+        .. versionchanged:: 2.6
+            Raises :exc:`ValueError` instead of ``InvalidArgument``
+
         Parameters
         ----------
         url: :class:`str`
@@ -1223,6 +1227,9 @@ class Webhook(BaseWebhook):
             :meth:`is_authenticated` returns ``False``, then the
             returned webhook does not contain any user information.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``
+
         Parameters
         ----------
         prefer_auth: :class:`bool`
@@ -1258,6 +1265,9 @@ class Webhook(BaseWebhook):
         """|coro|
 
         Deletes this Webhook.
+
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``
 
         Parameters
         ----------
@@ -1310,6 +1320,9 @@ class Webhook(BaseWebhook):
 
         Edits this Webhook.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``
+
         Parameters
         ----------
         name: Optional[:class:`str`]
@@ -1338,17 +1351,15 @@ class Webhook(BaseWebhook):
 
         Raises
         ------
-        NotFound
-            This webhook does not exist or the ``avatar`` asset couldn't be found.
         HTTPException
             Editing the webhook failed.
         NotFound
-            This webhook does not exist.
+            This webhook does not exist or the ``avatar`` asset couldn't be found.
+        TypeError
+            The ``avatar`` asset is a lottie sticker (see :func:`Sticker.read`).
         WebhookTokenMissing
             This webhook does not have a token associated with it
             or it tried editing a channel without authentication.
-        TypeError
-            The ``avatar`` asset is a lottie sticker (see :func:`Sticker.read`).
 
         Returns
         -------
@@ -1567,14 +1578,14 @@ class Webhook(BaseWebhook):
         Forbidden
             The authorization token for the webhook is incorrect.
         TypeError
+            Raised by any of the following:
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
-        ValueError
-            The length of ``embeds`` was invalid.
+            ``ephemeral`` was passed with the improper webhook type.
+            There was no state attached with this webhook when giving it a view.
         WebhookTokenMissing
             There was no token associated with this webhook.
-        TypeError
-            ``ephemeral`` was passed with the improper webhook type or there was no state
-            attached with this webhook when giving it a view.
+        ValueError
+            The length of ``embeds`` was invalid.
 
         Returns
         -------
@@ -1661,6 +1672,9 @@ class Webhook(BaseWebhook):
         Retrieves a single :class:`WebhookMessage` owned by this webhook.
 
         .. versionadded:: 2.0
+
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1793,10 +1807,10 @@ class Webhook(BaseWebhook):
         TypeError
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
             or there is no associated state when sending a view.
-        ValueError
-            The length of ``embeds`` was invalid
         WebhookTokenMissing
             There was no token associated with this webhook.
+        ValueError
+            The length of ``embeds`` was invalid
 
         Returns
         -------

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1151,7 +1151,6 @@ class Webhook(BaseWebhook):
     ) -> Webhook:
         """Creates a partial :class:`Webhook` from a webhook URL.
 
-
         .. versionchanged:: 2.6
             Raises :exc:`ValueError` instead of ``InvalidArgument``.
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1571,7 +1571,7 @@ class Webhook(BaseWebhook):
         ValueError
             The length of ``embeds`` was invalid.
         WebhookMissingToken
-            There was no token associated with this webhook
+            There was no token associated with this webhook.
         TypeError
             ``ephemeral`` was passed with the improper webhook type or there was no state
             attached with this webhook when giving it a view.

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1145,7 +1145,7 @@ class Webhook(BaseWebhook):
 
 
         .. versionchanged:: 2.6
-            Raises :exc:`ValueError` instead of ``InvalidArgument``
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1228,7 +1228,7 @@ class Webhook(BaseWebhook):
             returned webhook does not contain any user information.
 
         .. versionchanged:: 2.6
-            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1267,7 +1267,7 @@ class Webhook(BaseWebhook):
         Deletes this Webhook.
 
         .. versionchanged:: 2.6
-            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -1321,7 +1321,7 @@ class Webhook(BaseWebhook):
         Edits this Webhook.
 
         .. versionchanged:: 2.6
-            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -40,7 +40,7 @@ from urllib.parse import quote as urlquote
 
 from .. import utils
 from ..channel import PartialMessageable
-from ..errors import DiscordServerError, Forbidden, HTTPException, NotFound, WebhookMissingToken
+from ..errors import DiscordServerError, Forbidden, HTTPException, NotFound, WebhookTokenMissing
 from ..http import Route
 from ..message import Message
 from .async_ import BaseWebhook, _WebhookState, handle_message_parameters
@@ -464,7 +464,7 @@ class SyncWebhookMessage(Message):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
 
         Returns
@@ -695,7 +695,7 @@ class SyncWebhook(BaseWebhook):
             Could not fetch the webhook
         NotFound
             Could not find the webhook by this ID
-        WebhookMissingToken
+        WebhookTokenMissing
             This webhook does not have a token associated with it.
 
         Returns
@@ -710,7 +710,7 @@ class SyncWebhook(BaseWebhook):
         elif self.token:
             data = adapter.fetch_webhook_with_token(self.id, self.token, session=self.session)
         else:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         return SyncWebhook(data, self.session, token=self.auth_token, state=self._state)
 
@@ -736,11 +736,11 @@ class SyncWebhook(BaseWebhook):
             This webhook does not exist.
         Forbidden
             You do not have permissions to delete this webhook.
-        WebhookMissingToken
+        WebhookTokenMissing
             This webhook does not have a token associated with it.
         """
         if self.token is None and self.auth_token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         adapter: WebhookAdapter = _get_webhook_adapter()
 
@@ -786,7 +786,7 @@ class SyncWebhook(BaseWebhook):
             Editing the webhook failed.
         NotFound
             This webhook does not exist.
-        WebhookMissingToken
+        WebhookTokenMissing
             This webhook does not have a token associated with it
             or it tried editing a channel without authentication.
 
@@ -796,7 +796,7 @@ class SyncWebhook(BaseWebhook):
             The newly edited webhook.
         """
         if self.token is None and self.auth_token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         payload = {}
         if name is not MISSING:
@@ -811,7 +811,7 @@ class SyncWebhook(BaseWebhook):
         # If a channel is given, always use the authenticated endpoint
         if channel is not None:
             if self.auth_token is None:
-                raise WebhookMissingToken("Editing channel requires authenticated webhook")
+                raise WebhookTokenMissing("Editing channel requires authenticated webhook")
 
             payload["channel_id"] = channel.id
             data = adapter.edit_webhook(
@@ -962,7 +962,7 @@ class SyncWebhook(BaseWebhook):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
 
         Returns
@@ -971,7 +971,7 @@ class SyncWebhook(BaseWebhook):
             If ``wait`` is ``True`` then the message that was sent, otherwise ``None``.
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         previous_mentions: Optional[AllowedMentions] = getattr(
             self._state, "allowed_mentions", None
@@ -1033,7 +1033,7 @@ class SyncWebhook(BaseWebhook):
             You do not have the permissions required to get a message.
         HTTPException
             Retrieving the message failed.
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
 
         Returns
@@ -1042,7 +1042,7 @@ class SyncWebhook(BaseWebhook):
             The message asked for.
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         adapter: WebhookAdapter = _get_webhook_adapter()
         data = adapter.get_webhook_message(
@@ -1124,11 +1124,11 @@ class SyncWebhook(BaseWebhook):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
         ValueError
             The length of ``embeds`` was invalid
-        WebhookMissingToken
+        WebhookTokenMissing
             There was no token associated with this webhook.
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         # if no attachment list was provided but we're uploading new files,
         # use current attachments as the base
@@ -1184,11 +1184,11 @@ class SyncWebhook(BaseWebhook):
             Deleting the message failed.
         Forbidden
             Deleted a message that is not yours.
-        WebhookMissingToken
+        WebhookTokenMissing
             There is no token associated with this webhook.
         """
         if self.token is None:
-            raise WebhookMissingToken("This webhook does not have a token associated with it")
+            raise WebhookTokenMissing("This webhook does not have a token associated with it")
 
         adapter: WebhookAdapter = _get_webhook_adapter()
         adapter.delete_webhook_message(

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -420,6 +420,9 @@ class SyncWebhookMessage(Message):
             those images will be removed if the message's attachments are edited in any way
             (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         content: Optional[:class:`str`]
@@ -491,6 +494,9 @@ class SyncWebhookMessage(Message):
     def delete(self, *, delay: Optional[float] = None) -> None:
         """Deletes the message.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         delay: Optional[:class:`float`]
@@ -505,6 +511,8 @@ class SyncWebhookMessage(Message):
             The message was deleted already.
         HTTPException
             Deleting the message failed.
+        WebhookTokenMissing
+            There is no token associated with this webhook.
         """
         if delay is not None:
             time.sleep(delay)
@@ -1172,6 +1180,9 @@ class SyncWebhook(BaseWebhook):
         you only have an ID.
 
         .. versionadded:: 1.6
+
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -643,6 +643,9 @@ class SyncWebhook(BaseWebhook):
     ) -> SyncWebhook:
         """Creates a partial :class:`Webhook` from a webhook URL.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`ValueError` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         url: :class:`str`

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -468,7 +468,7 @@ class SyncWebhookMessage(Message):
         ValueError
             The length of ``embeds`` was invalid
         WebhookTokenMissing
-            There was no token associated with this webhook.
+            There is no token associated with this webhook.
 
         Returns
         -------
@@ -691,6 +691,9 @@ class SyncWebhook(BaseWebhook):
             :meth:`is_authenticated` returns ``False``, then the
             returned webhook does not contain any user information.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         prefer_auth: :class:`bool`
@@ -724,6 +727,9 @@ class SyncWebhook(BaseWebhook):
 
     def delete(self, *, reason: Optional[str] = None, prefer_auth: bool = True) -> None:
         """Deletes this Webhook.
+
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -771,6 +777,9 @@ class SyncWebhook(BaseWebhook):
         prefer_auth: bool = True,
     ) -> SyncWebhook:
         """Edits this Webhook.
+
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------
@@ -914,6 +923,9 @@ class SyncWebhook(BaseWebhook):
         it must be a rich embed type. You cannot mix the ``embed`` parameter with the
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         content: Optional[:class:`str`]
@@ -1028,6 +1040,9 @@ class SyncWebhook(BaseWebhook):
 
         .. versionadded:: 2.0
 
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
+
         Parameters
         ----------
         id: :class:`int`
@@ -1078,13 +1093,16 @@ class SyncWebhook(BaseWebhook):
         This is a lower level interface to :meth:`WebhookMessage.edit` in case
         you only have an ID.
 
-        .. versionadded:: 1.6
-
         .. note::
             If the original message has embeds with images that were created from local files
             (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
             those images will be removed if the message's attachments are edited in any way
             (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
+
+        .. versionadded:: 1.6
+
+        .. versionchanged:: 2.6
+            Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
 
         Parameters
         ----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5290,7 +5290,7 @@ The following exceptions are thrown by the library.
 
 .. autoexception:: InvalidData
 
-.. autoexception:: InvalidArgument
+.. autoexception:: WebhookMissingToken
 
 .. autoexception:: GatewayNotFound
 
@@ -5323,7 +5323,6 @@ Exception Hierarchy
         - :exc:`DiscordException`
             - :exc:`ClientException`
                 - :exc:`InvalidData`
-                - :exc:`InvalidArgument`
                 - :exc:`LoginFailure`
                 - :exc:`ConnectionClosed`
                 - :exc:`PrivilegedIntentsRequired`
@@ -5339,6 +5338,7 @@ Exception Hierarchy
                 - :exc:`NotFound`
                 - :exc:`DiscordServerError`
             - :exc:`LocalizationKeyError`
+            - :exc:`WebhookMissingToken`
 
 
 Warnings

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5290,7 +5290,7 @@ The following exceptions are thrown by the library.
 
 .. autoexception:: InvalidData
 
-.. autoexception:: WebhookMissingToken
+.. autoexception:: WebhookTokenMissing
 
 .. autoexception:: GatewayNotFound
 
@@ -5338,7 +5338,7 @@ Exception Hierarchy
                 - :exc:`NotFound`
                 - :exc:`DiscordServerError`
             - :exc:`LocalizationKeyError`
-            - :exc:`WebhookMissingToken`
+            - :exc:`WebhookTokenMissing`
 
 
 Warnings


### PR DESCRIPTION
# Summary
we used these all over anyways, rather than have two kinds of exceptions
this standardizes it to TypeError and ValueError

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
