### PR TITLE
chore: update invite link to vanity invite

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The following is a set of guidelines for contributing to the repository. These a
 
 Generally speaking questions are better suited in our resources below.
 
-- The official support server: https://discord.gg/gJDbCw8aQy
+- The official support server: https://discord.gg/disnake
 - The [FAQ in the documentation](https://docs.disnake.dev/en/latest/faq.html)
 - Stack Overflow's [`discord.py` tag](https://stackoverflow.com/questions/tagged/discord.py)
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out a bug.
-        If you want real-time support, consider joining our [Discord server](https://discord.gg/gJDbCw8aQy) instead.
+        If you want real-time support, consider joining our [Discord server](https://discord.gg/disnake) instead.
 
         Please note that this form is for bugs only!
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Discord Server
     about: Use our official Discord server to ask for help and questions as well.
-    url: https://discord.gg/gJDbCw8aQy
+    url: https://discord.gg/disnake

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ disnake
 =======
 
 <p align="center">
-    <a href="https://discord.gg/gJDbCw8aQy"><img src="https://img.shields.io/discord/808030843078836254?style=flat-square&color=5865f2&logo=discord&logoColor=ffffff&label=discord" alt="Discord server invite" /></a>
+    <a href="https://discord.gg/disnake"><img src="https://img.shields.io/discord/808030843078836254?style=flat-square&color=5865f2&logo=discord&logoColor=ffffff&label=discord" alt="Discord server invite" /></a>
     <a href="https://pypi.python.org/pypi/disnake"><img src="https://img.shields.io/pypi/v/disnake.svg?style=flat-square" alt="PyPI version info" /></a>
     <a href="https://pypi.python.org/pypi/disnake"><img src="https://img.shields.io/pypi/pyversions/disnake.svg?style=flat-square" alt="PyPI supported Python versions" /></a>
     <a href="https://github.com/DisnakeDev/disnake/commits"><img src="https://img.shields.io/github/commit-activity/w/DisnakeDev/disnake.svg?style=flat-square" alt="Commit activity" /></a>
@@ -108,8 +108,8 @@ You can find more examples in the [examples directory](./examples).
     ⁕
     <a href="https://guide.disnake.dev/">Guide</a>
     ⁕
-    <a href="https://discord.gg/gJDbCw8aQy">Discord Server</a>
+    <a href="https://discord.gg/disnake">Discord Server</a>
     ⁕
-    <a href="https://discord.gg/discord-api">Discord API</a>
+    <a href="https://discord.gg/discord-developers">Discord Developers</a>
 </p>
 <br>

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -227,7 +227,7 @@ class Guild(Hashable):
         - ``THREE_DAY_THREAD_ARCHIVE``: Guild has access to the three day archive time for threads.
         - ``THREADS_ENABLED``: Guild had early access to threads.
         - ``TICKETED_EVENTS_ENABLED``: Guild has enabled ticketed events.
-        - ``VANITY_URL``: Guild can have a vanity invite URL (e.g. discord.gg/discord-api).
+        - ``VANITY_URL``: Guild can have a vanity invite URL (e.g. discord.gg/disnake).
         - ``VERIFIED``: Guild is a verified server.
         - ``VIP_REGIONS``: Guild has VIP voice regions.
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,7 @@ html_experimental_html5_writer = True
 html_theme = "basic"
 
 html_context = {
-    "discord_invite": "https://discord.gg/gJDbCw8aQy",
+    "discord_invite": "https://discord.gg/disnake",
     "discord_extensions": [
         ("disnake.ext.commands", "ext/commands"),
         ("disnake.ext.tasks", "ext/tasks"),
@@ -240,7 +240,7 @@ html_context = {
 }
 
 resource_links = {
-    "disnake": "https://discord.gg/gJDbCw8aQy",
+    "disnake": "https://discord.gg/disnake",
     "issues": f"{github_repo}/issues",
     "discussions": f"{github_repo}/discussions",
     "examples": f"{github_repo}/tree/{git_ref}/examples",
@@ -425,5 +425,5 @@ texinfo_documents = [
 def setup(app):
     if app.config.language == "ja":
         app.config.intersphinx_mapping["py"] = ("https://docs.python.org/ja/3", None)
-        app.config.html_context["discord_invite"] = "https://discord.gg/gJDbCw8aQy"
-        app.config.resource_links["disnake"] = "https://discord.gg/gJDbCw8aQy"
+        app.config.html_context["discord_invite"] = "https://discord.gg/disnake"
+        app.config.resource_links["disnake"] = "https://discord.gg/disnake"


### PR DESCRIPTION
## Summary

Discord recently verified our server, so without concern of losing our vanity, we are now safe to update all invites to https://discord.gg/disnake

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
