### PR TITLE
fix: add `__str__` to `ApplicationCommand`

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -358,7 +358,7 @@ class ApplicationCommand(ABC):
         return f"<{type(self).__name__} {attrs}>"
 
     def __str__(self) -> str:
-        return f"<{type(self).__name__} name={self.name!r}>"
+        return self.name
 
     def __eq__(self, other) -> bool:
         return (

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -357,6 +357,9 @@ class ApplicationCommand(ABC):
         attrs = " ".join(f"{key}={getattr(self, key)!r}" for key in self.__repr_info__)
         return f"<{type(self).__name__} {attrs}>"
 
+    def __str__(self) -> str:
+        return f"<{type(self).__name__} name={self.name!r}>"
+
     def __eq__(self, other) -> bool:
         return (
             self.type == other.type
@@ -543,9 +546,6 @@ class SlashCommand(ApplicationCommand):
         )
         self.description: str = description
         self.options: List[Option] = options or []
-
-    def __str__(self) -> str:
-        return f"<SlashCommand name={self.name!r}>"
 
     def __eq__(self, other) -> bool:
         return (

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -130,7 +130,7 @@ def _format_diff(diff: Dict[str, List[ApplicationCommand]]) -> str:
     for key, label in _diff_map.items():
         lines.append(label)
         if changes := diff[key]:
-            lines.extend(f"    {cmd}" for cmd in changes)
+            lines.extend(f"    <{type(cmd).__name__} name={cmd.name!r}>" for cmd in changes)
         else:
             lines.append("    -")
 


### PR DESCRIPTION
## Summary

Adds `__str__` to `ApplicationCommand`, previously only implemented for `SlashCommand` while the other types would fall back to `__repr__`.
This is purely a cosmetic fix, and prevents this from happening with command sync debugging:
```py
COMMANDS IN 1234
===============================
| Update is required: False
| To upsert:
|     -
| To edit:
|     -
| To delete:
|     -
| No changes:
|     <SlashCommand name='localized_command'>
|     <SlashCommand name='localized_top_level'>
|     <MessageCommand name='Localized Reverse' default_permission=True>
```
(note the `default_permission` being shown)

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
