### PR TITLE
feat: add Member.role_icon property to display rendered role icon

### DIFF
--- a/disnake/member.py
+++ b/disnake/member.py
@@ -668,6 +668,18 @@ class Member(disnake.abc.Messageable, _UserTag):
         return max(guild.get_role(rid) or guild.default_role for rid in self._roles)
 
     @property
+    def display_icon(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: Returns the member's displayed role icon, if any.
+        .. versionadded:: 2.5
+        """
+        roles = self.roles[1:]  # remove @everyone
+
+        for role in reversed(roles):
+            if role.icon:
+                return role.icon
+        return None
+
+    @property
     def guild_permissions(self) -> Permissions:
         """:class:`Permissions`: Returns the member's guild permissions.
 

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -670,6 +670,7 @@ class Member(disnake.abc.Messageable, _UserTag):
     @property
     def role_icon(self) -> Optional[Asset]:
         """Optional[:class:`Asset`]: Returns the member's displayed role icon, if any.
+
         .. versionadded:: 2.5
         """
         roles = self.roles[1:]  # remove @everyone

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
     from .flags import PublicUserFlags
     from .guild import Guild
     from .message import Message
+    from .partial_emoji import PartialEmoji
     from .role import Role
     from .state import ConnectionState
     from .types.activity import PartialPresenceUpdate
@@ -668,16 +669,16 @@ class Member(disnake.abc.Messageable, _UserTag):
         return max(guild.get_role(rid) or guild.default_role for rid in self._roles)
 
     @property
-    def role_icon(self) -> Optional[Asset]:
-        """Optional[:class:`Asset`]: Returns the member's displayed role icon, if any.
+    def role_icon(self) -> Optional[Union[Asset, PartialEmoji]]:
+        """Optional[Union[:class:`Asset`, :class:`PartialEmoji`]]: Returns the member's displayed role icon, if any.
 
         .. versionadded:: 2.5
         """
         roles = self.roles[1:]  # remove @everyone
 
         for role in reversed(roles):
-            if role.icon:
-                return role.icon
+            if icon := (role.icon or role.emoji):
+                return icon
         return None
 
     @property

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -668,7 +668,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         return max(guild.get_role(rid) or guild.default_role for rid in self._roles)
 
     @property
-    def display_icon(self) -> Optional[Asset]:
+    def role_icon(self) -> Optional[Asset]:
         """Optional[:class:`Asset`]: Returns the member's displayed role icon, if any.
         .. versionadded:: 2.5
         """


### PR DESCRIPTION
## Summary

adds `Member.role_icon` which shows the member's rendered icon

## Checklist
- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
