### PR TITLE
feat(debug): add logging of what was sent to a webhook

### DIFF
--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -195,6 +195,7 @@ class AsyncWebhookAdapter:
                             lock.delay_by(delta)
 
                         if 300 > response.status >= 200:
+                            _log.debug("%s %s has received %s", method, url, data)
                             return data
 
                         if response.status == 429:

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -173,10 +173,11 @@ class AsyncWebhookAdapter:
                         method, url, data=to_send, headers=headers, params=params
                     ) as response:
                         _log.debug(
-                            "Webhook ID %s with %s %s has returned status code %s",
+                            "Webhook ID %s with %s %s with %s has returned status code %s",
                             webhook_id,
                             method,
                             url,
+                            to_send,
                             response.status,
                         )
                         data = (await response.text(encoding="utf-8")) or None

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -148,10 +148,11 @@ class WebhookAdapter:
                         method, url, data=to_send, files=file_data, headers=headers, params=params
                     ) as response:
                         _log.debug(
-                            "Webhook ID %s with %s %s has returned status code %s",
+                            "Webhook ID %s with %s %s with %s has returned status code %s",
                             webhook_id,
                             method,
                             url,
+                            to_send,
                             response.status_code,
                         )
                         response.encoding = "utf-8"
@@ -173,6 +174,7 @@ class WebhookAdapter:
                             lock.delay_by(delta)
 
                         if 300 > response.status_code >= 200:
+                            _log.debug("%s %s has received %s", method, url, data)
                             return data
 
                         if response.status_code == 429:


### PR DESCRIPTION
## Summary
this exists in http.py, but not for webhook handling.
as its very useful for debugging... it should be in webhook handling too
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
