### PR TITLE
fix: make disnake.types.interactions importable at runtime

### DIFF
--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Union
 
 from .channel import ChannelType
-from .components import ActionRow, Component, ComponentType
+from .components import ActionRow, Component, ComponentType, Modal
 from .embed import Embed
 from .member import Member, MemberWithUser
 from .role import Role
@@ -36,7 +36,6 @@ from .snowflake import Snowflake
 from .user import User
 
 if TYPE_CHECKING:
-    from .components import Modal
     from .message import AllowedMentions, Attachment, Message
 
 


### PR DESCRIPTION
## Summary

this only affects users who may use these files during runtime
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
