### PR TITLE
Pass error into `on_error`

### DIFF
--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -244,6 +244,41 @@ class ConnectionClosed(ClientException):
         super().__init__(f"Shard ID {self.shard_id} WebSocket closed with {self.code}")
 
 
+class EventError(DiscordException):
+    """Exception that's raised when an event raises an error.
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+    event_name: :class:`str`
+        The name of the event that raised the error.
+    """
+
+    def __init__(self, message: Optional[str] = None, *args: Any) -> None:
+        if message is not None:
+            super().__init__(message, *args)
+        else:
+            super().__init__(*args)
+
+
+class EventInvokeError(DiscordException):
+    """Exception that's raised when an event raises an error.
+
+    .. versionadded:: 2.5
+
+    Attributes
+    ----------
+    event_name: :class:`str`
+        The name of the event that raised the error.
+    """
+
+    def __init__(self, e: Exception, event_name: str) -> None:
+        self.original: Exception = e
+        self.event_name = event_name
+        super().__init__(f"Event raised an exception: {self.event_name}: {e}")
+
+
 class PrivilegedIntentsRequired(ClientException):
     """Exception that's raised when the gateway is requesting privileged intents
     but they're not ticked in the developer page yet.

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -512,15 +512,13 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         else:
             return self.copy()
 
-    async def dispatch_error(self, ctx: Context, error: Exception) -> None:
+    async def dispatch_error(self, ctx: Context, error: CommandError) -> None:
         stop_propagation = False
         ctx.command_failed = True
         cog = self.cog
-        try:
-            coro = self.on_error
-        except AttributeError:
-            pass
-        else:
+
+        coro = getattr(self, "on_error")
+        if coro is not None:
             injected = wrap_callback(coro)
             if cog is not None:
                 stop_propagation = await injected(cog, ctx, error)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -274,7 +274,7 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     :param shard_id: The shard ID that has resumed.
     :type shard_id: :class:`int`
 
-.. function:: on_error(event, *args, **kwargs)
+.. function:: on_error(error, *args, **kwargs)
 
     Usually when an event raises an uncaught exception, a traceback is
     printed to stderr and the exception is ignored. If you want to
@@ -298,8 +298,8 @@ to handle it, which defaults to print a traceback and ignoring the exception.
         :ref:`ext_commands_api_bot` listeners such as
         :meth:`~ext.commands.Bot.listen` or :meth:`~ext.commands.Cog.listener`.
 
-    :param event: The name of the event that raised the exception.
-    :type event: :class:`str`
+    :param error: The name of the event that raised the exception.
+    :type error: :class:`EventInvokeError`
 
     :param args: The positional arguments for the event that raised the
         exception.
@@ -5146,6 +5146,10 @@ The following exceptions are thrown by the library.
 
 .. autoexception:: ConnectionClosed
 
+.. autoexception:: EventError
+
+.. autoexception:: EventInvokeError
+
 .. autoexception:: PrivilegedIntentsRequired
 
 .. autoexception:: InteractionException
@@ -5180,6 +5184,8 @@ Exception Hierarchy
                     - :exc:`InteractionNotResponded`
                     - :exc:`InteractionTimedOut`
                     - :exc:`ModalChainNotSupported`
+            - :exc:`EventError`
+                - :exc:`EventInvokeError`
             - :exc:`NoMoreItems`
             - :exc:`GatewayNotFound`
             - :exc:`HTTPException`


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This pull request passes a new exception, `EventInvokeException` into `on_error` which contains information about the event name and the error.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
