### PR TITLE
feat: store the vanity_url_code provided to guilds

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -283,6 +283,13 @@ class Guild(Hashable):
 
             This value is unreliable and will only be set after the guild was updated at least once.
             Avoid using this and use :func:`widget_settings` instead.
+
+    vanity_url_code: Optional[:class:`str`]
+        The vanity invite code for this guild, if set.
+
+        To get a full :class:`Invite` object, see :attr:`Guild.vanity_invite`.
+
+        .. versionadded:: 2.5
     """
 
     __slots__ = (
@@ -312,6 +319,7 @@ class Guild(Hashable):
         "approximate_presence_count",
         "widget_enabled",
         "widget_channel_id",
+        "vanity_url_code",
         "_members",
         "_channels",
         "_icon",
@@ -564,6 +572,7 @@ class Guild(Hashable):
         self.approximate_member_count: Optional[int] = guild.get("approximate_member_count")
         self.widget_enabled: Optional[bool] = guild.get("widget_enabled")
         self.widget_channel_id: Optional[int] = utils._get_as_snowflake(guild, "widget_channel_id")
+        self.vanity_url_code: Optional[str] = guild.get("vanity_url_code")
 
         stage_instances = guild.get("stage_instances")
         if stage_instances is not None:
@@ -3428,15 +3437,23 @@ class Guild(Hashable):
         """
         await self._state.http.unban(user.id, self.id, reason=reason)
 
-    async def vanity_invite(self) -> Optional[Invite]:
+    async def vanity_invite(self, *, use_cached: bool = False) -> Optional[Invite]:
         """|coro|
 
         Returns the guild's special vanity invite.
 
         The guild must have ``VANITY_URL`` in :attr:`~Guild.features`.
 
-        You must have :attr:`~Permissions.manage_guild` permission to
-        use this.
+        If ``use_cached`` is False, then you must have
+        :attr:`~Permissions.manage_guild` permission to use this.
+
+        Parameters
+        ----------
+        use_cached: :class:`bool`
+            Whether to use the cached :attr:`Guild.vanity_url_code`
+            and attempt to convert it into a full invite.
+
+            .. versionadded:: 2.5
 
         Raises
         ------
@@ -3452,9 +3469,14 @@ class Guild(Hashable):
             have a vanity invite set.
         """
         # we start with { code: abc }
-        payload: Any = await self._state.http.get_vanity_code(self.id)
-        if not payload["code"]:
-            return None
+        if use_cached:
+            if not self.vanity_url_code:
+                return None
+            payload: Any = {"code": self.vanity_url_code}
+        else:
+            payload: Any = await self._state.http.get_vanity_code(self.id)
+            if not payload["code"]:
+                return None
 
         # get the vanity URL channel since default channels aren't
         # reliable or a thing anymore

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3555,7 +3555,7 @@ AuditLogDiff
 
         The guild's vanity URL.
 
-        See also :meth:`Guild.vanity_invite` and :meth:`Guild.edit`.
+        See also :meth:`Guild.vanity_invite`, :meth:`Guild.edit`, and :attr:`Guild.vanity_url_code`.
 
         :type: :class:`str`
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Saves the vanity_url_code to the guild object.
This allows a user to get the server's vanity without having manage guild permissions.

Not sure what to name ``use_cached``.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
