### PR TITLE
fix: make parameters in command handling functions positional-only

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -593,7 +593,7 @@ class ParamInfo:
         )
 
 
-def safe_call(function: Callable[..., T], *possible_args: Any, **possible_kwargs: Any) -> T:
+def safe_call(function: Callable[..., T], /, *possible_args: Any, **possible_kwargs: Any) -> T:
     """Calls a function without providing any extra unexpected arguments"""
     MISSING = object()
     sig = signature(function)
@@ -732,6 +732,7 @@ def format_kwargs(
     interaction: CommandInteraction,
     cog_param: str = None,
     inter_param: str = None,
+    /,
     *args: Any,
     **kwargs: Any,
 ) -> Dict[str, Any]:
@@ -756,7 +757,7 @@ def format_kwargs(
 
 
 async def run_injections(
-    injections: Dict[str, Injection], interaction: CommandInteraction, *args: Any, **kwargs: Any
+    injections: Dict[str, Injection], interaction: CommandInteraction, /, *args: Any, **kwargs: Any
 ) -> Dict[str, Any]:
     """Run and resolve a list of injections"""
 
@@ -768,7 +769,7 @@ async def run_injections(
 
 
 async def call_param_func(
-    function: Callable, interaction: CommandInteraction, *args: Any, **kwargs: Any
+    function: Callable, interaction: CommandInteraction, /, *args: Any, **kwargs: Any
 ) -> Any:
     """Call a function utilizing ParamInfo"""
     cog_param, inter_param, paraminfos, injections = collect_params(function)

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -572,7 +572,7 @@ def _parse_ratelimit_header(request: Any, *, use_clock: bool = False) -> float:
         return float(reset_after)
 
 
-async def maybe_coroutine(f, *args, **kwargs):
+async def maybe_coroutine(f, /, *args, **kwargs):
     value = f(*args, **kwargs)
     if _isawaitable(value):
         return await value


### PR DESCRIPTION
## Summary

Fixes errors like `TypeError: call_param_func() got multiple values for argument 'function'`, as reported here: https://discord.com/channels/808030843078836254/883342278280745030/967835407901401089

Due to how interactions are handled internally, slash commands previously couldn't have parameters named `function`, `interaction`, or `f`, as several internal functions used those same names while also taking `**kwargs`, evidently resulting in conflicts.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
