### PR TITLE
feat!: raise error instead of silently returning on interactions that do not support deferring

### DIFF
--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -715,16 +715,15 @@ class InteractionResponse:
                 "This interaction must be of type 'application_command', 'modal_submit', or 'component' in order to defer."
             )
 
-        if defer_type:
-            adapter = async_context.get()
-            await adapter.create_interaction_response(
-                parent.id,
-                parent.token,
-                session=parent._session,
-                type=defer_type.value,
-                data=data or None,
-            )
-            self._responded = True
+        adapter = async_context.get()
+        await adapter.create_interaction_response(
+            parent.id,
+            parent.token,
+            session=parent._session,
+            type=defer_type.value,
+            data=data or None,
+        )
+        self._responded = True
 
     async def pong(self) -> None:
         """|coro|

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -29,19 +29,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union, cast, overload
 
 from .. import utils
 from ..app_commands import OptionChoice
@@ -675,7 +663,7 @@ class InteractionResponse:
     async def defer(
         self,
         *,
-        with_message: Literal[True],
+        with_message: bool = ...,
         ephemeral: bool = ...,
     ) -> None:
         ...
@@ -683,8 +671,6 @@ class InteractionResponse:
     @overload
     async def defer(
         self,
-        *,
-        with_message: Literal[False],
     ) -> None:
         ...
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -672,15 +672,22 @@ class InteractionResponse:
         This is typically used when the interaction is acknowledged
         and a secondary action will be done later.
 
+        .. versionchanged:: 2.5
+
+            Raises :exc:`TypeError` when an interaction cannot be deferred.
+
         Parameters
         ----------
         with_message: :class:`bool`
             Whether the response will be a message with thinking state (bot is thinking...).
+            This only applies to interactions of type :attr:`InteractionType.component`.
 
             .. versionadded:: 2.4
 
         ephemeral: :class:`bool`
             Whether the deferred message will eventually be ephemeral.
+            This applies to interactions of type :attr:`InteractionType.application_command` and :attr:`InteractionType.modal_submit`
+            or when the ``with_message`` parameter is ``True``.
 
         Raises
         ------
@@ -688,6 +695,8 @@ class InteractionResponse:
             Deferring the interaction failed.
         InteractionResponded
             This interaction has already been responded to before.
+        TypeError
+            This interaction cannot be deferred.
         """
         if self._responded:
             raise InteractionResponded(self._parent)

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -659,21 +659,6 @@ class InteractionResponse:
         """
         return self._responded
 
-    @overload
-    async def defer(
-        self,
-        *,
-        with_message: bool = ...,
-        ephemeral: bool = ...,
-    ) -> None:
-        ...
-
-    @overload
-    async def defer(
-        self,
-    ) -> None:
-        ...
-
     async def defer(
         self,
         *,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

small update of typehints and documentation of defer handling,
and make it a bit more clear how it works.

code is directly taken from #474, but was removed to lower feature creep.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
