### PR TITLE
fix: audio delay when calling after

### DIFF
--- a/disnake/player.py
+++ b/disnake/player.py
@@ -748,8 +748,8 @@ class AudioPlayer(threading.Thread):
             self._current_error = exc
             self.stop()
         finally:
-            self.source.cleanup()
             self._call_after()
+            self.source.cleanup()
 
     def _call_after(self) -> None:
         error = self._current_error


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
Sometimes the execution of the cleanup function can take a few seconds which can cause a notifiable delay before the call of the `after` function. 
The idea is to call the `after` function in `player.py` before.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
