### PR TITLE
feat: return namedtuple from `ForumChannel.create_thread`, improve `Thread` repr

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2504,10 +2504,9 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         Returns
         -------
         Tuple[:class:`Thread`, :class:`Message`]
-            The newly created thread and the message sent in it.
+            A :class:`~typing.NamedTuple` with the newly created thread and the message sent in it.
 
-            These values can also be accessed through the ``thread`` and ``message``
-            fields in the returned namedtuple.
+            These values can also be accessed through the ``thread`` and ``message`` fields.
         """
         from .message import Message
         from .webhook.async_ import handle_message_parameters_dict

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -37,6 +37,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    NamedTuple,
     Optional,
     Sequence,
     Tuple,
@@ -2122,6 +2123,11 @@ class NewsChannel(TextChannel):
     type: ChannelType = ChannelType.news
 
 
+class ThreadWithMessage(NamedTuple):
+    thread: Thread
+    message: Message
+
+
 class ForumChannel(disnake.abc.GuildChannel, Hashable):
     """Represents a Discord Forum channel.
 
@@ -2429,7 +2435,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         view: View = MISSING,
         components: Components = MISSING,
         reason: Optional[str] = None,
-    ) -> Tuple[Thread, Message]:
+    ) -> ThreadWithMessage:
         """|coro|
 
         Creates a thread in this forum channel.
@@ -2499,6 +2505,9 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         -------
         Tuple[:class:`Thread`, :class:`Message`]
             The newly created thread and the message sent in it.
+
+            These values can also be accessed through the ``thread`` and ``message``
+            fields in the returned namedtuple.
         """
         from .message import Message
         from .webhook.async_ import handle_message_parameters_dict
@@ -2547,14 +2556,13 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
                 for f in params.files:
                     f.close()
 
-        if view:
-            self._state.store_view(view, int(data["message"]["id"]))
-
         thread = Thread(guild=self.guild, data=data, state=self._state)
-        return (
-            thread,
-            Message(channel=thread, data=data["message"], state=self._state),
-        )
+        message = Message(channel=thread, data=data["message"], state=self._state)
+
+        if view:
+            self._state.store_view(view, message.id)
+
+        return ThreadWithMessage(thread, message)
 
     def archived_threads(
         self,

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -177,8 +177,8 @@ class Thread(Messageable, Hashable):
 
     def __repr__(self) -> str:
         return (
-            f"<Thread id={self.id!r} name={self.name!r} parent={self.parent} "
-            f"owner_id={self.owner_id!r} locked={self.locked} archived={self.archived} "
+            f"<Thread id={self.id!r} name={self.name!r} parent={self.parent!r} "
+            f"owner_id={self.owner_id!r} locked={self.locked!r} archived={self.archived!r} "
             f"flags={self.flags!r}>"
         )
 


### PR DESCRIPTION
## Summary

followup to #504
- `ForumChannel.create_thread` now returns a namedtuple instead of a plain tuple
- `Thread.__repr__` uses `{self.parent!r}` instead of `{self.parent}`, since the latter only shows the channel name

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
