### PR TITLE
docs: update documentation to match new backend v2 behavior

### DIFF
--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -283,7 +283,7 @@ def user_command(
         Whether to automatically register the command. Defaults to ``True``.
     guild_ids: Sequence[:class:`int`]
         If specified, the client will register the command in these guilds.
-        Otherwise this command will be registered globally in ~1 hour.
+        Otherwise, this command will be registered globally.
     extras: Dict[:class:`str`, Any]
         A dict of user provided extras to attach to the command.
 
@@ -357,7 +357,7 @@ def message_command(
         Whether to automatically register the command. Defaults to ``True``.
     guild_ids: Sequence[:class:`int`]
         If specified, the client will register the command in these guilds.
-        Otherwise this command will be registered globally in ~1 hour.
+        Otherwise, this command will be registered globally.
     extras: Dict[:class:`str`, Any]
         A dict of user provided extras to attach to the command.
 

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -476,8 +476,8 @@ class InteractionBotBase(CommonBotBase):
         auto_sync: :class:`bool`
             Whether to automatically register the command. Defaults to ``True``
         guild_ids: Sequence[:class:`int`]
-            If specified, the client will register a command in these guilds.
-            Otherwise this command will be registered globally in ~1 hour.
+            If specified, the client will register the command in these guilds.
+            Otherwise, this command will be registered globally.
         connectors: Dict[:class:`str`, :class:`str`]
             Binds function names to option names. If the name
             of an option already matches the corresponding function param,
@@ -551,7 +551,7 @@ class InteractionBotBase(CommonBotBase):
             Whether to automatically register the command. Defaults to ``True``.
         guild_ids: Sequence[:class:`int`]
             If specified, the client will register the command in these guilds.
-            Otherwise this command will be registered globally in ~1 hour.
+            Otherwise, this command will be registered globally.
         extras: Dict[:class:`str`, Any]
             A dict of user provided extras to attach to the command.
 
@@ -616,7 +616,7 @@ class InteractionBotBase(CommonBotBase):
             Whether to automatically register the command. Defaults to ``True``
         guild_ids: Sequence[:class:`int`]
             If specified, the client will register the command in these guilds.
-            Otherwise this command will be registered globally in ~1 hour.
+            Otherwise, this command will be registered globally.
         extras: Dict[:class:`str`, Any]
             A dict of user provided extras to attach to the command.
 
@@ -727,8 +727,6 @@ class InteractionBotBase(CommonBotBase):
             "Application command synchronization:\n"
             "GLOBAL COMMANDS\n"
             "===============\n"
-            "| NOTE: global commands can take up to 1 hour to show up after registration.\n"
-            "|\n"
             f"| Update is required: {update_required}\n{_format_diff(diff)}"
         )
 

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -734,8 +734,8 @@ def slash_command(
         .. versionadded:: 2.5
 
     guild_ids: List[:class:`int`]
-        If specified, the client will register a command in these guilds.
-        Otherwise this command will be registered globally in ~1 hour.
+        If specified, the client will register the command in these guilds.
+        Otherwise, this command will be registered globally.
     connectors: Dict[:class:`str`, :class:`str`]
         Binds function names to option names. If the name
         of an option already matches the corresponding function param,

--- a/docs/ext/commands/additional_info.rst
+++ b/docs/ext/commands/additional_info.rst
@@ -17,12 +17,6 @@ understand how your commands show up in Discord. If ``sync_commands`` kwarg of :
 the library registers / updates all commands automatically. Based on the application commands defined in your code it decides
 which commands should be registered, edited or deleted but there're some edge cases you should keep in mind.
 
-Global registration
-+++++++++++++++++++
-
-Registering commands globally may take up to 1 hour, this is an API limitation. You don't have to keep your bot online this whole time though,
-it's enough to launch it at least once.
-
 Changing test guilds
 ++++++++++++++++++++
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -18,9 +18,9 @@ You have probably noticed that slash commands have really interactive user inter
 This is because each slash command is registered in Discord before people can see it. This library handles registration for you,
 but you can still manage it.
 
-By default, the registration is global. This means that your slash commands will be visible everywhere, including bot DMs.
-Global registration can take up to 1 hour to complete, this is an API limitation. You can change the registration to be local,
-so your slash commands will only be visible in several guilds. This type of registration is almost instant.
+By default, the registration is global. This means that your slash commands will be visible everywhere, including bot DMs,
+though you can disable them in DMs by setting the appropriate :ref:`permissions <app_command_permissions>`.
+You can also change the registration to be local, so your slash commands will only be visible in several guilds.
 
 This code sample shows how to set the registration to be local:
 

--- a/examples/context_menus/basic_contexts_menus.py
+++ b/examples/context_menus/basic_contexts_menus.py
@@ -6,7 +6,7 @@ bot = commands.Bot(
     # Insert IDs of your test guilds below, if
     # you want the context menus to instantly appear.
     # Without test_guilds specified, your commands will
-    # register globally in ~1 hour.
+    # register globally.
     test_guilds=[12345],
 )
 


### PR DESCRIPTION
## Summary

Now that commands/backend v2 appears to be rolled out for the most part, the disclaimers about registration of global commands taking up to an hour to propagate can be removed.

Keeping this as a draft while not all clients are able to access backend v2, mainly android stable.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
