### PR TITLE
fix: handle bool values for `default_member_permissions`

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -466,6 +466,8 @@ class ApplicationCommand(ABC):
         if default_member_permissions is None:
             # allow everyone to use the command if its not supplied
             self._default_member_permissions = None
+        elif isinstance(default_member_permissions, bool):
+            raise TypeError("`default_member_permissions` cannot be a bool value")
         elif isinstance(default_member_permissions, int):
             self._default_member_permissions = default_member_permissions
         else:

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -467,7 +467,7 @@ class ApplicationCommand(ABC):
             # allow everyone to use the command if its not supplied
             self._default_member_permissions = None
         elif isinstance(default_member_permissions, bool):
-            raise TypeError("`default_member_permissions` cannot be a bool value")
+            raise TypeError("`default_member_permissions` cannot be a bool")
         elif isinstance(default_member_permissions, int):
             self._default_member_permissions = default_member_permissions
         else:

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -33,7 +33,6 @@ from typing import (
     Coroutine,
     Dict,
     List,
-    Literal,
     Optional,
     Tuple,
     TypeVar,
@@ -648,7 +647,7 @@ class InvokableApplicationCommand(ABC):
             inter.application_command = original
 
 
-def default_member_permissions(value: int = 0, **permissions: Literal[True]) -> Callable[[T], T]:
+def default_member_permissions(value: int = 0, **permissions: bool) -> Callable[[T], T]:
     """
     A decorator that sets default required member permissions for the command.
     Unlike :func:`~.ext.commands.has_permissions`, this decorator does not add any checks.
@@ -680,9 +679,10 @@ def default_member_permissions(value: int = 0, **permissions: Literal[True]) -> 
     value: :class:`int`
         A raw permission bitfield of an integer representing the required permissions.
         May be used instead of specifying kwargs.
-    **permissions: Literal[True]
+    **permissions: bool
         The required permissions for a command. A member must have *all* these
         permissions to be able to invoke the command.
+        Setting a permission to ``False`` does not affect the result.
     """
     if isinstance(value, bool):
         raise TypeError("`value` cannot be a bool value")

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -684,6 +684,8 @@ def default_member_permissions(value: int = 0, **permissions: Literal[True]) -> 
         The required permissions for a command. A member must have *all* these
         permissions to be able to invoke the command.
     """
+    if isinstance(value, bool):
+        raise TypeError("`value` cannot be a bool value")
     perms_value = Permissions(value, **permissions).value
 
     def decorator(func: T) -> T:

--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -105,7 +105,7 @@ class InvokableUserCommand(InvokableApplicationCommand):
         self.auto_sync: bool = True if auto_sync is None else auto_sync
 
         try:
-            default_perms = func.__default_member_permissions__
+            default_perms: int = func.__default_member_permissions__
         except AttributeError:
             pass
         else:
@@ -113,7 +113,7 @@ class InvokableUserCommand(InvokableApplicationCommand):
                 raise ValueError(
                     "Cannot set `default_member_permissions` in both parameter and decorator"
                 )
-            default_member_permissions = Permissions(default_perms)
+            default_member_permissions = default_perms
 
         dm_permission = True if dm_permission is None else dm_permission
 
@@ -205,7 +205,7 @@ class InvokableMessageCommand(InvokableApplicationCommand):
         self.auto_sync: bool = True if auto_sync is None else auto_sync
 
         try:
-            default_perms = func.__default_member_permissions__
+            default_perms: int = func.__default_member_permissions__
         except AttributeError:
             pass
         else:
@@ -213,7 +213,7 @@ class InvokableMessageCommand(InvokableApplicationCommand):
                 raise ValueError(
                     "Cannot set `default_member_permissions` in both parameter and decorator"
                 )
-            default_member_permissions = Permissions(default_perms)
+            default_member_permissions = default_perms
 
         dm_permission = True if dm_permission is None else dm_permission
 

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -413,8 +413,11 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         if options is None:
             options = expand_params(self)
 
+        self.docstring = utils.parse_docstring(func)
+        desc_loc = Localized._cast(description, False)
+
         try:
-            default_perms = func.__default_member_permissions__
+            default_perms: int = func.__default_member_permissions__
         except AttributeError:
             pass
         else:
@@ -422,9 +425,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
                 raise ValueError(
                     "Cannot set `default_member_permissions` in both parameter and decorator"
                 )
-            default_member_permissions = Permissions(default_perms)
-        self.docstring = utils.parse_docstring(func)
-        desc_loc = Localized._cast(description, False)
+            default_member_permissions = default_perms
 
         dm_permission = True if dm_permission is None else dm_permission
 


### PR DESCRIPTION
## Summary

`bool` values for `default_member_permissions` pass type checks due to `bool` being a subtype of `int`. As this will result in issues further down the line, it now raises an exception instead.

Fixes #517.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
