### PR TITLE
fix: decorator-based autocompleters

### DIFF
--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -444,6 +444,10 @@ class InvokableSlashCommand(InvokableApplicationCommand):
             other.connectors = self.connectors.copy()
         if self.autocompleters != other.autocompleters:
             other.autocompleters = self.autocompleters.copy()
+            # Link existing autocompleter to the newly copied slash command...
+            for autocompleter in other.autocompleters.values():
+                if callable(autocompleter):
+                    autocompleter.__slash_command__ = other
         if self.children != other.children:
             other.children = self.children.copy()
         if self.description != other.description and "description" not in other.__original_kwargs__:


### PR DESCRIPTION
## Summary

Decorator-based autocompleters failed because of a bug introduced in #501 (my bad 😭) because the autocomplete function would be copied but not updated with the new slash command instance. To fix this, we now manually overwrite them inside `_ensure_assignment_on_copy`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
