### PR TITLE
docs(deps): update sphinx to v4.5

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -246,7 +246,7 @@ $(document).keydown((event) => {
       return false;
     }
 
-    // focus search `s` (`/` is already supported by Sphinx)
+    // focus search using `s` (`/` is already supported by Sphinx)
     if (event.key === "s") {
       focusSearch();
       return false;

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -239,16 +239,15 @@ $(document).keydown((event) => {
     return;
   }
 
-  if (!event.ctrlKey) {
+  if (!event.ctrlKey && !event.shiftKey) {
     // close modal using `escape`, if modal exists
-    if (!event.shiftKey && event.key === "Escape" && activeModal) {
+    if (event.key === "Escape" && activeModal) {
       activeModal.close();
       return false;
     }
 
-    // focus search using `/` or `s`
-    // (not checking `shiftKey` for `/` since some keyboards need it)
-    if (event.key === "/" || (!event.shiftKey && event.key === "s")) {
+    // focus search `s` (`/` is already supported by Sphinx)
+    if (event.key === "s") {
       focusSearch();
       return false;
     }

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open("README.md", encoding="utf-8") as f:
 extras_require = {
     "voice": ["PyNaCl>=1.3.0,<1.5"],
     "docs": [
-        "sphinx~=4.4.0",
+        "sphinx~=4.5.0",
         "sphinxcontrib_trio==1.1.2",
         "sphinx-hoverxref~=1.0.0",
         "sphinx-autobuild==2021.3.14",


### PR DESCRIPTION
## Summary

Updates Sphinx to 4.5.0, and removes the `/` search hotkey handler since Sphinx supports it as of sphinx-doc/sphinx@799385f5558a888d1a143bf703d06b66d6717fe4.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
