### PR TITLE
fix: update guild iterator + scheduled event user iterator

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3472,7 +3472,7 @@ class Guild(Hashable):
     def audit_logs(
         self,
         *,
-        limit: int = 100,
+        limit: Optional[int] = 100,
         before: Optional[SnowflakeTime] = None,
         after: Optional[SnowflakeTime] = None,
         user: Snowflake = None,

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -674,8 +674,8 @@ class GuildIterator(_AsyncIterator["Guild"]):
 
     def _get_retrieve(self):
         l = self.limit
-        if l is None or l > 100:
-            r = 100
+        if l is None or l > 200:
+            r = 200
         else:
             r = l
         self.retrieve = r
@@ -689,7 +689,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
     async def fill_guilds(self):
         if self._get_retrieve():
             data = await self._retrieve_guilds(self.retrieve)
-            if len(data) < 100:
+            if len(data) < 200:
                 self.limit = 0
 
             if self.reverse:

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -917,6 +917,8 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
         return r > 0
 
     def create_user(self, data: GuildScheduledEventUserPayload) -> Union[User, Member]:
+        from .member import Member
+
         user_data = data["user"]
         member_data = data.get("member")
         if member_data is not None and (guild := self.event.guild) is not None:

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -654,13 +654,14 @@ class GuildIterator(_AsyncIterator["Guild"]):
         self.get_guilds = self.bot.http.get_guilds
         self.guilds = asyncio.Queue()
 
-        if self.before and self.after:
+        if self.before:
+            self.reverse = True
             self._retrieve_guilds = self._retrieve_guilds_before_strategy  # type: ignore
-            self._filter = lambda m: int(m["id"]) > self.after.id  # type: ignore
-        elif self.after:
-            self._retrieve_guilds = self._retrieve_guilds_after_strategy  # type: ignore
+            if self.after:
+                self._filter = lambda m: int(m["id"]) > self.after.id  # type: ignore
         else:
-            self._retrieve_guilds = self._retrieve_guilds_before_strategy  # type: ignore
+            self.reverse = False
+            self._retrieve_guilds = self._retrieve_guilds_after_strategy  # type: ignore
 
     async def next(self) -> Guild:
         if self.guilds.empty():
@@ -688,9 +689,11 @@ class GuildIterator(_AsyncIterator["Guild"]):
     async def fill_guilds(self):
         if self._get_retrieve():
             data = await self._retrieve_guilds(self.retrieve)
-            if self.limit is None or len(data) < 100:
+            if len(data) < 100:
                 self.limit = 0
 
+            if self.reverse:
+                data = reversed(data)
             if self._filter:
                 data = filter(self._filter, data)
 
@@ -708,7 +711,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         if len(data):
             if self.limit is not None:
                 self.limit -= retrieve
-            self.before = Object(id=int(data[-1]["id"]))
+            self.before = Object(id=int(data[0]["id"]))
         return data
 
     async def _retrieve_guilds_after_strategy(self, retrieve):
@@ -718,7 +721,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         if len(data):
             if self.limit is not None:
                 self.limit -= retrieve
-            self.after = Object(id=int(data[0]["id"]))
+            self.after = Object(id=int(data[-1]["id"]))
         return data
 
 


### PR DESCRIPTION
## Summary

Noticed two bugs while refactoring parts of the code. They are not an issue anymore in the upcoming refactor, but having a separate fix makes it easier to backport to older versions.

- guild iterator
    - Only use `before` strategy if `before` parameter was specified
    - Don't stop after first page if `limit=None` is set
    - Always return results in correct order
- scheduled event user iterator
    - Fix missing import

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
