### PR TITLE
feat: add nsfw field to application commands

### DIFF
--- a/changelog/528.feature.rst
+++ b/changelog/528.feature.rst
@@ -1,0 +1,3 @@
+Add support for NSFW application commands.
+- Add :attr:`ApplicationCommand.nsfw`.
+- Add ``nsfw`` parameter to command constructors and decorators.

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -468,6 +468,12 @@ class ApplicationCommand(ABC):
         Defaults to ``True``.
 
         .. versionadded:: 2.5
+
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+        Defaults to ``False``.
+
+        .. versionadded:: 2.6
     """
 
     __repr_info__: ClassVar[Tuple[str, ...]] = (
@@ -475,6 +481,7 @@ class ApplicationCommand(ABC):
         "name",
         "dm_permission",
         "default_member_permisions",
+        "nsfw",
     )
 
     def __init__(
@@ -483,12 +490,14 @@ class ApplicationCommand(ABC):
         name: LocalizedRequired,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
     ):
         self.type: ApplicationCommandType = enum_if_int(ApplicationCommandType, type)
 
         name_loc = Localized._cast(name, True)
         self.name: str = name_loc.string
         self.name_localizations: LocalizationValue = name_loc.localizations
+        self.nsfw: bool = False if nsfw is None else nsfw
 
         self.dm_permission: bool = True if dm_permission is None else dm_permission
 
@@ -538,6 +547,7 @@ class ApplicationCommand(ABC):
             self.type == other.type
             and self.name == other.name
             and self.name_localizations == other.name_localizations
+            and self.nsfw == other.nsfw
             and self._default_member_permissions == other._default_member_permissions
             # ignore `dm_permission` if comparing guild commands
             and (
@@ -556,6 +566,7 @@ class ApplicationCommand(ABC):
             "name": self.name,
             "dm_permission": self.dm_permission,
             "default_permission": True,
+            "nsfw": self.nsfw,
         }
 
         if self._default_member_permissions is None:
@@ -601,6 +612,12 @@ class UserCommand(ApplicationCommand):
         Defaults to ``True``.
 
         .. versionadded:: 2.5
+
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+        Defaults to ``False``.
+
+        .. versionadded:: 2.6
     """
 
     __repr_info__ = ("name", "dm_permission", "default_member_permissions")
@@ -610,12 +627,14 @@ class UserCommand(ApplicationCommand):
         name: LocalizedRequired,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
     ):
         super().__init__(
             type=ApplicationCommandType.user,
             name=name,
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
         )
 
 
@@ -639,6 +658,11 @@ class APIUserCommand(UserCommand, _APIApplicationCommandMixin):
 
         .. versionadded:: 2.5
 
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+
+        .. versionadded:: 2.6
+
     id: :class:`int`
         The user command's ID.
     application_id: :class:`int`
@@ -661,6 +685,7 @@ class APIUserCommand(UserCommand, _APIApplicationCommandMixin):
             name=Localized(data["name"], data=data.get("name_localizations")),
             dm_permission=data.get("dm_permission") is not False,
             default_member_permissions=_get_as_snowflake(data, "default_member_permissions"),
+            nsfw=data.get("nsfw"),
         )
         self._update_common(data)
         return self
@@ -684,6 +709,12 @@ class MessageCommand(ApplicationCommand):
         Defaults to ``True``.
 
         .. versionadded:: 2.5
+
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+        Defaults to ``False``.
+
+        .. versionadded:: 2.6
     """
 
     __repr_info__ = ("name", "dm_permission", "default_member_permissions")
@@ -693,12 +724,14 @@ class MessageCommand(ApplicationCommand):
         name: LocalizedRequired,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
     ):
         super().__init__(
             type=ApplicationCommandType.message,
             name=name,
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
         )
 
 
@@ -722,6 +755,11 @@ class APIMessageCommand(MessageCommand, _APIApplicationCommandMixin):
 
         .. versionadded:: 2.5
 
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+
+        .. versionadded:: 2.6
+
     id: :class:`int`
         The message command's ID.
     application_id: :class:`int`
@@ -744,6 +782,7 @@ class APIMessageCommand(MessageCommand, _APIApplicationCommandMixin):
             name=Localized(data["name"], data=data.get("name_localizations")),
             dm_permission=data.get("dm_permission") is not False,
             default_member_permissions=_get_as_snowflake(data, "default_member_permissions"),
+            nsfw=data.get("nsfw"),
         )
         self._update_common(data)
         return self
@@ -775,6 +814,12 @@ class SlashCommand(ApplicationCommand):
 
         .. versionadded:: 2.5
 
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+        Defaults to ``False``.
+
+        .. versionadded:: 2.6
+
     options: List[:class:`Option`]
         The list of options the slash command has.
     """
@@ -794,12 +839,14 @@ class SlashCommand(ApplicationCommand):
         options: List[Option] = None,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
     ):
         super().__init__(
             type=ApplicationCommandType.chat_input,
             name=name,
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
         )
         _validate_name(self.name)
 
@@ -899,6 +946,11 @@ class APISlashCommand(SlashCommand, _APIApplicationCommandMixin):
 
         .. versionadded:: 2.5
 
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+
+        .. versionadded:: 2.6
+
     id: :class:`int`
         The slash command's ID.
     options: List[:class:`Option`]
@@ -927,6 +979,7 @@ class APISlashCommand(SlashCommand, _APIApplicationCommandMixin):
             ),
             dm_permission=data.get("dm_permission") is not False,
             default_member_permissions=_get_as_snowflake(data, "default_member_permissions"),
+            nsfw=data.get("nsfw"),
         )
         self._update_common(data)
         return self

--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -95,6 +95,7 @@ class InvokableUserCommand(InvokableApplicationCommand):
         name: LocalizedOptional = None,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
         guild_ids: Sequence[int] = None,
         auto_sync: bool = None,
         **kwargs,
@@ -121,6 +122,7 @@ class InvokableUserCommand(InvokableApplicationCommand):
             name=name_loc._upgrade(self.name),
             dm_permission=dm_permission and not self._guild_only,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
         )
 
     async def _call_external_error_handlers(
@@ -195,6 +197,7 @@ class InvokableMessageCommand(InvokableApplicationCommand):
         name: LocalizedOptional = None,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
         guild_ids: Sequence[int] = None,
         auto_sync: bool = None,
         **kwargs,
@@ -221,6 +224,7 @@ class InvokableMessageCommand(InvokableApplicationCommand):
             name=name_loc._upgrade(self.name),
             dm_permission=dm_permission and not self._guild_only,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
         )
 
     async def _call_external_error_handlers(
@@ -255,6 +259,7 @@ def user_command(
     name: LocalizedOptional = None,
     dm_permission: bool = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
+    nsfw: bool = None,
     guild_ids: Sequence[int] = None,
     auto_sync: bool = None,
     extras: Dict[str, Any] = None,
@@ -278,6 +283,12 @@ def user_command(
         See :attr:`.ApplicationCommand.default_member_permissions` for details.
 
         .. versionadded:: 2.5
+
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+        Defaults to ``False``.
+
+        .. versionadded:: 2.6
 
     auto_sync: :class:`bool`
         Whether to automatically register the command. Defaults to ``True``.
@@ -312,6 +323,7 @@ def user_command(
             name=name,
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
             guild_ids=guild_ids,
             auto_sync=auto_sync,
             extras=extras,
@@ -326,6 +338,7 @@ def message_command(
     name: LocalizedOptional = None,
     dm_permission: bool = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
+    nsfw: bool = None,
     guild_ids: Sequence[int] = None,
     auto_sync: bool = None,
     extras: Dict[str, Any] = None,
@@ -352,6 +365,12 @@ def message_command(
         See :attr:`.ApplicationCommand.default_member_permissions` for details.
 
         .. versionadded:: 2.5
+
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+        Defaults to ``False``.
+
+        .. versionadded:: 2.6
 
     auto_sync: :class:`bool`
         Whether to automatically register the command. Defaults to ``True``.
@@ -386,6 +405,7 @@ def message_command(
             name=name,
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
             guild_ids=guild_ids,
             auto_sync=auto_sync,
             extras=extras,

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -443,6 +443,7 @@ class InteractionBotBase(CommonBotBase):
         description: LocalizedOptional = None,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
         options: List[Option] = None,
         guild_ids: Sequence[int] = None,
         connectors: Dict[str, str] = None,
@@ -479,6 +480,12 @@ class InteractionBotBase(CommonBotBase):
 
             .. versionadded:: 2.5
 
+        nsfw: :class:`bool`
+            Whether this command can only be used in NSFW channels.
+            Defaults to ``False``.
+
+            .. versionadded:: 2.6
+
         auto_sync: :class:`bool`
             Whether to automatically register the command. Defaults to ``True``
         guild_ids: Sequence[:class:`int`]
@@ -511,6 +518,7 @@ class InteractionBotBase(CommonBotBase):
                 options=options,
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
+                nsfw=nsfw,
                 guild_ids=guild_ids,
                 connectors=connectors,
                 auto_sync=auto_sync,
@@ -528,6 +536,7 @@ class InteractionBotBase(CommonBotBase):
         name: LocalizedOptional = None,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
         guild_ids: Sequence[int] = None,
         auto_sync: bool = None,
         extras: Dict[str, Any] = None,
@@ -555,6 +564,12 @@ class InteractionBotBase(CommonBotBase):
 
             .. versionadded:: 2.5
 
+        nsfw: :class:`bool`
+            Whether this command can only be used in NSFW channels.
+            Defaults to ``False``.
+
+            .. versionadded:: 2.6
+
         auto_sync: :class:`bool`
             Whether to automatically register the command. Defaults to ``True``.
         guild_ids: Sequence[:class:`int`]
@@ -581,6 +596,7 @@ class InteractionBotBase(CommonBotBase):
                 name=name,
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
+                nsfw=nsfw,
                 guild_ids=guild_ids,
                 auto_sync=auto_sync,
                 extras=extras,
@@ -597,6 +613,7 @@ class InteractionBotBase(CommonBotBase):
         name: LocalizedOptional = None,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
         guild_ids: Sequence[int] = None,
         auto_sync: bool = None,
         extras: Dict[str, Any] = None,
@@ -624,6 +641,12 @@ class InteractionBotBase(CommonBotBase):
 
             .. versionadded:: 2.5
 
+        nsfw: :class:`bool`
+            Whether this command can only be used in NSFW channels.
+            Defaults to ``False``.
+
+            .. versionadded:: 2.6
+
         auto_sync: :class:`bool`
             Whether to automatically register the command. Defaults to ``True``
         guild_ids: Sequence[:class:`int`]
@@ -650,6 +673,7 @@ class InteractionBotBase(CommonBotBase):
                 name=name,
                 dm_permission=dm_permission,
                 default_member_permissions=default_member_permissions,
+                nsfw=nsfw,
                 guild_ids=guild_ids,
                 auto_sync=auto_sync,
                 extras=extras,

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -397,6 +397,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         options: List[Option] = None,
         dm_permission: bool = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
+        nsfw: bool = None,
         guild_ids: Sequence[int] = None,
         connectors: Dict[str, str] = None,
         auto_sync: bool = None,
@@ -437,6 +438,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
             options=options or [],
             dm_permission=dm_permission and not self._guild_only,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
         )
 
     def _ensure_assignment_on_copy(self, other: SlashCommandT) -> SlashCommandT:
@@ -703,6 +705,7 @@ def slash_command(
     description: LocalizedOptional = None,
     dm_permission: bool = None,
     default_member_permissions: Optional[Union[Permissions, int]] = None,
+    nsfw: bool = None,
     options: List[Option] = None,
     guild_ids: Sequence[int] = None,
     connectors: Dict[str, str] = None,
@@ -727,6 +730,12 @@ def slash_command(
 
         .. versionchanged:: 2.5
             Added support for localizations.
+
+    nsfw: :class:`bool`
+        Whether this command can only be used in NSFW channels.
+        Defaults to ``False``.
+
+        .. versionadded:: 2.6
 
     options: List[:class:`.Option`]
         The list of slash command options. The options will be visible in Discord.
@@ -777,6 +786,7 @@ def slash_command(
             options=options,
             dm_permission=dm_permission,
             default_member_permissions=default_member_permissions,
+            nsfw=nsfw,
             guild_ids=guild_ids,
             connectors=connectors,
             auto_sync=auto_sync,

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -54,8 +54,7 @@ class _ApplicationCommandOptional(TypedDict, total=False):
     dm_permission: Optional[bool]
     name_localizations: Optional[ApplicationCommandLocalizations]
     description_localizations: Optional[ApplicationCommandLocalizations]
-    # TODO: may be optional, though it doesn't really matter
-    nsfw: bool
+    nsfw: Optional[bool]
 
 
 class ApplicationCommand(_ApplicationCommandOptional):
@@ -351,7 +350,7 @@ class _EditApplicationCommandOptional(TypedDict, total=False):
     default_permission: bool  # deprecated
     name_localizations: Optional[ApplicationCommandLocalizations]
     description_localizations: Optional[ApplicationCommandLocalizations]
-    nsfw: bool
+    nsfw: Optional[bool]
 
 
 class EditApplicationCommand(_EditApplicationCommandOptional):

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -54,6 +54,8 @@ class _ApplicationCommandOptional(TypedDict, total=False):
     dm_permission: Optional[bool]
     name_localizations: Optional[ApplicationCommandLocalizations]
     description_localizations: Optional[ApplicationCommandLocalizations]
+    # TODO: may be optional, though it doesn't really matter
+    nsfw: bool
 
 
 class ApplicationCommand(_ApplicationCommandOptional):
@@ -349,6 +351,7 @@ class _EditApplicationCommandOptional(TypedDict, total=False):
     default_permission: bool  # deprecated
     name_localizations: Optional[ApplicationCommandLocalizations]
     description_localizations: Optional[ApplicationCommandLocalizations]
+    nsfw: bool
 
 
 class EditApplicationCommand(_EditApplicationCommandOptional):


### PR DESCRIPTION
## Summary

Setting `nsfw=True` disables/hides a command outside of nsfw channels - like many other fields, it cannot be set per subcommand or group.
Not announced/documented yet and support in DMs is still tbd/wip, hence the draft PR.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
