### PR TITLE
fix: handle other `type` field types in audit logs

### DIFF
--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -171,9 +171,17 @@ def _enum_transformer(enum: Type[T]) -> Callable[[AuditLogEntry, int], T]:
     return _transform
 
 
-def _transform_type(entry: AuditLogEntry, data: int) -> Union[enums.ChannelType, enums.StickerType]:
-    if entry.action.name.startswith("sticker_"):
+def _transform_type(
+    entry: AuditLogEntry, data: Any
+) -> Union[enums.ChannelType, enums.StickerType, enums.WebhookType, str, int]:
+    action_name = entry.action.name
+    if action_name.startswith("sticker_"):
         return enums.try_enum(enums.StickerType, data)
+    elif action_name.startswith("webhook_"):
+        return enums.try_enum(enums.WebhookType, data)
+    elif action_name.startswith("integration_") or action_name.startswith("overwrite_"):
+        # integration: str, overwrite: int
+        return data
     else:
         return enums.try_enum(enums.ChannelType, data)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2475,7 +2475,7 @@ of :class:`enum.Enum`.
 
         - :attr:`~AuditLogDiff.channel`
         - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.type` (always set to ``1`` if so)
+        - :attr:`~AuditLogDiff.type`
 
     .. attribute:: webhook_update
 
@@ -2504,7 +2504,7 @@ of :class:`enum.Enum`.
 
         - :attr:`~AuditLogDiff.channel`
         - :attr:`~AuditLogDiff.name`
-        - :attr:`~AuditLogDiff.type` (always set to ``1`` if so)
+        - :attr:`~AuditLogDiff.type`
 
     .. attribute:: emoji_create
 
@@ -2783,6 +2783,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.archived`
         - :attr:`~AuditLogDiff.locked`
         - :attr:`~AuditLogDiff.auto_archive_duration`
+        - :attr:`~AuditLogDiff.type`
 
         .. versionadded:: 2.0
 
@@ -2817,6 +2818,7 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.archived`
         - :attr:`~AuditLogDiff.locked`
         - :attr:`~AuditLogDiff.auto_archive_duration`
+        - :attr:`~AuditLogDiff.type`
 
         .. versionadded:: 2.0
 
@@ -3675,9 +3677,9 @@ AuditLogDiff
 
     .. attribute:: type
 
-        The type of channel or sticker.
+        The type of channel/thread, sticker, webhook, integration (:class:`str`), or permission overwrite (:class:`int`).
 
-        :type: Union[:class:`ChannelType`, :class:`StickerType`]
+        :type: Union[:class:`ChannelType`, :class:`StickerType`, :class:`WebhookType`, :class:`str`, :class:`int`]
 
     .. attribute:: topic
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2236,6 +2236,9 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.id`
         - :attr:`~AuditLogDiff.type`
 
+        .. versionchanged:: 2.6
+            :attr:`~AuditLogDiff.type` for this action is now an :class:`int`.
+
     .. attribute:: overwrite_update
 
         A channel permission overwrite was changed, this is typically
@@ -2252,6 +2255,9 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.id`
         - :attr:`~AuditLogDiff.type`
 
+        .. versionchanged:: 2.6
+            :attr:`~AuditLogDiff.type` for this action is now an :class:`int`.
+
     .. attribute:: overwrite_delete
 
         A channel permission overwrite was deleted.
@@ -2266,6 +2272,9 @@ of :class:`enum.Enum`.
         - :attr:`~AuditLogDiff.allow`
         - :attr:`~AuditLogDiff.id`
         - :attr:`~AuditLogDiff.type`
+
+        .. versionchanged:: 2.6
+            :attr:`~AuditLogDiff.type` for this action is now an :class:`int`.
 
     .. attribute:: kick
 
@@ -2481,6 +2490,9 @@ of :class:`enum.Enum`.
         .. versionchanged:: 2.6
             Added :attr:`~AuditLogDiff.application_id`.
 
+        .. versionchanged:: 2.6
+            :attr:`~AuditLogDiff.type` for this action is now a :class:`WebhookType`.
+
     .. attribute:: webhook_update
 
         A webhook was updated. This trigger in the following situations:
@@ -2513,6 +2525,9 @@ of :class:`enum.Enum`.
 
         .. versionchanged:: 2.6
             Added :attr:`~AuditLogDiff.application_id`.
+
+        .. versionchanged:: 2.6
+            :attr:`~AuditLogDiff.type` for this action is now a :class:`WebhookType`.
 
     .. attribute:: emoji_create
 


### PR DESCRIPTION
## Summary

Updates the `type` field handling for audit logs, which would previously return a `ChannelType` value for webhook, integration, and permission overwrite changes.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
