### PR TITLE
fix: update `Guild.bitrate_limit` to use correct value for `VIP_REGIONS`

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -855,7 +855,8 @@ class Guild(Hashable):
 
     @property
     def bitrate_limit(self) -> float:
-        """:class:`float`: The maximum bitrate for voice channels this guild can have."""
+        """:class:`float`: The maximum bitrate for voice channels this guild can have.
+        For stage channels, the maximum bitrate is 64000."""
         vip_guild = self._PREMIUM_GUILD_LIMITS[3].bitrate if "VIP_REGIONS" in self.features else 0
         return max(vip_guild, self._PREMIUM_GUILD_LIMITS[self.premium_tier].bitrate)
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -856,9 +856,7 @@ class Guild(Hashable):
     @property
     def bitrate_limit(self) -> float:
         """:class:`float`: The maximum bitrate for voice channels this guild can have."""
-        vip_guild = (
-            self._PREMIUM_GUILD_LIMITS[1].bitrate if "VIP_REGIONS" in self.features else 96e3
-        )
+        vip_guild = self._PREMIUM_GUILD_LIMITS[3].bitrate if "VIP_REGIONS" in self.features else 0
         return max(vip_guild, self._PREMIUM_GUILD_LIMITS[self.premium_tier].bitrate)
 
     @property


### PR DESCRIPTION
## Summary

The `VIP_REGIONS` feature gives guilds access to 384kbps vc, which corresponds to boost level 3 instead of 1.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
