### PR TITLE
fix: update intersphinx link for requests

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ extlinks = {
 intersphinx_mapping = {
     "py": ("https://docs.python.org/3", None),
     "aio": ("https://docs.aiohttp.org/en/stable/", None),
-    "req": ("https://docs.python-requests.org/en/latest/", None),
+    "req": ("https://requests.readthedocs.io/en/latest/", None),
 }
 
 rst_prolog = """


### PR DESCRIPTION
## Summary

see https://github.com/psf/requests/issues/6140#issuecomment-1135071992

https://readthedocs.org/projects/disnake/builds/16991675/ (last step)
```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.python-requests.org/en/latest/objects.inv' not fetchable due to <class 'requests.exceptions.SSLError'>: HTTPSConnectionPool(host='docs.python-requests.org', port=443): Max retries exceeded with url: /en/latest/objects.inv (Caused by SSLError(CertificateError("hostname 'docs.python-requests.org' doesn't match either of '*.ispapi.net', 'ispapi.net'")))
...
/home/docs/checkouts/readthedocs.org/user_builds/disnake/checkouts/529/docs/faq.rst:56: WARNING: unknown document: req:index
/home/docs/checkouts/readthedocs.org/user_builds/disnake/checkouts/529/docs/faq.rst:56: WARNING: unknown document: req:index
```

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
