### PR TITLE
typing: improve guild channel typing

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -76,16 +76,15 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from .asset import Asset
-    from .channel import CategoryChannel, DMChannel, PartialMessageable, TextChannel, VoiceChannel
+    from .channel import CategoryChannel, DMChannel, PartialMessageable
     from .client import Client
     from .embeds import Embed
     from .enums import InviteTarget
-    from .guild import Guild
+    from .guild import Guild, GuildMessageable
     from .guild_scheduled_event import GuildScheduledEvent
     from .member import Member
     from .message import Message, MessageReference, PartialMessage
     from .state import ConnectionState
-    from .threads import Thread
     from .types.channel import (
         Channel as ChannelPayload,
         GuildChannel as GuildChannelPayload,
@@ -96,7 +95,7 @@ if TYPE_CHECKING:
     from .ui.view import View
     from .user import ClientUser
 
-    MessageableChannel = Union[TextChannel, Thread, DMChannel, PartialMessageable, VoiceChannel]
+    MessageableChannel = Union[GuildMessageable, DMChannel, PartialMessageable]
     SnowflakeTime = Union["Snowflake", datetime]
 
 MISSING = utils.MISSING

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -36,8 +36,8 @@ from disnake.message import Message
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
-    from disnake.channel import DMChannel, TextChannel, Thread, VoiceChannel
-    from disnake.guild import Guild
+    from disnake.channel import DMChannel
+    from disnake.guild import Guild, GuildMessageable
     from disnake.member import Member
     from disnake.state import ConnectionState
     from disnake.user import ClientUser, User
@@ -286,7 +286,7 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
         return self.message.guild
 
     @disnake.utils.cached_property
-    def channel(self) -> Union[TextChannel, Thread, DMChannel, VoiceChannel]:
+    def channel(self) -> Union[GuildMessageable, DMChannel]:
         """Union[:class:`.abc.Messageable`]: Returns the channel associated with this context's command.
         Shorthand for :attr:`.Message.channel`.
         """
@@ -407,7 +407,7 @@ class GuildContext(Context):
     """
 
     guild: Guild
-    channel: Union[TextChannel, Thread, VoiceChannel]
+    channel: GuildMessageable
     author: Member
     me: Member
 

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -52,7 +52,7 @@ from .context import AnyContext, Context
 from .errors import *
 
 if TYPE_CHECKING:
-    from disnake.message import MessageableChannel
+    from disnake.abc import MessageableChannel
 
 
 # TODO: USE ACTUAL FUNCTIONS INSTEAD OF USELESS CLASSES

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -109,6 +109,7 @@ if TYPE_CHECKING:
     from .voice_client import VoiceProtocol
     from .webhook import Webhook
 
+    GuildMessageable = Union[TextChannel, Thread, VoiceChannel]
     GuildChannel = Union[VoiceChannel, StageChannel, TextChannel, CategoryChannel, ForumChannel]
     ByCategoryItem = Tuple[Optional[CategoryChannel], List[GuildChannel]]
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
     from ..embeds import Embed
     from ..ext.commands import AutoShardedBot, Bot
     from ..file import File
+    from ..guild import GuildMessageable
     from ..mentions import AllowedMentions
     from ..state import ConnectionState
     from ..threads import Thread
@@ -245,7 +246,7 @@ class Interaction:
         return self.guild.me
 
     @utils.cached_slot_property("_cs_channel")
-    def channel(self) -> Union[TextChannel, Thread, VoiceChannel]:
+    def channel(self) -> Union[GuildMessageable, PartialMessageable]:
         """Union[:class:`abc.GuildChannel`, :class:`PartialMessageable`, :class:`Thread`]: The channel the interaction was sent from.
 
         Note that due to a Discord limitation, DM channels are not resolved since there is
@@ -258,7 +259,7 @@ class Interaction:
             type = (
                 None if self.guild_id is not None else ChannelType.private
             )  # could be a text, voice, or thread channel in a guild
-            return PartialMessageable(state=self._state, id=self.channel_id, type=type)  # type: ignore
+            return PartialMessageable(state=self._state, id=self.channel_id, type=type)
         return channel  # type: ignore
 
     @property
@@ -1302,8 +1303,8 @@ class InteractionMessage(Message):
         The actual contents of the message.
     embeds: List[:class:`Embed`]
         A list of embeds the message has.
-    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
-        The :class:`TextChannel` or :class:`Thread` that the message was sent from.
+    channel: Union[:class:`TextChannel`, :class:`VoiceChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
+        The channel that the message was sent from.
         Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
     reference: Optional[:class:`~disnake.MessageReference`]
         The message that this message references. This is only applicable to message replies.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -67,8 +67,9 @@ from .utils import MISSING, escape_mentions
 
 if TYPE_CHECKING:
     from .abc import GuildChannel, MessageableChannel, Snowflake
-    from .channel import DMChannel, TextChannel, VoiceChannel
+    from .channel import DMChannel
     from .components import Component
+    from .guild import GuildMessageable
     from .mentions import AllowedMentions
     from .role import Role
     from .state import ConnectionState
@@ -735,8 +736,8 @@ class Message(Hashable):
         This is not stored long term within Discord's servers and is only used ephemerally.
     embeds: List[:class:`Embed`]
         A list of embeds the message has.
-    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
-        The :class:`TextChannel` or :class:`Thread` that the message was sent from.
+    channel: Union[:class:`TextChannel`, :class:`VoiceChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
+        The channel that the message was sent from.
         Could be a :class:`DMChannel` or :class:`GroupChannel` if it's a private message.
     reference: Optional[:class:`~disnake.MessageReference`]
         The message that this message references. This is only applicable to messages of
@@ -892,7 +893,7 @@ class Message(Hashable):
         self.activity: Optional[MessageActivityPayload] = data.get("activity")
         # for user experience, on_message has no business getting partials
         # TODO: Subscripted message to include the channel
-        self.channel: Union[TextChannel, DMChannel, Thread, VoiceChannel] = channel  # type: ignore
+        self.channel: Union[GuildMessageable, DMChannel] = channel  # type: ignore
         self._edited_timestamp: Optional[datetime.datetime] = utils.parse_time(
             data["edited_timestamp"]
         )
@@ -1130,9 +1131,7 @@ class Message(Hashable):
     def _handle_components(self, components: List[ComponentPayload]):
         self.components = [_component_factory(d) for d in components]
 
-    def _rebind_cached_references(
-        self, new_guild: Guild, new_channel: Union[TextChannel, Thread, VoiceChannel]
-    ) -> None:
+    def _rebind_cached_references(self, new_guild: Guild, new_channel: GuildMessageable) -> None:
         self.guild = new_guild
         self.channel = new_channel
         if isinstance(self.author, Member):

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -80,13 +80,12 @@ from .user import ClientUser, User
 from .utils import MISSING
 
 if TYPE_CHECKING:
-    from .abc import PrivateChannel
+    from .abc import MessageableChannel, PrivateChannel
     from .app_commands import APIApplicationCommand, ApplicationCommand
     from .client import Client
     from .gateway import DiscordWebSocket
     from .guild import GuildChannel, VocalGuildChannel
     from .http import HTTPClient
-    from .message import MessageableChannel
     from .types.activity import Activity as ActivityPayload
     from .types.channel import DMChannel as DMChannelPayload
     from .types.emoji import Emoji as EmojiPayload

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1793,7 +1793,7 @@ class ConnectionState:
     def create_message(
         self,
         *,
-        channel: Union[TextChannel, Thread, DMChannel, PartialMessageable, VoiceChannel],
+        channel: MessageableChannel,
         data: MessagePayload,
     ) -> Message:
         return Message(state=self, channel=channel, data=data)


### PR DESCRIPTION
## Summary

Small internal improvement to guild channel typing by introducing `GuildMessageable` as a type alias of `TextChannel | VoiceChannel | Thread`. Also adds `VoiceChannel` to the `message.channel` documentation.

required by #530

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
