### PR TITLE
fix: make system info render in a codeblock in github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,6 +52,7 @@ body:
       required: true
   - type: textarea
     attributes:
+      render: markdown
       label: System Information
       description: >
         Run `python -m disnake -v` and paste the output below.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

makes the System Information field render as a codeblock.
![image](https://user-images.githubusercontent.com/71233171/170842411-83d1f245-84d1-4915-99a2-14c5577620db.png)

I don't really care what language is chosen, this is just to make it not be a codeblock. We could likely provide an empty language and it would work.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
