### PR TITLE
fix: make interaction data dataclasses dicts

### DIFF
--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -199,7 +199,7 @@ class MessageCommandInteraction(ApplicationCommandInteraction):
     target: Message
 
 
-class ApplicationCommandInteractionData(dict):
+class ApplicationCommandInteractionData(Dict[str, Any]):
     """Represents the data of an interaction with an application command.
 
     .. versionadded:: 2.1
@@ -293,7 +293,7 @@ class ApplicationCommandInteractionData(dict):
         return self._get_focused_option()  # type: ignore
 
 
-class ApplicationCommandInteractionDataOption(dict):
+class ApplicationCommandInteractionDataOption(Dict[str, Any]):
     """This class represents the structure of an interaction data option from the API.
 
     Attributes
@@ -362,7 +362,7 @@ class ApplicationCommandInteractionDataOption(dict):
         return chain, {}
 
 
-class ApplicationCommandInteractionDataResolved(dict):
+class ApplicationCommandInteractionDataResolved(Dict[str, Any]):
     """Represents the resolved data related to an interaction with an application command.
 
     .. versionadded:: 2.1

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -199,7 +199,7 @@ class MessageCommandInteraction(ApplicationCommandInteraction):
     target: Message
 
 
-class ApplicationCommandInteractionData:
+class ApplicationCommandInteractionData(dict):
     """Represents the data of an interaction with an application command.
 
     .. versionadded:: 2.1
@@ -239,6 +239,7 @@ class ApplicationCommandInteractionData:
         state: ConnectionState,
         guild: Optional[Guild],
     ):
+        super().__init__(data)
         self.id: int = int(data["id"])
         self.name: str = data["name"]
         self.type: ApplicationCommandType = try_enum(ApplicationCommandType, data["type"])
@@ -292,7 +293,7 @@ class ApplicationCommandInteractionData:
         return self._get_focused_option()  # type: ignore
 
 
-class ApplicationCommandInteractionDataOption:
+class ApplicationCommandInteractionDataOption(dict):
     """This class represents the structure of an interaction data option from the API.
 
     Attributes
@@ -315,6 +316,7 @@ class ApplicationCommandInteractionDataOption:
     def __init__(
         self, *, data: Mapping[str, Any], resolved: ApplicationCommandInteractionDataResolved
     ):
+        super().__init__(data)
         self.name: str = data["name"]
         self.type: OptionType = try_enum(OptionType, data["type"])
         value = data.get("value")
@@ -360,7 +362,7 @@ class ApplicationCommandInteractionDataOption:
         return chain, {}
 
 
-class ApplicationCommandInteractionDataResolved:
+class ApplicationCommandInteractionDataResolved(dict):
     """Represents the resolved data related to an interaction with an application command.
 
     .. versionadded:: 2.1
@@ -394,6 +396,7 @@ class ApplicationCommandInteractionDataResolved:
         guild: Optional[Guild],
     ):
         data = data or {}
+        super().__init__(data)
 
         self.members: Dict[int, Member] = {}
         self.users: Dict[int, User] = {}

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ..components import ActionRow, Button, SelectMenu
 from ..enums import ComponentType, try_enum
@@ -118,7 +118,7 @@ class MessageInteraction(Interaction):
         raise Exception("MessageInteraction is malformed - no component found")
 
 
-class MessageInteractionData(dict):
+class MessageInteractionData(Dict[str, Any]):
     """Represents the data of an interaction with a message component.
 
     .. versionadded:: 2.1

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -118,7 +118,7 @@ class MessageInteraction(Interaction):
         raise Exception("MessageInteraction is malformed - no component found")
 
 
-class MessageInteractionData:
+class MessageInteractionData(dict):
     """Represents the data of an interaction with a message component.
 
     .. versionadded:: 2.1
@@ -136,6 +136,7 @@ class MessageInteractionData:
     __slots__ = ("custom_id", "component_type", "values")
 
     def __init__(self, *, data: ComponentInteractionDataPayload):
+        super().__init__(data)
         self.custom_id: str = data["custom_id"]
         self.component_type: ComponentType = try_enum(ComponentType, data["component_type"])
         self.values: Optional[List[str]] = data.get("values")

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -125,7 +125,7 @@ class ModalInteraction(Interaction):
         return self.data.custom_id
 
 
-class ModalInteractionData:
+class ModalInteractionData(dict):
     """Represents the data of an interaction with a modal.
 
     .. versionadded:: 2.4
@@ -139,6 +139,7 @@ class ModalInteractionData:
     __slots__ = ("custom_id", "_components")
 
     def __init__(self, *, data: ModalInteractionDataPayload):
+        super().__init__(data)
         self.custom_id: str = data["custom_id"]
         # this attribute is not meant to be used since it lacks most of the component data
         self._components: List[ActionRow] = [ActionRow(d) for d in data["components"]]

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Generator, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional
 
 from ..components import ActionRow, NestedComponent, TextInput
 from ..message import Message
@@ -125,7 +125,7 @@ class ModalInteraction(Interaction):
         return self.data.custom_id
 
 
-class ModalInteractionData(dict):
+class ModalInteractionData(Dict[str, Any]):
     """Represents the data of an interaction with a modal.
 
     .. versionadded:: 2.4


### PR DESCRIPTION
makes interaction data available before the data objects have been
modified to add data as a property or attribute
