### PR TITLE
typing: update pyright to 1.1.254, fix new errors

### DIFF
--- a/disnake/components.py
+++ b/disnake/components.py
@@ -143,9 +143,9 @@ class ActionRow(Component, Generic[ComponentT]):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: ComponentPayload):
+    def __init__(self, data: ActionRowPayload):
         self.type: ComponentType = try_enum(ComponentType, data["type"])
-        self.children: List[ComponentT] = [  # type: ignore
+        self.children: List[ComponentT] = [
             _component_factory(d) for d in data.get("components", [])
         ]
 

--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -29,17 +29,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 if TYPE_CHECKING:
     from aiohttp import ClientResponse, ClientWebSocketResponse
+    from requests import Response
 
     from .client import SessionStartLimit
-
-    try:
-        from requests import Response
-
-        _ResponseType = Union[ClientResponse, Response]
-    except ModuleNotFoundError:
-        _ResponseType = ClientResponse
-
     from .interactions import Interaction, ModalInteraction
+
+    _ResponseType = Union[ClientResponse, Response]
 
 __all__ = (
     "DiscordException",

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -1202,7 +1202,7 @@ async def _actual_conversion(
         raise ConversionError(converter, exc) from exc
 
     try:
-        return converter(argument)  # type: ignore
+        return converter(argument)
     except CommandError:
         raise
     except Exception as exc:

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -315,7 +315,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             raise TypeError("Name of a command must be a string.")
         self.name: str = name
 
-        self.callback = func
+        self.callback = func  # type: ignore
         self.enabled: bool = kwargs.get("enabled", True)
 
         help_doc = kwargs.get("help")
@@ -398,13 +398,13 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
     @property
     def callback(
         self,
-    ) -> CommandCallback[CogT, ContextT, P, T]:
+    ) -> CommandCallback[CogT, Context, P, T]:
         return self._callback
 
     @callback.setter
     def callback(
         self,
-        function: CommandCallback[CogT, ContextT, P, T],
+        function: CommandCallback[CogT, Context, P, T],
     ) -> None:
         self._callback = function
         unwrap = unwrap_function(function)

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -587,7 +587,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         view.previous = previous
 
         # type-checker fails to narrow argument
-        return await run_converters(ctx, converter, argument, param)
+        return await run_converters(ctx, converter, argument, param)  # type: ignore
 
     async def _transform_greedy_pos(
         self, ctx: Context, param: inspect.Parameter, required: bool, converter: Any

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -210,6 +210,7 @@ class _CaseInsensitiveDict(dict):
         super().__setitem__(k.casefold(), v)
 
 
+# TODO: ideally, `ContextT` should be bound on the class here as well
 class Command(_BaseCommand, Generic[CogT, P, T]):
     """
     A class that implements the protocol for a bot text command.
@@ -315,7 +316,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             raise TypeError("Name of a command must be a string.")
         self.name: str = name
 
-        self.callback = func  # type: ignore
+        self.callback = func
         self.enabled: bool = kwargs.get("enabled", True)
 
         help_doc = kwargs.get("help")
@@ -396,16 +397,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self.__command_flag__ = None
 
     @property
-    def callback(
-        self,
-    ) -> CommandCallback[CogT, Context, P, T]:
+    def callback(self) -> CommandCallback[CogT, ContextT, P, T]:
         return self._callback
 
     @callback.setter
-    def callback(
-        self,
-        function: CommandCallback[CogT, Context, P, T],
-    ) -> None:
+    def callback(self, function: CommandCallback[CogT, Any, P, T]) -> None:
         self._callback = function
         unwrap = unwrap_function(function)
         self.module = unwrap.__module__

--- a/disnake/ext/commands/view.py
+++ b/disnake/ext/commands/view.py
@@ -49,7 +49,7 @@ _all_quotes = set(_quotes.keys()) | set(_quotes.values())
 
 
 class StringView:
-    def __init__(self, buffer):
+    def __init__(self, buffer: str):
         self.index = 0
         self.buffer = buffer
         self.end = len(buffer)

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -140,10 +140,6 @@ class _AsyncIterator(AsyncIterator[T]):
             raise StopAsyncIteration()
 
 
-def _identity(x):
-    return x
-
-
 class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
     def __init__(self, iterator, max_size):
         self.iterator = iterator
@@ -165,25 +161,25 @@ class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
         return ret
 
 
-class _MappedAsyncIterator(_AsyncIterator[T]):
-    def __init__(self, iterator, func):
+class _MappedAsyncIterator(_AsyncIterator[OT]):
+    def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]):
         self.iterator = iterator
         self.func = func
 
-    async def next(self) -> T:
+    async def next(self) -> OT:
         # this raises NoMoreItems and will propagate appropriately
         item = await self.iterator.next()
         return await maybe_coroutine(self.func, item)
 
 
 class _FilteredAsyncIterator(_AsyncIterator[T]):
-    def __init__(self, iterator, predicate):
+    def __init__(self, iterator: _AsyncIterator[T], predicate: _Func[T, bool]):
         self.iterator = iterator
 
         if predicate is None:
-            predicate = _identity
+            predicate = lambda x: bool(x)
 
-        self.predicate = predicate
+        self.predicate: _Func[T, bool] = predicate
 
     async def next(self) -> T:
         getter = self.iterator.next

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -139,7 +139,7 @@ class ActionRow(Generic[UIComponentT]):
     def __init__(self: ActionRow[StrictUIComponentT], *components: StrictUIComponentT):
         ...
 
-    def __init__(self, *components: UIComponentT):  # type: ignore
+    def __init__(self, *components: UIComponentT):
         self._children: List[UIComponentT] = []
 
         for component in components:

--- a/disnake/widget.py
+++ b/disnake/widget.py
@@ -341,7 +341,7 @@ class Widget:
         for member in data.get("members", []):
             connected_channel = _get_as_snowflake(member, "channel_id")
             if connected_channel in channels:
-                connected_channel = channels[connected_channel]  # type: ignore
+                connected_channel = channels[connected_channel]
             elif connected_channel:
                 connected_channel = WidgetChannel(id=connected_channel, name="", position=0)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ import os
 import re
 import subprocess
 import sys
+from typing import Any
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -193,7 +194,7 @@ def linkcode_resolve(domain, info):
         return None
 
     try:
-        obj = sys.modules[info["module"]]
+        obj: Any = sys.modules[info["module"]]
         for part in info["fullname"].split("."):
             obj = getattr(obj, part)
         obj = inspect.unwrap(obj)

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -3,7 +3,7 @@
 ## type checking
 typing_extensions~=4.2.0
 # this is not pyright itself, but the python wrapper
-pyright==1.1.245
+pyright==1.1.253
 
 
 ## linting

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -3,7 +3,7 @@
 ## type checking
 typing_extensions~=4.2.0
 # this is not pyright itself, but the python wrapper
-pyright==1.1.253
+pyright==1.1.254
 
 
 ## linting

--- a/tests/ext/commands/test_core.py
+++ b/tests/ext/commands/test_core.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING
+
+from disnake.ext import commands
+
+if TYPE_CHECKING:
+    from typing_extensions import assert_type
+
+    # NOTE: using undocumented `expected_text` parameter of pyright instead of `assert_type`,
+    # as `assert_type` can't handle bound ParamSpecs
+    # sanity check: if `reveal_type` isn't working as intended,
+    # the second `type: ignore` will be flagged
+    reveal_type(
+        42,  # type: ignore
+        expected_text="str",  # type: ignore
+    )
+
+
+class CustomContext(commands.Context):
+    ...
+
+
+class CustomCog(commands.Cog):
+    ...
+
+
+class TestDecorators:
+    def _test_typing_defaults(self):
+        base = commands.GroupMixin[None]()
+
+        # no cog
+
+        async def f1(ctx: CustomContext, a: int, b: str) -> bool:
+            ...
+
+        for cd in (commands.command(), base.command()):
+            reveal_type(
+                cd(f1),  # type: ignore
+                expected_text="Command[None, (a: int, b: str), bool]",
+            )
+
+        for gd in (commands.group(), base.group()):
+            reveal_type(
+                gd(f1),  # type: ignore
+                expected_text="Group[None, (a: int, b: str), bool]",
+            )
+
+        # custom cog
+        base = commands.GroupMixin[CustomCog]()
+
+        async def f2(_self: CustomCog, ctx: CustomContext, a: int, b: str) -> bool:
+            ...
+
+        for cd in (commands.command(), base.command()):
+            reveal_type(
+                cd(f2),  # type: ignore
+                expected_text="Command[CustomCog, (a: int, b: str), bool]",
+            )
+
+        for gd in (commands.group(), base.group()):
+            reveal_type(
+                gd(f2),  # type: ignore
+                expected_text="Group[CustomCog, (a: int, b: str), bool]",
+            )
+
+    def _test_typing_cls(self):
+        class CustomCommand(commands.Command):
+            ...
+
+        class CustomGroup(commands.Group):
+            ...
+
+        base = commands.GroupMixin[None]()
+
+        command_decorators = (commands.command(cls=CustomCommand), base.command(cls=CustomCommand))
+        group_decorators = (commands.group(cls=CustomGroup), base.group(cls=CustomGroup))
+
+        async def f(ctx: CustomContext, a: int, b: str) -> bool:
+            ...
+
+        for cd in command_decorators:
+            assert_type(cd(f), CustomCommand)
+
+        for gd in group_decorators:
+            assert_type(gd(f), CustomGroup)

--- a/tests/ext/commands/test_core.py
+++ b/tests/ext/commands/test_core.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
     # NOTE: using undocumented `expected_text` parameter of pyright instead of `assert_type`,
     # as `assert_type` can't handle bound ParamSpecs
+    #
     # sanity check: if `reveal_type` isn't working as intended,
     # the second `type: ignore` will be flagged
     reveal_type(


### PR DESCRIPTION
## Summary

Updates pyright from 1.1.245 to .254, and fixes the 27 new type-checking errors caused by the version bump.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
