### PR TITLE
fix!: raise `TypeError` instead of `ValueError` in scheduled events validation

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2110,6 +2110,10 @@ class Guild(Hashable):
 
         .. versionadded:: 2.3
 
+        .. versionchanged:: 2.6
+            Now raises :exc:`TypeError` instead of :exc:`ValueError` for
+            invalid parameter types.
+
         Parameters
         ----------
         name: :class:`str`
@@ -2146,7 +2150,9 @@ class Guild(Hashable):
         HTTPException
             The request failed.
         TypeError
-            The ``image`` asset is a lottie sticker (see :func:`Sticker.read`).
+            The ``image`` asset is a lottie sticker (see :func:`Sticker.read`),
+            or one of ``entity_type``, ``privacy_level``, or ``entity_metadata``
+            is not of the correct type.
 
         Returns
         -------
@@ -2154,12 +2160,12 @@ class Guild(Hashable):
             The newly created guild scheduled event.
         """
         if not isinstance(entity_type, GuildScheduledEventEntityType):
-            raise ValueError("entity_type must be an instance of GuildScheduledEventEntityType")
+            raise TypeError("entity_type must be an instance of GuildScheduledEventEntityType")
 
         if privacy_level is MISSING:
             privacy_level = GuildScheduledEventPrivacyLevel.guild_only
         elif not isinstance(privacy_level, GuildScheduledEventPrivacyLevel):
-            raise ValueError("privacy_level must be an instance of GuildScheduledEventPrivacyLevel")
+            raise TypeError("privacy_level must be an instance of GuildScheduledEventPrivacyLevel")
 
         fields: Dict[str, Any] = {
             "name": name,
@@ -2170,7 +2176,7 @@ class Guild(Hashable):
 
         if entity_metadata is not MISSING:
             if not isinstance(entity_metadata, GuildScheduledEventMetadata):
-                raise ValueError(
+                raise TypeError(
                     "entity_metadata must be an instance of GuildScheduledEventMetadata"
                 )
 

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -286,6 +286,10 @@ class GuildScheduledEvent(Hashable):
         - ``entity_metadata`` with a location field must be provided
         - ``scheduled_end_time`` must be provided
 
+        .. versionchanged:: 2.6
+            Now raises :exc:`TypeError` instead of :exc:`ValueError` for
+            invalid parameter types.
+
         Parameters
         ----------
         name: :class:`str`
@@ -327,7 +331,9 @@ class GuildScheduledEvent(Hashable):
         HTTPException
             Editing the event failed.
         TypeError
-            The ``image`` asset is a lottie sticker (see :func:`Sticker.read`).
+            The ``image`` asset is a lottie sticker (see :func:`Sticker.read`),
+            or one of ``entity_type``, ``privacy_level``, ``entity_metadata`` or ``status``
+            is not of the correct type.
 
         Returns
         -------
@@ -342,7 +348,7 @@ class GuildScheduledEvent(Hashable):
 
         if privacy_level is not MISSING:
             if not isinstance(privacy_level, GuildScheduledEventPrivacyLevel):
-                raise ValueError(
+                raise TypeError(
                     "privacy_level must be an instance of GuildScheduledEventPrivacyLevel"
                 )
 
@@ -350,7 +356,7 @@ class GuildScheduledEvent(Hashable):
 
         if entity_type is not MISSING:
             if not isinstance(entity_type, GuildScheduledEventEntityType):
-                raise ValueError("entity_type must be an instance of GuildScheduledEventEntityType")
+                raise TypeError("entity_type must be an instance of GuildScheduledEventEntityType")
 
             fields["entity_type"] = entity_type.value
 
@@ -365,13 +371,13 @@ class GuildScheduledEvent(Hashable):
                 fields["entity_metadata"] = entity_metadata.to_dict()
 
             else:
-                raise ValueError(
+                raise TypeError(
                     "entity_metadata must be an instance of GuildScheduledEventMetadata"
                 )
 
         if status is not MISSING:
             if not isinstance(status, GuildScheduledEventStatus):
-                raise ValueError("status must be an instance of GuildScheduledEventStatus")
+                raise TypeError("status must be an instance of GuildScheduledEventStatus")
 
             fields["status"] = status.value
 


### PR DESCRIPTION
## Summary

Replaces `ValueError`s used for invalid parameter types with `TypeError`s in `Guild.create_scheduled_event` and `GuildScheduledEvent.edit`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
