### PR TITLE
feat: add `GuildScheduledEvent.created_at` and `.url` properties

### DIFF
--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -195,7 +195,7 @@ class GuildScheduledEvent(Hashable):
         )
         self.entity_id: Optional[int] = _get_as_snowflake(data, "entity_id")
 
-        metadata = data["entity_metadata"]
+        metadata = data.get("entity_metadata")
         self.entity_metadata: Optional[GuildScheduledEventMetadata] = (
             None if metadata is None else GuildScheduledEventMetadata.from_dict(metadata)
         )
@@ -204,10 +204,8 @@ class GuildScheduledEvent(Hashable):
         self.creator: Optional[User]
         if creator_data is not None:
             self.creator = self._state.create_user(creator_data)
-        elif self.creator_id is not None:
-            self.creator = self._state.get_user(self.creator_id)
         else:
-            self.creator = None
+            self.creator = self._state.get_user(self.creator_id)
 
         self.user_count: Optional[int] = data.get("user_count")
         self._image: Optional[str] = data.get("image")

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -121,7 +121,7 @@ class GuildScheduledEvent(Hashable):
         The guild ID which the guild scheduled event belongs to.
     channel_id: Optional[:class:`int`]
         The channel ID in which the guild scheduled event will be hosted.
-        This field is ``None`` if :attr:`entity_type` is :class:`GuildScheduledEventEntityType.external`
+        This field is ``None`` if :attr:`entity_type` is :class:`GuildScheduledEventEntityType.external`.
     creator_id: Optional[:class:`int`]
         The ID of the user that created the guild scheduled event.
         This field is ``None`` for events created before October 25th, 2021.
@@ -133,7 +133,7 @@ class GuildScheduledEvent(Hashable):
     description: :class:`str`
         The description of the guild scheduled event (1-1000 characters).
     scheduled_start_time: :class:`datetime.datetime`
-        The time when the guild scheduled event will start
+        The time when the guild scheduled event will start.
     scheduled_end_time: Optional[:class:`datetime.datetime`]
         The time when the guild scheduled event will end, or ``None`` if the event does not have a scheduled time to end.
     privacy_level: :class:`GuildScheduledEventPrivacyLevel`
@@ -249,7 +249,10 @@ class GuildScheduledEvent(Hashable):
 
     @cached_slot_property("_cs_channel")
     def channel(self) -> Optional[GuildChannel]:
-        """Optional[:class:`abc.GuildChannel`]: The channel in which the guild scheduled event will be hosted."""
+        """Optional[:class:`abc.GuildChannel`]: The channel in which the guild scheduled event will be hosted.
+
+        This will be ``None`` if :attr:`entity_type` is :class:`GuildScheduledEventEntityType.external`.
+        """
         if self.channel_id is None:
             return None
         guild = self.guild

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -41,6 +41,7 @@ from .utils import (
     _get_as_snowflake,
     cached_slot_property,
     parse_time,
+    snowflake_time,
 )
 
 if TYPE_CHECKING:
@@ -224,6 +225,22 @@ class GuildScheduledEvent(Hashable):
 
     def __str__(self) -> str:
         return self.name
+
+    @property
+    def created_at(self) -> datetime:
+        """:class:`datetime.datetime`: Returns the guild scheduled event's creation time in UTC.
+
+        .. versionadded:: 2.6
+        """
+        return snowflake_time(self.id)
+
+    @property
+    def url(self) -> str:
+        """:class:`str`: The guild scheduled event's URL.
+
+        .. versionadded:: 2.6
+        """
+        return f"https://discord.com/events/{self.guild_id}/{self.id}"
 
     @cached_slot_property("_cs_guild")
     def guild(self) -> Optional[Guild]:


### PR DESCRIPTION
## Summary

Adds `GuildScheduledEvent.created_at` and `.url`, and addresses some minor documentation issues.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
