### PR TITLE
typing: update command decorators, fix item typevar bounds

### DIFF
--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -26,19 +26,7 @@ import asyncio
 import datetime
 import functools
 from abc import ABC
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Coroutine,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 
 from disnake.app_commands import ApplicationCommand
 from disnake.enums import ApplicationCommandType
@@ -53,7 +41,7 @@ if TYPE_CHECKING:
 
     from disnake.interactions import ApplicationCommandInteraction
 
-    from ._types import Check, Error, Hook
+    from ._types import Check, Coro, Error, Hook
     from .cog import Cog, CogT
 
     ApplicationCommandInteractionT = TypeVar(
@@ -62,10 +50,10 @@ if TYPE_CHECKING:
 
     P = ParamSpec("P")
 
-    CommandCallback = Callable[..., Coroutine]
+    CommandCallback = Callable[..., Coro[Any]]
     InteractionCommandCallback = Union[
-        Callable[Concatenate[CogT, ApplicationCommandInteractionT, P], Coroutine],
-        Callable[Concatenate[ApplicationCommandInteractionT, P], Coroutine],
+        Callable[Concatenate[CogT, ApplicationCommandInteractionT, P], Coro[Any]],
+        Callable[Concatenate[ApplicationCommandInteractionT, P], Coro[Any]],
     ]
 
 

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -62,12 +62,20 @@ from .errors import CommandRegistrationError
 from .slash_core import InvokableSlashCommand, SubCommand, SubCommandGroup, slash_command
 
 if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
     from disnake.i18n import LocalizedOptional
-    from disnake.interactions import ApplicationCommandInteraction
+    from disnake.interactions import (
+        ApplicationCommandInteraction,
+        MessageCommandInteraction,
+        UserCommandInteraction,
+    )
     from disnake.permissions import Permissions
 
     from ._types import Check, CoroFunc
-    from .base_core import CommandCallback, InteractionCommandCallback
+    from .base_core import CogT, CommandCallback, InteractionCommandCallback
+
+    P = ParamSpec("P")
 
 
 __all__ = ("InteractionBotBase",)
@@ -526,7 +534,9 @@ class InteractionBotBase(CommonBotBase):
         auto_sync: bool = None,
         extras: Dict[str, Any] = None,
         **kwargs,
-    ) -> Callable[[InteractionCommandCallback], InvokableUserCommand]:
+    ) -> Callable[
+        [InteractionCommandCallback[CogT, UserCommandInteraction, P]], InvokableUserCommand
+    ]:
         """A shortcut decorator that invokes :func:`.user_command` and adds it to
         the internal command list.
 
@@ -566,7 +576,9 @@ class InteractionBotBase(CommonBotBase):
             A decorator that converts the provided method into an InvokableUserCommand, adds it to the bot, then returns it.
         """
 
-        def decorator(func: InteractionCommandCallback) -> InvokableUserCommand:
+        def decorator(
+            func: InteractionCommandCallback[CogT, UserCommandInteraction, P]
+        ) -> InvokableUserCommand:
             result = user_command(
                 name=name,
                 dm_permission=dm_permission,
@@ -591,7 +603,9 @@ class InteractionBotBase(CommonBotBase):
         auto_sync: bool = None,
         extras: Dict[str, Any] = None,
         **kwargs,
-    ) -> Callable[[InteractionCommandCallback], InvokableMessageCommand]:
+    ) -> Callable[
+        [InteractionCommandCallback[CogT, MessageCommandInteraction, P]], InvokableMessageCommand
+    ]:
         """A shortcut decorator that invokes :func:`.message_command` and adds it to
         the internal command list.
 
@@ -631,7 +645,9 @@ class InteractionBotBase(CommonBotBase):
             A decorator that converts the provided method into an InvokableMessageCommand, adds it to the bot, then returns it.
         """
 
-        def decorator(func: InteractionCommandCallback) -> InvokableMessageCommand:
+        def decorator(
+            func: InteractionCommandCallback[CogT, MessageCommandInteraction, P]
+        ) -> InvokableMessageCommand:
             result = message_command(
                 name=name,
                 dm_permission=dm_permission,

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -287,8 +287,10 @@ class ParamInfo:
 
     Parameters
     ----------
-    default: Any
+    default: Union[Any, Callable[[:class:`CommandInteraction`], Any]]
         The actual default value for the corresponding function param.
+        Can be a sync/async callable taking an interaction and returning a dynamic default value,
+        if the user didn't pass a value for this parameter.
     name: Optional[Union[:class:`str`, :class:`.Localized`]]
         The name of this slash command option.
 
@@ -339,7 +341,7 @@ class ParamInfo:
 
     def __init__(
         self,
-        default: Any = ...,
+        default: Union[Any, Callable[[CommandInteraction], Any]] = ...,
         *,
         name: LocalizedOptional = None,
         description: LocalizedOptional = None,
@@ -847,7 +849,7 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
 
 
 def Param(
-    default: Any = ...,
+    default: Union[Any, Callable[[CommandInteraction], Any]] = ...,
     *,
     name: LocalizedOptional = None,
     description: LocalizedOptional = None,
@@ -870,8 +872,10 @@ def Param(
 
     Parameters
     ----------
-    default: Any
+    default: Union[Any, Callable[[:class:`CommandInteraction`], Any]]
         The actual default value of the function parameter that should be passed instead of the :class:`ParamInfo` instance.
+        Can be a sync/async callable taking an interaction and returning a dynamic default value,
+        if the user didn't pass a value for this parameter.
     name: Optional[Union[:class:`str`, :class:`.Localized`]]
         The name of the option. By default, the option name is the parameter name.
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -56,7 +56,7 @@ from disnake.channel import _channel_type_factory
 from disnake.enums import ChannelType, OptionType, try_enum_to_int
 from disnake.ext import commands
 from disnake.i18n import Localized
-from disnake.interactions import CommandInteraction
+from disnake.interactions import ApplicationCommandInteraction
 from disnake.utils import maybe_coroutine
 
 from . import errors
@@ -287,7 +287,7 @@ class ParamInfo:
 
     Parameters
     ----------
-    default: Union[Any, Callable[[:class:`CommandInteraction`], Any]]
+    default: Union[Any, Callable[[:class:`.ApplicationCommandInteraction`], Any]]
         The actual default value for the corresponding function param.
         Can be a sync/async callable taking an interaction and returning a dynamic default value,
         if the user didn't pass a value for this parameter.
@@ -341,13 +341,13 @@ class ParamInfo:
 
     def __init__(
         self,
-        default: Union[Any, Callable[[CommandInteraction], Any]] = ...,
+        default: Union[Any, Callable[[ApplicationCommandInteraction], Any]] = ...,
         *,
         name: LocalizedOptional = None,
         description: LocalizedOptional = None,
-        converter: Callable[[CommandInteraction, Any], Any] = None,
+        converter: Callable[[ApplicationCommandInteraction, Any], Any] = None,
         convert_default: bool = False,
-        autcomplete: Callable[[CommandInteraction, str], Any] = None,
+        autcomplete: Callable[[ApplicationCommandInteraction, str], Any] = None,
         choices: Choices = None,
         type: type = None,
         channel_types: List[ChannelType] = None,
@@ -428,7 +428,7 @@ class ParamInfo:
         args = ", ".join(f"{k}={'...' if v is ... else repr(v)}" for k, v in vars(self).items())
         return f"{type(self).__name__}({args})"
 
-    async def get_default(self, inter: CommandInteraction) -> Any:
+    async def get_default(self, inter: ApplicationCommandInteraction) -> Any:
         """Gets the default for an interaction"""
         default = self.default
         if callable(self.default):
@@ -442,7 +442,7 @@ class ParamInfo:
 
         return default
 
-    async def verify_type(self, inter: CommandInteraction, argument: Any) -> Any:
+    async def verify_type(self, inter: ApplicationCommandInteraction, argument: Any) -> Any:
         """Check if a type of an argument is correct and possibly fix it"""
         if issubclass_(self.type, disnake.Member):
             if isinstance(argument, disnake.Member):
@@ -453,7 +453,7 @@ class ParamInfo:
         # unexpected types may just be ignored
         return argument
 
-    async def convert_argument(self, inter: CommandInteraction, argument: Any) -> Any:
+    async def convert_argument(self, inter: ApplicationCommandInteraction, argument: Any) -> Any:
         """Convert a value if a converter is given"""
         if self.large:
             try:
@@ -691,7 +691,7 @@ def isolate_self(
         parametersl.pop(0)
     if parametersl:
         annot = parametersl[0].annotation
-        if issubclass_(annot, CommandInteraction) or annot is inspect.Parameter.empty:
+        if issubclass_(annot, ApplicationCommandInteraction) or annot is inspect.Parameter.empty:
             inter_param = parameters.pop(parametersl[0].name)
 
     return (cog_param, inter_param), parameters
@@ -721,7 +721,7 @@ def collect_params(
             injections[parameter.name] = default
         elif parameter.annotation in Injection._registered:
             injections[parameter.name] = Injection._registered[parameter.annotation]
-        elif issubclass_(parameter.annotation, CommandInteraction):
+        elif issubclass_(parameter.annotation, ApplicationCommandInteraction):
             if inter_param is None:
                 inter_param = parameter
             else:
@@ -760,7 +760,7 @@ def collect_nested_params(function: Callable) -> List[ParamInfo]:
 
 
 def format_kwargs(
-    interaction: CommandInteraction,
+    interaction: ApplicationCommandInteraction,
     cog_param: str = None,
     inter_param: str = None,
     /,
@@ -788,7 +788,11 @@ def format_kwargs(
 
 
 async def run_injections(
-    injections: Dict[str, Injection], interaction: CommandInteraction, /, *args: Any, **kwargs: Any
+    injections: Dict[str, Injection],
+    interaction: ApplicationCommandInteraction,
+    /,
+    *args: Any,
+    **kwargs: Any,
 ) -> Dict[str, Any]:
     """Run and resolve a list of injections"""
 
@@ -800,7 +804,7 @@ async def run_injections(
 
 
 async def call_param_func(
-    function: Callable, interaction: CommandInteraction, /, *args: Any, **kwargs: Any
+    function: Callable, interaction: ApplicationCommandInteraction, /, *args: Any, **kwargs: Any
 ) -> Any:
     """Call a function utilizing ParamInfo"""
     cog_param, inter_param, paraminfos, injections = collect_params(function)
@@ -849,14 +853,14 @@ def expand_params(command: AnySlashCommand) -> List[Option]:
 
 
 def Param(
-    default: Union[Any, Callable[[CommandInteraction], Any]] = ...,
+    default: Union[Any, Callable[[ApplicationCommandInteraction], Any]] = ...,
     *,
     name: LocalizedOptional = None,
     description: LocalizedOptional = None,
     choices: Choices = None,
-    converter: Callable[[CommandInteraction, Any], Any] = None,
+    converter: Callable[[ApplicationCommandInteraction, Any], Any] = None,
     convert_defaults: bool = False,
-    autocomplete: Callable[[CommandInteraction, str], Any] = None,
+    autocomplete: Callable[[ApplicationCommandInteraction, str], Any] = None,
     channel_types: List[ChannelType] = None,
     lt: float = None,
     le: float = None,
@@ -872,7 +876,7 @@ def Param(
 
     Parameters
     ----------
-    default: Union[Any, Callable[[:class:`CommandInteraction`], Any]]
+    default: Union[Any, Callable[[:class:`.ApplicationCommandInteraction`], Any]]
         The actual default value of the function parameter that should be passed instead of the :class:`ParamInfo` instance.
         Can be a sync/async callable taking an interaction and returning a dynamic default value,
         if the user didn't pass a value for this parameter.

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from .view import View
 
 B = TypeVar("B", bound="Button")
-V = TypeVar("V", "View", None, covariant=True)
+V = TypeVar("V", bound="Optional[View]", covariant=True)
 
 
 class Button(Item[V]):

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -43,7 +43,7 @@ from typing import (
 __all__ = ("Item", "WrappedComponent")
 
 I = TypeVar("I", bound="Item")
-V = TypeVar("V", "View", None, covariant=True)
+V = TypeVar("V", bound="Optional[View]", covariant=True)
 
 if TYPE_CHECKING:
     from ..components import NestedComponent

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
     from .view import View
 
 S = TypeVar("S", bound="Select")
-V = TypeVar("V", "View", None, covariant=True)
+V = TypeVar("V", bound="Optional[View]", covariant=True)
 
 
 def _parse_select_options(


### PR DESCRIPTION
## Summary

- Add generic parameters to user/message command decorators in `InteractionBotBase`, similar to #514
- Update `Param` default parameter type to improve compatibility with callable/dynamic defaults
- Fix view typevar in ui items by using `Optional[View]` bound instead of `View, None` constraints

some changes were originally part of #519, but now split to avoid additional scope creep

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
