### PR TITLE
fix: handle `default_auto_archive_duration` enum value in channel edits

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -343,6 +343,17 @@ class GuildChannel(ABC):
         else:
             options["video_quality_mode"] = int(video_quality_mode)
 
+        try:
+            default_auto_archive_duration = options.pop("default_auto_archive_duration")
+        except KeyError:
+            pass
+        else:
+            options["default_auto_archive_duration"] = (
+                int(default_auto_archive_duration)
+                if default_auto_archive_duration is not None
+                else None
+            )
+
         lock_permissions = options.pop("sync_permissions", False)
 
         try:

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -690,6 +690,9 @@ class ThreadArchiveDuration(Enum):
     three_days = 4320
     week = 10080
 
+    def __int__(self):
+        return self.value
+
 
 class WidgetStyle(Enum):
     shield = "shield"


### PR DESCRIPTION
## Summary

Fixes `channel.edit(default_auto_archive_duration=ThreadArchiveDuration.hour)` which should be supported according to type hints but instead resulted in `TypeError: Type is not JSON serializable: _EnumValueBase_ThreadArchiveDuration`

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
