### PR TITLE
fix: update identify properties

### DIFF
--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -498,9 +498,9 @@ class DiscordWebSocket:
             "d": {
                 "token": self.token,
                 "properties": {
-                    "$os": sys.platform,
-                    "$browser": "disnake",
-                    "$device": "disnake",
+                    "os": sys.platform,
+                    "browser": "disnake",
+                    "device": "disnake",
                 },
                 "compress": True,
                 "large_threshold": 250,

--- a/disnake/types/gateway.py
+++ b/disnake/types/gateway.py
@@ -70,14 +70,11 @@ class HeartbeatCommand(TypedDict):
 
 # opcode 2
 
-IdentifyProperties = TypedDict(
-    "IdentifyProperties",
-    {
-        "$os": str,
-        "$browser": str,
-        "$device": str,
-    },
-)
+
+class IdentifyProperties(TypedDict):
+    os: str
+    browser: str
+    device: str
 
 
 class _IdentifyDataOptional(TypedDict, total=False):


### PR DESCRIPTION
## Summary

Removes the `$` prefix from ws identify properties. The old field names still work, but are deprecated.

ref: https://github.com/discord/discord-api-docs/pull/5058

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
