### PR TITLE
docs: make guild invite documentation clearer regarding vanity invites

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3523,6 +3523,11 @@ class Guild(Hashable):
             Whether to use the cached :attr:`Guild.vanity_url_code`
             and attempt to convert it into a full invite.
 
+            .. note::
+
+                If set to ``True``, the :attr:`Invite.uses`
+                information will not be accurate.
+
             .. versionadded:: 2.5
 
         Raises

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2751,6 +2751,12 @@ class Guild(Hashable):
         -------
         List[:class:`Invite`]
             The list of invites that are currently active.
+
+
+        .. note::
+
+            This method does not include the Guild's vanity URL.
+            To get the vanity URL :class:`Invite`, refer to :meth:`Guild.vanity_invite`.
         """
         data = await self._state.http.invites_from(self.id)
         result = []

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2740,6 +2740,11 @@ class Guild(Hashable):
         You must have :attr:`~Permissions.manage_guild` permission to
         use this.
 
+        .. note::
+
+            This method does not include the guild's vanity URL invite.
+            To get the vanity URL :class:`Invite`, refer to :meth:`Guild.vanity_invite`.
+
         Raises
         ------
         Forbidden
@@ -2751,12 +2756,6 @@ class Guild(Hashable):
         -------
         List[:class:`Invite`]
             The list of invites that are currently active.
-
-
-        .. note::
-
-            This method does not include the guild's vanity URL invite.
-            To get the vanity URL :class:`Invite`, refer to :meth:`Guild.vanity_invite`.
         """
         data = await self._state.http.invites_from(self.id)
         result = []

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2755,7 +2755,7 @@ class Guild(Hashable):
 
         .. note::
 
-            This method does not include the Guild's vanity URL.
+            This method does not include the guild's vanity URL invite.
             To get the vanity URL :class:`Invite`, refer to :meth:`Guild.vanity_invite`.
         """
         data = await self._state.http.invites_from(self.id)


### PR DESCRIPTION
## Summary

Currently ``Guild.invites`` is unclear as to whether or not it also returns the Guilds vanity invite in applicable guilds, this PR aims to clear that up.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
