### PR TITLE
typing: improve component annotations

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1553,7 +1553,7 @@ class Messageable:
                     allowed_mentions=allowed_mentions_payload,
                     message_reference=reference_payload,
                     stickers=stickers_payload,
-                    components=components_payload,  # type: ignore
+                    components=components_payload,
                     flags=flags,
                 )
             finally:
@@ -1569,7 +1569,7 @@ class Messageable:
                 allowed_mentions=allowed_mentions_payload,
                 message_reference=reference_payload,
                 stickers=stickers_payload,
-                components=components_payload,  # type: ignore
+                components=components_payload,
                 flags=flags,
             )
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -554,7 +554,7 @@ class HTTPClient:
         allowed_mentions: Optional[message.AllowedMentions] = None,
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[Sequence[Snowflake]] = None,
-        components: Optional[List[components.Component]] = None,
+        components: Optional[Sequence[components.Component]] = None,
         flags: Optional[int] = None,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
@@ -608,7 +608,7 @@ class HTTPClient:
         allowed_mentions: Optional[message.AllowedMentions] = None,
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[Sequence[Snowflake]] = None,
-        components: Optional[List[components.Component]] = None,
+        components: Optional[Sequence[components.Component]] = None,
         flags: Optional[int] = None,
     ) -> Response[message.Message]:
         payload: Dict[str, Any] = {"tts": tts}
@@ -648,7 +648,7 @@ class HTTPClient:
         allowed_mentions: Optional[message.AllowedMentions] = None,
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[Sequence[Snowflake]] = None,
-        components: Optional[List[components.Component]] = None,
+        components: Optional[Sequence[components.Component]] = None,
         flags: Optional[int] = None,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -116,7 +116,7 @@ class Item(WrappedComponent, Generic[V]):
         ...
 
     def __init__(self):
-        self._view: Optional[V] = None
+        self._view: V = None
         self._row: Optional[int] = None
         self._rendered_row: Optional[int] = None
         # This works mostly well but there is a gotcha with
@@ -157,7 +157,7 @@ class Item(WrappedComponent, Generic[V]):
             raise ValueError("row cannot be negative or greater than or equal to 5")
 
     @property
-    def view(self) -> Optional[V]:
+    def view(self) -> V:
         """Optional[:class:`View`]: The underlying view for this item."""
         return self._view
 

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -34,7 +34,6 @@ from functools import partial
 from itertools import groupby
 from typing import (
     TYPE_CHECKING,
-    Any,
     Callable,
     ClassVar,
     Dict,
@@ -63,7 +62,7 @@ if TYPE_CHECKING:
     from ..interactions import MessageInteraction
     from ..message import Message
     from ..state import ConnectionState
-    from ..types.components import Component as ComponentPayload
+    from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
     from .item import ItemCallbackType
 
 
@@ -205,12 +204,12 @@ class View:
             # Wait N seconds to see if timeout data has been refreshed
             await asyncio.sleep(self.__timeout_expiry - now)
 
-    def to_components(self) -> List[Dict[str, Any]]:
+    def to_components(self) -> List[ActionRowPayload]:
         def key(item: Item) -> int:
             return item._rendered_row or 0
 
         children = sorted(self.children, key=key)
-        components: List[Dict[str, Any]] = []
+        components: List[ActionRowPayload] = []
         for _, group in groupby(children, key=key):
             children = [item.to_component_dict() for item in group]
             if not children:


### PR DESCRIPTION
## Summary

- update `View.to_components()` typing to return `ActionRowPayload` instead of generic `Dict[str, Any]`
- change `components` parameter in http methods to be covariant container type instead of invariant list
- use `V` instead of `Optional[V]` for item view types, see https://canary.discord.com/channels/808030843078836254/913779868985090089/988554297123938384

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
