### PR TITLE
fix!: improve interaction component typings

### DIFF
--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -38,7 +38,7 @@ __all__ = (
 if TYPE_CHECKING:
     from ..state import ConnectionState
     from ..types.interactions import (
-        ComponentInteractionData as ComponentInteractionDataPayload,
+        MessageComponentInteractionData as MessageComponentInteractionDataPayload,
         MessageInteraction as MessageInteractionPayload,
     )
 
@@ -130,7 +130,7 @@ class MessageInteractionData(Dict[str, Any]):
 
     __slots__ = ("custom_id", "component_type", "values")
 
-    def __init__(self, *, data: ComponentInteractionDataPayload):
+    def __init__(self, *, data: MessageComponentInteractionDataPayload):
         super().__init__(data)
         self.custom_id: str = data["custom_id"]
         self.component_type: ComponentType = try_enum(ComponentType, data["component_type"])

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -107,6 +107,8 @@ class ModalInteraction(Interaction):
         """
         Returns a generator that yields raw component data from action rows one by one.
 
+        .. versionadded:: 2.6
+
         Returns
         -------
         Generator[:class:`dict`, None, None]
@@ -142,6 +144,8 @@ class ModalInteractionData(Dict[str, Any]):
         The custom ID of the modal.
     components: List[:class:`dict`]
         The raw component data of the modal interaction.
+
+        .. versionadded:: 2.6
     """
 
     __slots__ = ("custom_id", "components")

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -103,7 +103,7 @@ class ModalInteraction(Interaction):
             message = None
         self.message: Optional[Message] = message
 
-    def walk_component_data(self) -> Generator[ModalInteractionComponentDataPayload, None, None]:
+    def walk_raw_components(self) -> Generator[ModalInteractionComponentDataPayload, None, None]:
         """
         Returns a generator that yields raw component data from action rows one by one, as provided by Discord.
         This does not contain all fields of the components due to API limitations.
@@ -124,7 +124,7 @@ class ModalInteraction(Interaction):
         text_input_type = ComponentType.text_input.value
         return {
             component["custom_id"]: component.get("value") or ""
-            for component in self.walk_component_data()
+            for component in self.walk_raw_components()
             if component.get("type") == text_input_type
         }
 

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -105,7 +105,8 @@ class ModalInteraction(Interaction):
 
     def walk_component_data(self) -> Generator[ModalInteractionComponentDataPayload, None, None]:
         """
-        Returns a generator that yields raw component data from action rows one by one.
+        Returns a generator that yields raw component data from action rows one by one, as provided by Discord.
+        This does not contain all fields of the components due to API limitations.
 
         .. versionadded:: 2.6
 
@@ -143,7 +144,8 @@ class ModalInteractionData(Dict[str, Any]):
     custom_id: :class:`str`
         The custom ID of the modal.
     components: List[:class:`dict`]
-        The raw component data of the modal interaction.
+        The raw component data of the modal interaction, as provided by Discord.
+        This does not contain all fields of the components due to API limitations.
 
         .. versionadded:: 2.6
     """
@@ -153,6 +155,9 @@ class ModalInteractionData(Dict[str, Any]):
     def __init__(self, *, data: ModalInteractionDataPayload):
         super().__init__(data)
         self.custom_id: str = data["custom_id"]
+        # This uses a stripped-down action row TypedDict, as we only receive
+        # partial data from the API, generally only containing `type`, `custom_id`,
+        # and relevant fields like a select's `values`.
         self.components: List[ModalInteractionActionRowPayload] = data["components"]
 
     def __repr__(self):

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Union
 
 from .channel import ChannelType
-from .components import ActionRow, Component, ComponentType, Modal
+from .components import Component, Modal
 from .embed import Embed
 from .member import Member, MemberWithUser
 from .role import Role
@@ -188,22 +188,67 @@ class ApplicationCommandInteractionData(_ApplicationCommandInteractionDataOption
     type: ApplicationCommandType
 
 
-class _ComponentInteractionDataOptional(TypedDict, total=False):
+## Interaction components
+
+
+class _BaseComponentInteractionData(TypedDict):
+    custom_id: str
+
+
+### Message interaction components
+
+
+class MessageComponentInteractionButtonData(_BaseComponentInteractionData):
+    component_type: Literal[2]
+
+
+class MessageComponentInteractionSelectData(_BaseComponentInteractionData):
+    component_type: Literal[3]
     values: List[str]
 
 
-class ComponentInteractionData(_ComponentInteractionDataOptional):
-    custom_id: str
-    component_type: ComponentType
+MessageComponentInteractionData = Union[
+    MessageComponentInteractionButtonData,
+    MessageComponentInteractionSelectData,
+]
+
+
+### Modal interaction components
+
+
+class ModalInteractionSelectData(_BaseComponentInteractionData):
+    type: Literal[3]
+    values: List[str]
+
+
+class ModalInteractionTextInputData(_BaseComponentInteractionData):
+    type: Literal[4]
+    value: str
+
+
+ModalInteractionComponentData = Union[
+    ModalInteractionSelectData,
+    ModalInteractionTextInputData,
+]
+
+
+class ModalInteractionActionRow(TypedDict):
+    type: Literal[1]
+    components: List[ModalInteractionComponentData]
 
 
 class ModalInteractionData(TypedDict):
     custom_id: str
-    components: List[ActionRow]
+    components: List[ModalInteractionActionRow]
+
+
+## Interactions
 
 
 InteractionData = Union[
-    ApplicationCommandInteractionData, ComponentInteractionData, ModalInteractionData
+    ApplicationCommandInteractionData,
+    MessageComponentInteractionData,
+    ModalInteractionData,
 ]
 
 
@@ -236,7 +281,7 @@ class ApplicationCommandInteraction(Interaction):
 
 
 class MessageInteraction(Interaction):
-    data: ComponentInteractionData
+    data: MessageComponentInteractionData
     message: Message
 
 


### PR DESCRIPTION
## Summary

Refactors modal interaction component typings which previously used full `ActionRow` types instead of partial types like the ones that are actually received in interactions.
`ModalInteractionData.[_]components` is now no longer a `List[ActionRow]` with mostly empty components, and instead just the raw data dict from the interaction, which avoids discarding currently unused data (like select values). This is unfortunately a breaking change, but necessary as the old typing was mostly wrong and could've resulted in issues with component parsing code due to missing fields.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
    - *renamed `_components` to `components`, changed type*
    - *renamed `walk_components` to `walk_raw_components`*
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
