### PR TITLE
fix: correctly handle unions in `verify_type`

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -43,7 +43,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
     get_args,
     get_origin,
     get_type_hints,
@@ -114,8 +113,6 @@ def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[Type
 def remove_optionals(annotation: Any) -> Any:
     """remove unwanted optionals from an annotation"""
     if get_origin(annotation) in (Union, UnionType):
-        annotation = cast(Any, annotation)
-
         args = tuple(i for i in annotation.__args__ if i not in (None, type(None)))
         if len(args) == 1:
             annotation = args[0]

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -36,6 +36,8 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Final,
+    FrozenSet,
     List,
     Literal,
     Optional,
@@ -277,6 +279,10 @@ class LargeInt(int):
     """Type for large integers in slash commands."""
 
 
+# option types that require additional handling in verify_type
+_VERIFY_TYPES: Final[FrozenSet[OptionType]] = frozenset((OptionType.user, OptionType.mentionable))
+
+
 class ParamInfo:
     """A class that basically connects function params with slash command options.
     The instances of this class are not created manually, but via the functional interface instead.
@@ -441,8 +447,7 @@ class ParamInfo:
 
     async def verify_type(self, inter: ApplicationCommandInteraction, argument: Any) -> Any:
         """Check if the type of an argument is correct and possibly raise if it's not."""
-        if self.discord_type.value not in (6, 9):
-            # not `user` or `mentionable`
+        if self.discord_type not in _VERIFY_TYPES:
             return argument
 
         # The API may return a `User` for options annotated with `Member`,

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -440,7 +440,7 @@ class ParamInfo:
         return default
 
     async def verify_type(self, inter: ApplicationCommandInteraction, argument: Any) -> Any:
-        """Check if the type of an argument is correct and possibly raise if it's not"""
+        """Check if the type of an argument is correct and possibly raise if it's not."""
         if self.discord_type.value not in (6, 9):
             # not `user` or `mentionable`
             return argument

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -441,6 +441,9 @@ class ParamInfo:
 
     async def verify_type(self, inter: ApplicationCommandInteraction, argument: Any) -> Any:
         """Check if the type of an argument is correct and possibly raise if it's not"""
+        if self.discord_type.value not in (6, 9):
+            # not `user` or `mentionable`
+            return argument
 
         # The API may return a `User` for options annotated with `Member`,
         # including `Member` (user option), `Union[User, Member]` (user option) and
@@ -453,8 +456,6 @@ class ParamInfo:
         ):
             raise errors.MemberNotFound(str(argument.id))
 
-        # Other argument types are assumed to match the specified option type,
-        # thanks to server-side validation.
         return argument
 
     async def convert_argument(self, inter: ApplicationCommandInteraction, argument: Any) -> Any:

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -1,0 +1,61 @@
+from typing import Union
+from unittest import mock
+
+import pytest
+
+import disnake
+from disnake import Member, Role, User
+from disnake.ext import commands
+
+OptionType = disnake.OptionType
+
+
+class TestParamInfo:
+    @pytest.mark.parametrize(
+        ("annotation", "expected_type", "arg_types"),
+        [
+            # should accept user or member
+            (disnake.abc.User, OptionType.user, [User, Member]),
+            (User, OptionType.user, [User, Member]),
+            (Union[User, Member], OptionType.user, [User, Member]),
+            # only accepts member, not user
+            (Member, OptionType.user, [Member]),
+            # only accepts role
+            (Role, OptionType.role, [Role]),
+            # should accept member or role
+            (Union[Member, Role], OptionType.mentionable, [Member, Role]),
+            # should accept everything
+            (disnake.abc.Snowflake, OptionType.mentionable, [User, Member, Role]),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_verify_type(self, annotation, expected_type, arg_types) -> None:
+        # tests that the Discord option type is determined correctly,
+        # and that valid argument types are accepted
+        info = commands.ParamInfo()
+        info.parse_annotation(annotation)
+
+        # type should be valid
+        assert info.discord_type is expected_type
+
+        for arg_type in arg_types:
+            arg_mock = mock.Mock(arg_type)
+            assert await info.verify_type(mock.Mock(), arg_mock) is arg_mock
+
+    @pytest.mark.parametrize(
+        ("annotation", "arg_types"),
+        [
+            (Member, [User]),
+            (Union[Member, Role], [User]),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_verify_type__invalid_member(self, annotation, arg_types) -> None:
+        # tests that invalid argument types result in `verify_type` raising an exception
+        info = commands.ParamInfo()
+        info.parse_annotation(annotation)
+
+        for arg_type in arg_types:
+            arg_mock = mock.Mock(arg_type)
+            with pytest.raises(commands.errors.MemberNotFound):
+                await info.verify_type(mock.Mock(), arg_mock)


### PR DESCRIPTION
## Summary

Fixes #577.

An annotation like `Union[User, Member]` passes the `issubclass_(self.type, disnake.Member)` check since `issubclass_` explicitly handles unions; the following `isinstance(argument, disnake.Member)` check did not accept `User` objects, even though they should've been permitted based on the annotation type.
This PR improves the validation logic to correctly handle cases like this as well.

Regression from #283 - third test case of `test_verify_type` checks for this particular one.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
