### PR TITLE
fix: base allowed mentions off of the current message when editing

### DIFF
--- a/disnake/message.py
+++ b/disnake/message.py
@@ -56,6 +56,7 @@ from .file import File
 from .flags import MessageFlags
 from .guild import Guild
 from .member import Member
+from .mentions import AllowedMentions
 from .mixins import Hashable
 from .partial_emoji import PartialEmoji
 from .reaction import Reaction
@@ -69,7 +70,6 @@ if TYPE_CHECKING:
     from .abc import GuildChannel, MessageableChannel, Snowflake
     from .channel import DMChannel
     from .guild import GuildMessageable
-    from .mentions import AllowedMentions
     from .role import Role
     from .state import ConnectionState
     from .threads import AnyThreadArchiveDuration
@@ -1592,8 +1592,13 @@ class Message(Hashable):
             The message that was edited.
         """
         # allowed_mentions can only be changed on the bot's own messages
-        if self._state.allowed_mentions is not None and self.author.id == self._state.self_id:
-            previous_allowed_mentions = self._state.allowed_mentions
+        if self.author.id == self._state.self_id:
+            # make a custom allowed mentions based on the current message state
+            previous_allowed_mentions = AllowedMentions(
+                everyone=self.mention_everyone,
+                users=self.mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
+                roles=self.role_mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
+            )
         else:
             previous_allowed_mentions = None
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

When editing a message that we have the current contents for, we can use the mentions provided by Discord to know what the allowed mentions were when sending the message.

closes #573, although the inherent request of #573 is still a Discord limitation.

Previously, using `Message.edit` would use the state's `allowed_mentions` attribute, which may or may not match the overridden mentions when sending the message. This changes that to use the processed mentions by Discord if we have them provided. 

(this example requires the bot to have `everyone=True` on its `AllowedMentions` object)
For example, the below code would show as a mention once edited (provided the author has permissions) but this change will make the mentions persist.
```py
message = await ctx.send('@everyone', allowed_mentions=disnake.AllowedMentions.none())
await message.edit(content='@here')
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
