### PR TITLE
feat: string option length limits

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -206,13 +206,13 @@ class Option:
         The minimum value permitted.
     max_value: Union[:class:`int`, :class:`float`]
         The maximum value permitted.
-    min_length: Optional[:class:`str`]
-        The minimum length for this option if the type of this Option is :attr:`OptionType.string`.
+    min_length: :class:`int`
+        The minimum length for this option if this is a string option.
 
         .. versionadded:: 2.6
 
-    max_length: Optional[:class:`str`]
-        The maximum length for this option if the type of this Option is :attr:`OptionType.string`.
+    max_length: :class:`int`
+        The maxmium length for this option if this is a string option.
 
         .. versionadded:: 2.6
     """

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -212,7 +212,7 @@ class Option:
         .. versionadded:: 2.6
 
     max_length: :class:`int`
-        The maxmium length for this option if this is a string option.
+        The maximum length for this option if this is a string option.
 
         .. versionadded:: 2.6
     """

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -206,6 +206,15 @@ class Option:
         The minimum value permitted.
     max_value: Union[:class:`int`, :class:`float`]
         The maximum value permitted.
+    min_length: Optional[:class:`str`]
+        The minimum length for this option if the type of this Option is :attr:`OptionType.string`.
+
+        .. versionadded:: 2.6
+
+    max_length: Optional[:class:`str`]
+        The maximum length for this option if the type of this Option is :attr:`OptionType.string`.
+
+        .. versionadded:: 2.6
     """
 
     __slots__ = (
@@ -221,6 +230,8 @@ class Option:
         "max_value",
         "name_localizations",
         "description_localizations",
+        "min_length",
+        "max_length",
     )
 
     def __init__(
@@ -235,6 +246,8 @@ class Option:
         autocomplete: bool = False,
         min_value: float = None,
         max_value: float = None,
+        min_length: int = None,
+        max_length: int = None,
     ):
         name_loc = Localized._cast(name, True)
         _validate_name(name_loc.string)
@@ -256,6 +269,9 @@ class Option:
 
         self.min_value: Optional[float] = min_value
         self.max_value: Optional[float] = max_value
+
+        self.min_length: Optional[int] = min_length
+        self.max_length: Optional[int] = max_length
 
         if channel_types is not None and not all(isinstance(t, ChannelType) for t in channel_types):
             raise TypeError("channel_types must be a list of `ChannelType`s")
@@ -298,6 +314,8 @@ class Option:
             and self.autocomplete == other.autocomplete
             and self.min_value == other.min_value
             and self.max_value == other.max_value
+            and self.min_length == other.min_length
+            and self.max_length == other.max_length
             and self.name_localizations == other.name_localizations
             and self.description_localizations == other.description_localizations
         )
@@ -323,6 +341,8 @@ class Option:
             autocomplete=data.get("autocomplete", False),
             min_value=data.get("min_value"),
             max_value=data.get("max_value"),
+            min_length=data.get("min_length"),
+            max_length=data.get("max_length"),
         )
 
     def add_choice(
@@ -352,6 +372,8 @@ class Option:
         autocomplete: bool = False,
         min_value: float = None,
         max_value: float = None,
+        min_length: int = None,
+        max_length: int = None,
     ) -> None:
         """Adds an option to the current list of options,
         parameters are the same as for :class:`Option`."""
@@ -368,6 +390,8 @@ class Option:
                 autocomplete=autocomplete,
                 min_value=min_value,
                 max_value=max_value,
+                min_length=min_length,
+                max_length=max_length,
             )
         )
 
@@ -391,6 +415,10 @@ class Option:
             payload["min_value"] = self.min_value
         if self.max_value is not None:
             payload["max_value"] = self.max_value
+        if self.min_length is not None:
+            payload["min_length"] = self.min_length
+        if self.max_length is not None:
+            payload["max_length"] = self.max_length
         if (loc := self.name_localizations.data) is not None:
             payload["name_localizations"] = loc
         if (loc := self.description_localizations.data) is not None:

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -299,7 +299,8 @@ class Option:
         return (
             f"<Option name={self.name!r} description={self.description!r}"
             f" type={self.type!r} required={self.required!r} choices={self.choices!r}"
-            f" options={self.options!r} min_value={self.min_value!r} max_value={self.max_value!r}>"
+            f" options={self.options!r} min_value={self.min_value!r} max_value={self.max_value!r}"
+            f" min_length={self.min_length!r} max_length={self.max_length!r}>"
         )
 
     def __eq__(self, other) -> bool:

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -826,6 +826,8 @@ class SlashCommand(ApplicationCommand):
         autocomplete: bool = False,
         min_value: float = None,
         max_value: float = None,
+        min_length: int = None,
+        max_length: int = None,
     ) -> None:
         """Adds an option to the current list of options,
         parameters are the same as for :class:`Option`
@@ -842,6 +844,8 @@ class SlashCommand(ApplicationCommand):
                 autocomplete=autocomplete,
                 min_value=min_value,
                 max_value=max_value,
+                min_length=min_length,
+                max_length=max_length,
             )
         )
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -320,6 +320,15 @@ class ParamInfo:
         The function that will suggest possible autocomplete options while typing.
     converter: Callable[[:class:`.ApplicationCommandInteraction`, Any], Any]
         The function that will convert the original input to a desired format.
+    min_length: :class:`str`
+        The minimum length allowed for this option.
+
+        .. versionadded:: 2.6
+
+    max_length: :class:`str`
+        The maximum length allowed for this option.
+
+        .. versionadded:: 2.6
     """
 
     TYPES: ClassVar[Dict[type, int]] = {
@@ -359,6 +368,8 @@ class ParamInfo:
         gt: float = None,
         ge: float = None,
         large: bool = False,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
     ) -> None:
         name_loc = Localized._cast(name, False)
         self.name: str = name_loc.string or ""
@@ -378,6 +389,8 @@ class ParamInfo:
         self.channel_types = channel_types or []
         self.max_value = _xt_to_xe(le, lt, -1)
         self.min_value = _xt_to_xe(ge, gt, 1)
+        self.min_length = min_length
+        self.max_length = max_length
         self.large = large
 
     @property
@@ -631,6 +644,8 @@ class ParamInfo:
             autocomplete=self.autocomplete is not None,
             min_value=self.min_value,
             max_value=self.max_value,
+            min_length=self.min_length,
+            max_length=self.max_length,
         )
 
 
@@ -877,6 +892,8 @@ def Param(
     gt: float = None,
     ge: float = None,
     large: bool = False,
+    min_length: int = None,
+    max_length: int = None,
     **kwargs: Any,
 ) -> Any:
     """A special function that creates an instance of :class:`ParamInfo` that contains some information about a
@@ -933,6 +950,16 @@ def Param(
 
         .. versionadded:: 2.3
 
+    min_length: :class:`str`
+        The minimum length this option can be if it is a string option.
+
+        .. versionadded:: 2.6
+
+    max_length: :class:`str`
+        The maximum length this option can be if it is a string option.
+
+        .. versionadded:: 2.6
+
     Raises
     ------
     TypeError
@@ -967,6 +994,8 @@ def Param(
         gt=gt,
         ge=ge,
         large=large,
+        min_length=min_length,
+        max_length=max_length,
     )
 
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -360,13 +360,13 @@ class ParamInfo:
         The function that will suggest possible autocomplete options while typing.
     converter: Callable[[:class:`.ApplicationCommandInteraction`, Any], Any]
         The function that will convert the original input to a desired format.
-    min_length: :class:`str`
-        The minimum length allowed for this option.
+    min_length: :class:`int`
+        The minimum length for this option, if it is a string option.
 
         .. versionadded:: 2.6
 
-    max_length: :class:`str`
-        The maximum length allowed for this option.
+    max_length: :class:`int`
+        The maximum length for this option, if it is a string option.
 
         .. versionadded:: 2.6
     """
@@ -994,13 +994,13 @@ def Param(
 
         .. versionadded:: 2.3
 
-    min_length: :class:`str`
-        The minimum length this option can be if it is a string option.
+    min_length: :class:`int`
+        The minimum length for this option if this is a string option.
 
         .. versionadded:: 2.6
 
-    max_length: :class:`str`
-        The maximum length this option can be if it is a string option.
+    max_length: :class:`int`
+        The maxmium length for this option if this is a string option.
 
         .. versionadded:: 2.6
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -287,6 +287,8 @@ class StringMeta(type):
 class String(type, metaclass=StringMeta):
     """Type depicting a limited length of a string option.
 
+    See :ref:`string_lengths` for more information.
+
     .. versionadded:: 2.6
 
     """

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -202,7 +202,7 @@ class RangeMeta(type):
         ...
 
     def __getitem__(self, args: Tuple[Any, ...]) -> Any:
-        a, b = [None if x is Ellipsis else x for x in args]
+        a, b = [None if isinstance(x, type(Ellipsis)) else x for x in args]
         return Range.create(min_value=a, max_value=b)
 
 
@@ -280,8 +280,8 @@ class StringMeta(type):
     """Custom Generic implementation for String."""
 
     def __getitem__(self, args: Tuple[Union[int, ellipsis], Union[int, ellipsis]]) -> Type[str]:
-        a, b = [None if x is ... else x for x in args]
-        return String.create(min_length=a, max_length=b)  # type: ignore # these are not ellipsis
+        a, b = [None if isinstance(x, type(Ellipsis)) else x for x in args]
+        return String.create(min_length=a, max_length=b)
 
 
 class String(type, metaclass=StringMeta):

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -1000,7 +1000,7 @@ def Param(
         .. versionadded:: 2.6
 
     max_length: :class:`int`
-        The maxmium length for this option if this is a string option.
+        The maximum length for this option if this is a string option.
 
         .. versionadded:: 2.6
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -285,7 +285,7 @@ class StringMeta(type):
 
 
 class String(type, metaclass=StringMeta):
-    """Type depicting a limited length of a string option.
+    """Type depicting a string option with limited length.
 
     See :ref:`string_lengths` for more information.
 
@@ -295,7 +295,7 @@ class String(type, metaclass=StringMeta):
 
     min_length: Optional[int]
     max_length: Optional[int]
-    underlying_type = str
+    underlying_type: Final[Type[str]] = str
 
     @classmethod
     def create(

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -71,6 +71,8 @@ class _ApplicationCommandOptionOptional(TypedDict, total=False):
     channel_types: List[ChannelType]
     min_value: float
     max_value: float
+    min_length: int
+    max_length: int
     autocomplete: bool
     name_localizations: Optional[ApplicationCommandLocalizations]
     description_localizations: Optional[ApplicationCommandLocalizations]

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -534,6 +534,11 @@ Range
 
 .. autoclass:: disnake.ext.commands.Range
 
+String
+~~~~~~
+
+.. autoclass:: disnake.ext.commands.String
+
 
 .. _ext_commands_api_cogs:
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -243,6 +243,14 @@ The lengths bounds are both inclusive; using ``...`` as a bound indicates that t
     ):
         ...
 
+.. note::
+
+    There is a max length of 6000 characters, which is enforced by Discord.
+
+.. note::
+
+    For mypy type checking support, please see the above note on :ref:`param_ranges`.
+
 .. _docstrings:
 
 Docstrings

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -200,6 +200,48 @@ The type of the option is determined by the range bounds, with the option being 
         [tool.mypy]
         plugins = "disnake.ext.mypy_plugin"
 
+.. _string_lengths:
+
+String Lengths
+++++++++++++++
+
+:class:`str` parameters support minimum and maximum allowed value lengths.
+values using the ``min_length`` and ``max_length`` parameters on :func:`Param <ext.commands.Param>`.
+For instance, you could restrict an option to only accept a single character:
+
+.. code-block:: python3
+
+    @bot.slash_command()
+    async def charinfo(
+        inter: disnake.CommandInteraction,
+        character: str = commands.Param(max_length=1),
+    ):
+        ...
+
+Or restrict a tag command to limit tag names to 20 characters:
+
+.. code-block:: python3
+
+    @bot.slash_command()
+    async def tags(
+        inter: disnake.CommandInteraction,
+        tag: str = commands.Param(max_length=20)
+    ):
+        ...
+
+Instead of using :func:`Param <ext.commands.Param>`, you can also use a :class:`~ext.commands.String` annotation.
+The lengths bounds are both inclusive; using ``...`` as a bound indicates that this end of the string length is unbounded.
+
+.. code-block:: python3
+
+    @bot.slash_command()
+    async def strings(
+        inter: disnake.CommandInteraction,
+        a: commands.String[0, 10],       # a str no longer than 10 characters.
+        b: commands.String[10, 100],     # a str that's at least 10 characters but not longer than 100.
+        c: commands.String[50, ...]      # a str that's at least 50 characters.
+    ):
+        ...
 
 .. _docstrings:
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -251,7 +251,7 @@ The length bounds are both inclusive; using ``...`` as a bound indicates that th
 
 .. note::
 
-    For mypy type checking support, please see the above note :ref:`about the mypy_plugin <type_checker_mypy_plugin>`.
+    For mypy type checking support, please see the above note about the :ref:`mypy plugin <type_checker_mypy_plugin>`.
 
 .. _docstrings:
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -205,15 +205,15 @@ The type of the option is determined by the range bounds, with the option being 
 String Lengths
 ++++++++++++++
 
-:class:`str` parameters support minimum and maximum allowed value lengths.
-values using the ``min_length`` and ``max_length`` parameters on :func:`Param <ext.commands.Param>`.
+:class:`str` parameters support minimum and maximum allowed value lengths
+using the ``min_length`` and ``max_length`` parameters on :func:`Param <ext.commands.Param>`.
 For instance, you could restrict an option to only accept a single character:
 
 .. code-block:: python3
 
     @bot.slash_command()
     async def charinfo(
-        inter: disnake.CommandInteraction,
+        inter: disnake.ApplicationCommandInteraction,
         character: str = commands.Param(max_length=1),
     ):
         ...
@@ -224,19 +224,19 @@ Or restrict a tag command to limit tag names to 20 characters:
 
     @bot.slash_command()
     async def tags(
-        inter: disnake.CommandInteraction,
+        inter: disnake.ApplicationCommandInteraction,
         tag: str = commands.Param(max_length=20)
     ):
         ...
 
 Instead of using :func:`Param <ext.commands.Param>`, you can also use a :class:`~ext.commands.String` annotation.
-The lengths bounds are both inclusive; using ``...`` as a bound indicates that this end of the string length is unbounded.
+The length bounds are both inclusive; using ``...`` as a bound indicates that this end of the string length is unbounded.
 
 .. code-block:: python3
 
     @bot.slash_command()
     async def strings(
-        inter: disnake.CommandInteraction,
+        inter: disnake.ApplicationCommandInteraction,
         a: commands.String[0, 10],       # a str no longer than 10 characters.
         b: commands.String[10, 100],     # a str that's at least 10 characters but not longer than 100.
         c: commands.String[50, ...]      # a str that's at least 50 characters.
@@ -442,12 +442,12 @@ create autocomplete options with the :func:`autocomplete <ext.commands.Invokable
 .. code-block:: python3
 
     @bot.slash_command()
-    async def languages(inter: disnake.CommandInteraction, language: str):
+    async def languages(inter: disnake.ApplicationCommandInteraction, language: str):
         pass
 
 
     @languages.autocomplete("language")
-    async def language_autocomp(inter: disnake.CommandInteraction, string: str):
+    async def language_autocomp(inter: disnake.ApplicationCommandInteraction, string: str):
         string = string.lower()
         return [lang for lang in LANGUAGES if string in lang.lower()]
         ...

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -182,6 +182,8 @@ The type of the option is determined by the range bounds, with the option being 
     ):
         ...
 
+.. _type_checker_mypy_plugin:
+
 .. note::
 
     Type checker support for :class:`~ext.commands.Range` and :class:`~ext.commands.String` (:ref:`see below <string_lengths>`) is limited.
@@ -249,7 +251,7 @@ The length bounds are both inclusive; using ``...`` as a bound indicates that th
 
 .. note::
 
-    For mypy type checking support, please see the above note on :ref:`param_ranges`.
+    For mypy type checking support, please see the above note :ref:`about the mypy_plugin <type_checker_mypy_plugin>`.
 
 .. _docstrings:
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -184,9 +184,9 @@ The type of the option is determined by the range bounds, with the option being 
 
 .. note::
 
-    Type checker support for :class:`~ext.commands.Range` is limited. Pylance/Pyright seem to handle it correctly;
-    MyPy currently needs a plugin for it to understand :class:`~ext.commands.Range` semantics, which can be added in
-    the configuration file (``setup.cfg``, ``mypy.ini``):
+    Type checker support for :class:`~ext.commands.Range` and :class:`~ext.commands.String` (:ref:`see below <string_lengths>`) is limited.
+    Pylance/Pyright seem to handle it correctly; MyPy currently needs a plugin for it to understand :class:`~ext.commands.Range`
+    and :class:`~ext.commands.String` semantics, which can be added in the configuration file (``setup.cfg``, ``mypy.ini``):
 
     .. code-block:: ini
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
implements https://github.com/discord/discord-api-docs/commit/1159aef52648602c22f72104faaed0155fafca64

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
