### PR TITLE
feat: support additional union types for mentionable parameters

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -334,10 +334,10 @@ class ParamInfo:
         # channels handled separately
         disnake.abc.GuildChannel:                          OptionType.channel.value,
         disnake.Role:                                      OptionType.role.value,
+        disnake.abc.Snowflake:                             OptionType.mentionable.value,
         Union[disnake.Member, disnake.Role]:               OptionType.mentionable.value,
         Union[disnake.User, disnake.Role]:                 OptionType.mentionable.value,
         Union[disnake.User, disnake.Member, disnake.Role]: OptionType.mentionable.value,
-        disnake.abc.Snowflake:                             OptionType.mentionable.value,
         float:                                             OptionType.number.value,
         disnake.Attachment:                                OptionType.attachment.value,
         # fmt: on

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -324,20 +324,22 @@ class ParamInfo:
 
     TYPES: ClassVar[Dict[type, int]] = {
         # fmt: off
-        str:                                 OptionType.string.value,
-        int:                                 OptionType.integer.value,
-        bool:                                OptionType.boolean.value,
-        disnake.abc.User:                    OptionType.user.value,
-        disnake.User:                        OptionType.user.value,
-        disnake.Member:                      OptionType.user.value,
-        Union[disnake.User, disnake.Member]: OptionType.user.value,
+        str:                                               OptionType.string.value,
+        int:                                               OptionType.integer.value,
+        bool:                                              OptionType.boolean.value,
+        disnake.abc.User:                                  OptionType.user.value,
+        disnake.User:                                      OptionType.user.value,
+        disnake.Member:                                    OptionType.user.value,
+        Union[disnake.User, disnake.Member]:               OptionType.user.value,
         # channels handled separately
-        disnake.abc.GuildChannel:            OptionType.channel.value,
-        disnake.Role:                        OptionType.role.value,
-        Union[disnake.Member, disnake.Role]: OptionType.mentionable.value,
-        disnake.abc.Snowflake:               OptionType.mentionable.value,
-        float:                               OptionType.number.value,
-        disnake.Attachment:                  OptionType.attachment.value,
+        disnake.abc.GuildChannel:                          OptionType.channel.value,
+        disnake.Role:                                      OptionType.role.value,
+        Union[disnake.Member, disnake.Role]:               OptionType.mentionable.value,
+        Union[disnake.User, disnake.Role]:                 OptionType.mentionable.value,
+        Union[disnake.User, disnake.Member, disnake.Role]: OptionType.mentionable.value,
+        disnake.abc.Snowflake:                             OptionType.mentionable.value,
+        float:                                             OptionType.number.value,
+        disnake.Attachment:                                OptionType.attachment.value,
         # fmt: on
     }
     _registered_converters: ClassVar[Dict[type, Callable]] = {}

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -120,10 +120,11 @@ Discord itself supports only a few built-in types which are guaranteed to be enf
 - :class:`int`
 - :class:`float`
 - :class:`bool`
-- :class:`disnake.User` or :class:`disnake.Member`
 - :class:`disnake.abc.GuildChannel`\*
+- :class:`disnake.User` or :class:`disnake.Member`\*\*
 - :class:`disnake.Role`\*\*
 - :class:`disnake.Attachment`
+- :class:`disnake.abc.Snowflake`\*\*\*
 
 All the other types may be converted implicitly, similarly to :ref:`ext_commands_basic_converters`
 
@@ -142,9 +143,18 @@ All the other types may be converted implicitly, similarly to :ref:`ext_commands
         ...
 
 .. note::
-  \* All channel subclasses and unions are also supported. See :attr:`ParamInfo.channel_types <ext.commands.ParamInfo>` for more fine-grained control
+  \* All channel subclasses and unions (e.g. ``Union[TextChannel, StageChannel]``) are also supported.
+  See :attr:`ParamInfo.channel_types <ext.commands.ParamInfo>` for more fine-grained control.
 
-  \*\* Role and Member may be used together to create a "mentionable" (``Union[Role, Member]``)
+  \*\* Some combinations of types are also allowed, including:
+    - ``Union[User, Member]`` (results in :class:`OptionType.user`)
+    - ``Union[Member, Role]`` (results in :class:`OptionType.mentionable`)
+    - ``Union[User, Role]`` (results in :class:`OptionType.mentionable`)
+    - ``Union[User, Member, Role]`` (results in :class:`OptionType.mentionable`)
+
+  Note that a :class:`~disnake.User` annotation can also result in a :class:`~disnake.Member` being received.
+
+  \*\*\* Corresponds to any mentionable type, currently equivalent to ``Union[User, Member, Role]``.
 
 
 .. _param_ranges:

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -25,6 +25,8 @@ class TestParamInfo:
             # should accept member or role
             (Union[Member, Role], OptionType.mentionable, [Member, Role]),
             # should accept everything
+            (Union[User, Role], OptionType.mentionable, [User, Member, Role]),
+            (Union[User, Member, Role], OptionType.mentionable, [User, Member, Role]),
             (disnake.abc.Snowflake, OptionType.mentionable, [User, Member, Role]),
         ],
     )


### PR DESCRIPTION
## Summary

Adds support for `Union[User, Role]` and `Union[User, Member, Role]` in slash commands, which correspond to `OptionType.mentionable`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
