### PR TITLE
revert: "feat: support selects in modals (#558)"

### DIFF
--- a/disnake/components.py
+++ b/disnake/components.py
@@ -68,7 +68,11 @@ C = TypeVar("C", bound="Component")
 
 MessageComponent = Union["Button", "SelectMenu"]
 
-ModalComponent = Union["TextInput", "SelectMenu"]
+if TYPE_CHECKING:  # TODO: remove when we add modal select support
+    from typing_extensions import TypeAlias
+
+# ModalComponent = Union["TextInput", "SelectMenu"]
+ModalComponent: TypeAlias = "TextInput"
 NestedComponent = Union[MessageComponent, ModalComponent]
 ComponentT = TypeVar("ComponentT", bound=NestedComponent)
 

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -91,12 +91,7 @@ class ModalInteraction(Interaction):
         The interaction client.
     """
 
-    __slots__ = (
-        "data",
-        "message",
-        "_cs_text_values",
-        "_cs_select_values",
-    )
+    __slots__ = ("data", "message", "_cs_text_values")
 
     def __init__(self, *, data: ModalInteractionPayload, state: ConnectionState):
         super().__init__(data=data, state=state)
@@ -125,26 +120,12 @@ class ModalInteraction(Interaction):
     @cached_slot_property("_cs_text_values")
     def text_values(self) -> Dict[str, str]:
         """Dict[:class:`str`, :class:`str`]: Returns the text values the user has entered in the modal.
-        This is a dict of the form ``{custom_id: value, ...}``."""
+        This is a dict of the form ``{custom_id: value}``."""
         text_input_type = ComponentType.text_input.value
         return {
             component["custom_id"]: component.get("value") or ""
             for component in self.walk_raw_components()
             if component.get("type") == text_input_type
-        }
-
-    @cached_slot_property("_cs_select_values")
-    def select_values(self) -> Dict[str, List[str]]:
-        """Dict[:class:`str`, List[:class:`str`]]: Returns the select values the user has entered in the modal.
-        This is a dict of the form ``{custom_id: [value1, value2, ...], ...}``.
-
-        .. versionadded:: 2.6
-        """
-        select_type = ComponentType.select.value
-        return {
-            component["custom_id"]: component.get("values") or []
-            for component in self.walk_raw_components()
-            if component.get("type") == select_type
         }
 
     @property

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -71,7 +71,7 @@ __all__ = (
 
 
 MessageUIComponent = Union[Button[Any], Select[Any]]
-ModalUIComponent = Union[TextInput, Select[Any]]
+ModalUIComponent = TextInput  # Union[TextInput, Select[Any]]
 UIComponentT = TypeVar("UIComponentT", bound=WrappedComponent)
 StrictUIComponentT = TypeVar("StrictUIComponentT", MessageUIComponent, ModalUIComponent)
 
@@ -269,7 +269,7 @@ class ActionRow(Generic[UIComponentT]):
     def add_select(
         self: Union[
             ActionRow[MessageUIComponent],
-            ActionRow[ModalUIComponent],
+            # ActionRow[ModalUIComponent],
             ActionRow[WrappedComponent],
         ],
         *,
@@ -280,7 +280,8 @@ class ActionRow(Generic[UIComponentT]):
         options: List[SelectOption] = MISSING,
         disabled: bool = False,
     ) -> None:
-        """Add a select menu to the action row.
+        """Add a select menu to the action row. Can only be used if the action
+        row holds message components.
 
         To append a pre-existing :class:`~disnake.ui.Select` use the
         :meth:`append_item` method instead.

--- a/examples/modal.py
+++ b/examples/modal.py
@@ -8,11 +8,6 @@ bot = commands.Bot(command_prefix=commands.when_mentioned)
 
 class MyModal(disnake.ui.Modal):
     def __init__(self) -> None:
-
-        select_options = [
-            disnake.SelectOption(label="Yes"),
-            disnake.SelectOption(label="No", default=True),
-        ]
         components = [
             disnake.ui.TextInput(
                 label="Name",
@@ -37,28 +32,13 @@ class MyModal(disnake.ui.Modal):
                 min_length=5,
                 max_length=1024,
             ),
-            disnake.ui.Select(
-                custom_id="select",
-                placeholder="Send as an embed.",
-                min_values=1,
-                max_values=1,
-                options=select_options,
-            ),
         ]
-
         super().__init__(title="Create Tag", custom_id="create_tag", components=components)
 
     async def callback(self, inter: disnake.ModalInteraction) -> None:
         embed = disnake.Embed(title="Tag Creation")
-
-        # text_values is a dict of TextInput.custom_id to the inputted value.
         for key, value in inter.text_values.items():
             embed.add_field(name=key.capitalize(), value=value, inline=False)
-
-        # select_values is a dict of Select.custom_id to the selected value.
-        for key, value in inter.select_values.items():
-            embed.add_field(name=key.capitalize(), value=value, inline=False)
-
         await inter.response.send_message(embed=embed)
 
     async def on_error(self, error: Exception, inter: disnake.ModalInteraction) -> None:
@@ -75,45 +55,34 @@ async def create_tag(inter: disnake.CommandInteraction):
 async def create_tag_low(inter: disnake.CommandInteraction):
     # Works same as the above code but using a low level interface.
     # It's recommended to use this if you don't want to increase cache usage.
-    select_options = [
-        disnake.SelectOption(label="Yes"),
-        disnake.SelectOption(label="No", default=True),
-    ]
-    components = [
-        disnake.ui.TextInput(
-            label="Name",
-            placeholder="The name of the tag",
-            custom_id="name",
-            style=disnake.TextInputStyle.short,
-            max_length=50,
-        ),
-        disnake.ui.TextInput(
-            label="Description",
-            placeholder="The description of the tag",
-            custom_id="description",
-            style=disnake.TextInputStyle.short,
-            min_length=5,
-            max_length=50,
-        ),
-        disnake.ui.TextInput(
-            label="Content",
-            placeholder="The content of the tag",
-            custom_id="content",
-            style=disnake.TextInputStyle.paragraph,
-            min_length=5,
-            max_length=1024,
-        ),
-        disnake.ui.Select(
-            custom_id="select",
-            placeholder="Send as an embed.",
-            min_values=1,
-            max_values=1,
-            options=select_options,
-        ),
-    ]
-
     await inter.response.send_modal(
-        title="Create Tag", custom_id="create_tag_low", components=components
+        title="Create Tag",
+        custom_id="create_tag_low",
+        components=[
+            disnake.ui.TextInput(
+                label="Name",
+                placeholder="The name of the tag",
+                custom_id="name",
+                style=disnake.TextInputStyle.short,
+                max_length=50,
+            ),
+            disnake.ui.TextInput(
+                label="Description",
+                placeholder="The description of the tag",
+                custom_id="description",
+                style=disnake.TextInputStyle.short,
+                min_length=5,
+                max_length=50,
+            ),
+            disnake.ui.TextInput(
+                label="Content",
+                placeholder="The content of the tag",
+                custom_id="content",
+                style=disnake.TextInputStyle.paragraph,
+                min_length=5,
+                max_length=1024,
+            ),
+        ],
     )
 
     # Waits until the user submits the modal.
@@ -129,15 +98,8 @@ async def create_tag_low(inter: disnake.CommandInteraction):
         return
 
     embed = disnake.Embed(title="Tag Creation")
-
-    # text_values is a dict of TextInput.custom_id to the entered value.
-    for key, value in modal_inter.text_values.items():
-        embed.add_field(name=key.capitalize(), value=value, inline=False)
-
-    # select_values is a dict of Select.custom_id to the selected values.
-    for key, value in modal_inter.select_values.items():
-        embed.add_field(name=key.capitalize(), value=value, inline=False)
-
+    for custom_id, value in modal_inter.text_values.items():
+        embed.add_field(name=custom_id.capitalize(), value=value, inline=False)
     await modal_inter.response.send_message(embed=embed)
 
 

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -86,7 +86,8 @@ class TestActionRow:
         if TYPE_CHECKING:
             ActionRow().add_select
             ActionRow.with_message_components().add_select
-            ActionRow.with_modal_components().add_select
+            # should not work  # TODO: revert when modal select support is added.
+            ActionRow.with_modal_components().add_select  # type: ignore
 
     def test_add_text_input(self):
         r = ActionRow.with_modal_components()
@@ -201,13 +202,14 @@ class TestActionRow:
         assert_type(ActionRow(button1, select), ActionRow[MessageUIComponent])
         assert_type(ActionRow(select, button1), ActionRow[MessageUIComponent])
 
-        assert_type(ActionRow(select, text_input), ActionRow[ModalUIComponent])
-        assert_type(ActionRow(text_input, select), ActionRow[ModalUIComponent])
-
         # these should fail to type-check - if they pass, there will be an error
         # because of the unnecessary ignore comment
         ActionRow(button1, text_input)  # type: ignore
         ActionRow(text_input, button1)  # type: ignore
+
+        # TODO: revert when modal select support is added.
+        assert_type(ActionRow(select, text_input), ActionRow[ModalUIComponent])  # type: ignore
+        assert_type(ActionRow(text_input, select), ActionRow[ModalUIComponent])  # type: ignore
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Reverts #558 which was merged prematurely.
Support is not guaranteed on all platforms and the API may not be finalized yet, so it's better to keep this implementation in a draft state for now while details are still being worked on.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
