### PR TITLE
feat: add AllowedMentions.from_message

### DIFF
--- a/disnake/mentions.py
+++ b/disnake/mentions.py
@@ -31,6 +31,7 @@ __all__ = ("AllowedMentions",)
 
 if TYPE_CHECKING:
     from .abc import Snowflake
+    from .message import Message
     from .types.message import AllowedMentions as AllowedMentionsPayload
 
 
@@ -110,6 +111,22 @@ class AllowedMentions:
         .. versionadded:: 1.5
         """
         return cls(everyone=False, users=False, roles=False, replied_user=False)
+
+    @classmethod
+    def from_message(cls: Type[A], message: Message) -> A:
+        """A factory method that returns a :class:`AllowedMentions` dervived from the current :class:`.Message` state.
+
+        Note that this is not what AllowedMentions the message was sent with, but what the message actually mentioned.
+        For example, a message that successfully mentioned everyone will have :attr:`~AllowedMentions.everyone` set to ``True``.
+
+        .. versionadded:: 2.6
+        """
+        return cls(
+            everyone=message.mention_everyone,
+            users=message.mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
+            roles=message.role_mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
+            replied_user=False,
+        )
 
     def to_dict(self) -> AllowedMentionsPayload:
         parse = []

--- a/disnake/mentions.py
+++ b/disnake/mentions.py
@@ -131,7 +131,7 @@ class AllowedMentions:
             users=message.mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
             roles=message.role_mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
             replied_user=bool(
-                message.type == MessageType.reply
+                message.type is MessageType.reply
                 and message.reference
                 and isinstance(message.reference.resolved, Message)
                 and message.reference.resolved.author in message.mentions

--- a/disnake/mentions.py
+++ b/disnake/mentions.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Type, TypeVar, Union
 
+from .enums import MessageType
+
 __all__ = ("AllowedMentions",)
 
 if TYPE_CHECKING:
@@ -121,11 +123,19 @@ class AllowedMentions:
 
         .. versionadded:: 2.6
         """
+        # circular import
+        from .message import Message
+
         return cls(
             everyone=message.mention_everyone,
             users=message.mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
             roles=message.role_mentions.copy(),  # type: ignore # mentions is a list of Snowflakes
-            replied_user=False,
+            replied_user=bool(
+                message.type == MessageType.reply
+                and message.reference
+                and isinstance(message.reference.resolved, Message)
+                and message.reference.resolved.author in message.mentions
+            ),
         )
 
     def to_dict(self) -> AllowedMentionsPayload:

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,117 @@
+from typing import Dict, Union
+from unittest import mock
+
+import pytest
+
+from disnake import AllowedMentions, Message, MessageType, Object
+
+
+def test_classmethod_none() -> None:
+    none = AllowedMentions.none()
+    assert none.everyone is False
+    assert none.roles is False
+    assert none.users is False
+    assert none.replied_user is False
+
+
+def test_classmethod_all() -> None:
+    all_mentions = AllowedMentions.all()
+    assert all_mentions.everyone is True
+    assert all_mentions.roles is True
+    assert all_mentions.users is True
+    assert all_mentions.replied_user is True
+
+
+@pytest.mark.parametrize(
+    ("am", "expected"),
+    [
+        (AllowedMentions(), {"parse": ["everyone", "users", "roles"], "replied_user": True}),
+        (AllowedMentions.all(), {"parse": ["everyone", "users", "roles"], "replied_user": True}),
+        (AllowedMentions(everyone=False), {"parse": ["users", "roles"], "replied_user": True}),
+        (
+            AllowedMentions(users=[Object(x) for x in [123, 456, 789]]),
+            {"parse": ["everyone", "roles"], "replied_user": True, "users": [123, 456, 789]},
+        ),
+        (
+            AllowedMentions(
+                users=[Object(x) for x in [123, 456, 789]],
+                roles=[Object(x) for x in [123, 456, 789]],
+            ),
+            {
+                "parse": ["everyone"],
+                "replied_user": True,
+                "users": [123, 456, 789],
+                "roles": [123, 456, 789],
+            },
+        ),
+        (AllowedMentions.none(), {"parse": []}),
+    ],
+)
+def test_to_dict(am: AllowedMentions, expected: Dict[str, Union[bool, list]]) -> None:
+    assert expected == am.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("og", "to_merge", "expected"),
+    [
+        (AllowedMentions.none(), AllowedMentions.none(), AllowedMentions.none()),
+        (AllowedMentions.none(), AllowedMentions(), AllowedMentions.none()),
+        (AllowedMentions.all(), AllowedMentions(), AllowedMentions.all()),
+        (AllowedMentions(), AllowedMentions(), AllowedMentions()),
+        (AllowedMentions.all(), AllowedMentions.none(), AllowedMentions.none()),
+        (
+            AllowedMentions(everyone=False),
+            AllowedMentions(users=True),
+            AllowedMentions(everyone=False, users=True),
+        ),
+        (
+            AllowedMentions(users=[Object(x) for x in [123, 456, 789]]),
+            AllowedMentions(users=False),
+            AllowedMentions(users=False),
+        ),
+    ],
+)
+def test_merge(og: AllowedMentions, to_merge: AllowedMentions, expected: AllowedMentions) -> None:
+    merged = og.merge(to_merge)
+
+    assert expected.everyone is merged.everyone
+    assert expected.users is merged.users
+    assert expected.roles is merged.roles
+    assert expected.replied_user is merged.replied_user
+
+
+def test_from_message() -> None:
+    # as we don't have a message mock yet we are faking a message here with the necessary components
+    msg = mock.NonCallableMock()
+    msg.mention_everyone = True
+    users = [Object(x) for x in [123, 456, 789]]
+    msg.mentions = users
+    roles = [Object(x) for x in [123, 456, 789]]
+    msg.role_mentions = roles
+    msg.reference = None
+
+    am = AllowedMentions.from_message(msg)
+
+    assert am.everyone is True
+    # check that while the list matches, it isn't the same list
+    assert am.users == users
+    assert am.users is not users
+
+    assert am.roles == roles
+    assert am.roles is not roles
+
+    assert am.replied_user is False
+
+
+def test_from_message_replied_user() -> None:
+    message = mock.Mock(Message)
+    author = Object(123)
+    message.mentions = [author]
+    assert AllowedMentions.from_message(message).replied_user is False
+
+    message.type = MessageType.reply
+    assert AllowedMentions.from_message(message).replied_user is False
+
+    resolved = mock.Mock(Message, author=author)
+    message.reference = mock.Mock(resolved=resolved)
+    assert AllowedMentions.from_message(message).replied_user is True


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
superseeds #592 

closes #573

Add `AllowedMentions.from_message()` which creates an AllowedMentions from a message's current state.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
