### PR TITLE
ci: don't run tests on the pull context if on main repo

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -140,8 +140,13 @@ jobs:
       run: task slotscheck
 
   pytest:
-    # for testing, we want it to run on both the pull_request and
-    # push so we get a coveralls comment on the pull request
+    # Thanks to black for this rule
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. Without this if check, checks are duplicated since
+    # internal PRs match both the push and pull_request events.
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]


### PR DESCRIPTION
## Summary
we don't have coveralls configured to comment
plus this is not ideal for action concurrency limits

so we add the concurrency rule to pytest
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
