### PR TITLE
feat: add more operators to flags

### DIFF
--- a/changelog/605.feature.rst
+++ b/changelog/605.feature.rst
@@ -1,0 +1,3 @@
+Add support of more operators to all ``Flag`` classes. This list includes :class:`Intents` and :class:`Permissions`.
+- ``&``, ``|``, ``^``, and ``~`` bitwise operator support.
+- ``<``, ``<=``, ``>``, and ``>=`` comparsion operator support.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -131,10 +131,10 @@ class BaseFlags:
         self.value = value
         return self
 
-    def __eq__(self, other: Self) -> bool:
+    def __eq__(self, other: Any) -> bool:
         return isinstance(other, self.__class__) and self.value == other.value
 
-    def __ne__(self, other: Self) -> bool:
+    def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
 
     def __and__(self, other: Self) -> Self:

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -160,6 +160,8 @@ class BaseFlags:
 
     def __invert__(self) -> Self:
         # invert the bit but make sure all truthy values are valid flags
+        # this code means that if a flag class doesn't define 1 << 2 that
+        # value won't suddenly be set to True
         bitmask = functools.reduce(operator.or_, self.VALID_FLAGS.values())
         return self._from_value((self.value ^ bitmask) & bitmask)
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -131,11 +131,37 @@ class BaseFlags:
         self.value = value
         return self
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: Self) -> bool:
         return isinstance(other, self.__class__) and self.value == other.value
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: Self) -> bool:
         return not self.__eq__(other)
+
+    def __and__(self, other: Self) -> Self:
+        return self._from_value(self.value & other.value)
+
+    def __iand__(self, other: Self) -> Self:
+        self.value &= other.value
+        return self
+
+    def __or__(self, other: Self) -> Self:
+        return self._from_value(self.value | other.value)
+
+    def __ior__(self, other: Self) -> Self:
+        self.value |= other.value
+        return self
+
+    def __xor__(self, other: Self) -> Self:
+        return self._from_value(self.value ^ other.value)
+
+    def __ixor__(self, other: Self) -> Self:
+        self.value ^= other.value
+        return self
+
+    def __invert__(self) -> Self:
+        # invert the bit but make sure all truthy values are valid flags
+        bitmask = functools.reduce(operator.or_, self.VALID_FLAGS.values())
+        return self._from_value((self.value ^ bitmask) & bitmask)
 
     def __hash__(self) -> int:
         return hash(self.value)
@@ -183,6 +209,29 @@ class SystemChannelFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x | y, x |= y
+
+            Returns a new SystemChannelFlags with all enabled flags from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new SystemChannelFlags with only flags enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new SystemChannelFlags with only flags enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new SystemChannelFlags with all flags inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -260,6 +309,29 @@ class MessageFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x | y, x |= y
+
+            Returns a new MessageFlags with all enabled flags from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new MessageFlags with only flags enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new MessageFlags with only flags enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new MessageFlags with all flags inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -356,6 +428,29 @@ class PublicUserFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two PublicUserFlags are not equal.
+        .. describe:: x | y, x |= y
+
+            Returns a new PublicUserFlags with all enabled flags from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new PublicUserFlags with only flags enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new PublicUserFlags with only flags enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new PublicUserFlags with all flags inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
             Return the flag's hash.
@@ -501,10 +596,33 @@ class Intents(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two flags are equal.
+            Checks if two intents are equal.
         .. describe:: x != y
 
-            Checks if two flags are not equal.
+            Checks if two intents are not equal.
+        .. describe:: x | y, x |= y
+
+            Returns a new Intents with all enabled intents from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new Intents with only intents enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new Intents with only intents enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new Intents with all intents inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -1027,6 +1145,29 @@ class MemberCacheFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x | y, x |= y
+
+            Returns a new MemberCacheFlags with all enabled flags from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new MemberCacheFlags with only flags enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new MemberCacheFlags with only flags enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new MemberCacheFlags with all flags inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
                Return the flag's hash.
@@ -1141,6 +1282,29 @@ class ApplicationFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two ApplicationFlags are not equal.
+        .. describe:: x | y, x |= y
+
+            Returns a new ApplicationFlags with all enabled flags from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new ApplicationFlags with only flags enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new ApplicationFlags with only flags enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new ApplicationFlags with all flags inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
             Return the flag's hash.
@@ -1228,6 +1392,29 @@ class ChannelFlags(BaseFlags):
         .. describe:: x != y
 
             Checks if two flags are not equal.
+        .. describe:: x | y, x |= y
+
+            Returns a new ChannelFlags with all enabled flags from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new ChannelFlags with only flags enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new ChannelFlags with only flags enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new ChannelFlags with all flags inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
             Return the flag's hash.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -158,6 +158,26 @@ class BaseFlags:
         self.value ^= other.value
         return self
 
+    def __le__(self, other: Self) -> bool:
+        if isinstance(other, type(self)):
+            return (self.value & other.value) == self.value
+        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+
+    def __ge__(self, other: Self) -> bool:
+        if isinstance(other, type(self)):
+            return (self.value | other.value) == self.value
+        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+
+    def __lt__(self, other: Self) -> bool:
+        if isinstance(other, type(self)):
+            return (self.value & other.value) == self.value and self.value != other.value
+        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+
+    def __gt__(self, other: Self) -> bool:
+        if isinstance(other, type(self)):
+            return (self.value | other.value) == self.value and self.value != other.value
+        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+
     def __invert__(self) -> Self:
         # invert the bit but make sure all truthy values are valid flags
         # this code means that if a flag class doesn't define 1 << 2 that

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -227,31 +227,43 @@ class SystemChannelFlags(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two flags are equal.
+            Checks if two SystemChannelFlags instances are equal.
         .. describe:: x != y
 
-            Checks if two flags are not equal.
+            Checks if two SystemChannelFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if a SystemChannelFlags instance is a subset of another SystemChannelFlags instance.
+        .. describe:: x >= y
+
+            Checks if a SystemChannelFlags instance is a superset of another SystemChannelFlags instance.
+        .. describe:: x < y
+
+             Checks if a SystemChannelFlags instance is a strict subset of another SystemChannelFlags instance.
+        .. describe:: x > y
+
+             Checks if a SystemChannelFlags instance is a strict superset of another SystemChannelFlags instance.
         .. describe:: x | y, x |= y
 
-            Returns a new SystemChannelFlags with all enabled flags from both x and y.
-            (Using `|=` will update in place).
+            Returns a new SystemChannelFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new SystemChannelFlags with only flags enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new SystemChannelFlags with only flags enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new SystemChannelFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new SystemChannelFlags with all flags inverted from x.
+            Returns a new SystemChannelFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new SystemChannelFlags instance with all flags from x inverted.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)
@@ -327,31 +339,43 @@ class MessageFlags(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two flags are equal.
+            Checks if two MessageFlags instances are equal.
         .. describe:: x != y
 
-            Checks if two flags are not equal.
+            Checks if two MessageFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if a MessageFlags instance is a subset of another MessageFlags instance.
+        .. describe:: x >= y
+
+            Checks if a MessageFlags instance is a superset of another MessageFlags instance.
+        .. describe:: x < y
+
+             Checks if a MessageFlags instance is a strict subset of another MessageFlags instance.
+        .. describe:: x > y
+
+             Checks if a MessageFlags instance is a strict superset of another MessageFlags instance.
         .. describe:: x | y, x |= y
 
-            Returns a new MessageFlags with all enabled flags from both x and y.
-            (Using `|=` will update in place).
+            Returns a new MessageFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new MessageFlags with only flags enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new MessageFlags with only flags enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new MessageFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new MessageFlags with all flags inverted from x.
+            Returns a new MessageFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new MessageFlags instance with all flags from x inverted.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)
@@ -446,31 +470,43 @@ class PublicUserFlags(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two PublicUserFlags are equal.
+            Checks if two PublicUserFlags instances are equal.
         .. describe:: x != y
 
-            Checks if two PublicUserFlags are not equal.
+            Checks if two PublicUserFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if a PublicUserFlags instance is a subset of another PublicUserFlags instance.
+        .. describe:: x >= y
+
+            Checks if a PublicUserFlags instance is a superset of another PublicUserFlags instance.
+        .. describe:: x < y
+
+             Checks if a PublicUserFlags instance is a strict subset of another PublicUserFlags instance.
+        .. describe:: x > y
+
+             Checks if a PublicUserFlags instance is a strict superset of another PublicUserFlags instance.
         .. describe:: x | y, x |= y
 
-            Returns a new PublicUserFlags with all enabled flags from both x and y.
-            (Using `|=` will update in place).
+            Returns a new PublicUserFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new PublicUserFlags with only flags enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new PublicUserFlags with only flags enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new PublicUserFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new PublicUserFlags with all flags inverted from x.
+            Returns a new PublicUserFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new PublicUserFlags instance with all flags from x inverted.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)
@@ -618,31 +654,43 @@ class Intents(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two intents are equal.
+            Checks if two Intents instances are equal.
         .. describe:: x != y
 
-            Checks if two intents are not equal.
+            Checks if two Intents instances are not equal.
+        .. describe:: x <= y
+
+            Checks if an Intents instance is a subset of another Intents instance.
+        .. describe:: x >= y
+
+            Checks if an Intents instance is a superset of another Intents instance.
+        .. describe:: x < y
+
+             Checks if an Intents instance is a strict subset of another Intents instance.
+        .. describe:: x > y
+
+             Checks if an Intents instance is a strict superset of another Intents instance.
         .. describe:: x | y, x |= y
 
-            Returns a new Intents with all enabled intents from both x and y.
-            (Using `|=` will update in place).
+            Returns a new Intents instance with all enabled intents from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new Intents with only intents enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new Intents with only intents enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new Intents instance with only intents enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new Intents with all intents inverted from x.
+            Returns a new Intents instance with only intents enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new Intents instance with all intents inverted from x.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)
@@ -1163,31 +1211,43 @@ class MemberCacheFlags(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two flags are equal.
+            Checks if two MemberCacheFlags instances are equal.
         .. describe:: x != y
 
-            Checks if two flags are not equal.
+            Checks if two MemberCacheFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if an MemberCacheFlags instance is a subset of another MemberCacheFlags instance.
+        .. describe:: x >= y
+
+            Checks if an MemberCacheFlags instance is a superset of another MemberCacheFlags instance.
+        .. describe:: x < y
+
+             Checks if an MemberCacheFlags instance is a strict subset of another MemberCacheFlags instance.
+        .. describe:: x > y
+
+             Checks if an MemberCacheFlags instance is a strict superset of another MemberCacheFlags instance.
         .. describe:: x | y, x |= y
 
-            Returns a new MemberCacheFlags with all enabled flags from both x and y.
-            (Using `|=` will update in place).
+            Returns a new MemberCacheFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new MemberCacheFlags with only flags enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new MemberCacheFlags with only flags enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new MemberCacheFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new MemberCacheFlags with all flags inverted from x.
+            Returns a new MemberCacheFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new MemberCacheFlags instance with all flags from x inverted.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)
@@ -1300,31 +1360,43 @@ class ApplicationFlags(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two ApplicationFlags are equal.
+            Checks if two ApplicationFlags instances are equal.
         .. describe:: x != y
 
-            Checks if two ApplicationFlags are not equal.
+            Checks if two ApplicationFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if an ApplicationFlags instance is a subset of another ApplicationFlags instance.
+        .. describe:: x >= y
+
+            Checks if an ApplicationFlags instance is a superset of another ApplicationFlags instance.
+        .. describe:: x < y
+
+             Checks if an ApplicationFlags instance is a strict subset of another ApplicationFlags instance.
+        .. describe:: x > y
+
+             Checks if an ApplicationFlags instance is a strict superset of another ApplicationFlags instance.
         .. describe:: x | y, x |= y
 
-            Returns a new ApplicationFlags with all enabled flags from both x and y.
-            (Using `|=` will update in place).
+            Returns a new ApplicationFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new ApplicationFlags with only flags enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new ApplicationFlags with only flags enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new ApplicationFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new ApplicationFlags with all flags inverted from x.
+            Returns a new ApplicationFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new ApplicationFlags instance with all flags from x inverted.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)
@@ -1410,31 +1482,43 @@ class ChannelFlags(BaseFlags):
 
         .. describe:: x == y
 
-            Checks if two flags are equal.
+            Checks if two ChannelFlags instances are equal.
         .. describe:: x != y
 
-            Checks if two flags are not equal.
+            Checks if two ChannelFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if an ChannelFlags instance is a subset of another ChannelFlags instance.
+        .. describe:: x >= y
+
+            Checks if an ChannelFlags instance is a superset of another ChannelFlags instance.
+        .. describe:: x < y
+
+             Checks if an ChannelFlags instance is a strict subset of another ChannelFlags instance.
+        .. describe:: x > y
+
+             Checks if an ChannelFlags instance is a strict superset of another ChannelFlags instance.
         .. describe:: x | y, x |= y
 
-            Returns a new ChannelFlags with all enabled flags from both x and y.
-            (Using `|=` will update in place).
+            Returns a new ChannelFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new ChannelFlags with only flags enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new ChannelFlags with only flags enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new ChannelFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new ChannelFlags with all flags inverted from x.
+            Returns a new ChannelFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new ChannelFlags instance with all flags from x inverted.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -1284,22 +1284,22 @@ class MemberCacheFlags(BaseFlags):
             Checks if two MemberCacheFlags instances are not equal.
         .. describe:: x <= y
 
-            Checks if an MemberCacheFlags instance is a subset of another MemberCacheFlags instance.
+            Checks if a MemberCacheFlags instance is a subset of another MemberCacheFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x >= y
 
-            Checks if an MemberCacheFlags instance is a superset of another MemberCacheFlags instance.
+            Checks if a MemberCacheFlags instance is a superset of another MemberCacheFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x < y
 
-            Checks if an MemberCacheFlags instance is a strict subset of another MemberCacheFlags instance.
+            Checks if a MemberCacheFlags instance is a strict subset of another MemberCacheFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x > y
 
-            Checks if an MemberCacheFlags instance is a strict superset of another MemberCacheFlags instance.
+            Checks if a MemberCacheFlags instance is a strict superset of another MemberCacheFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x | y, x |= y
@@ -1568,22 +1568,22 @@ class ChannelFlags(BaseFlags):
             Checks if two ChannelFlags instances are not equal.
         .. describe:: x <= y
 
-            Checks if an ChannelFlags instance is a subset of another ChannelFlags instance.
+            Checks if a ChannelFlags instance is a subset of another ChannelFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x >= y
 
-            Checks if an ChannelFlags instance is a superset of another ChannelFlags instance.
+            Checks if a ChannelFlags instance is a superset of another ChannelFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x < y
 
-            Checks if an ChannelFlags instance is a strict subset of another ChannelFlags instance.
+            Checks if a ChannelFlags instance is a strict subset of another ChannelFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x > y
 
-            Checks if an ChannelFlags instance is a strict superset of another ChannelFlags instance.
+            Checks if a ChannelFlags instance is a strict superset of another ChannelFlags instance.
 
             .. versionadded:: 2.6
         .. describe:: x | y, x |= y

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -141,45 +141,77 @@ class BaseFlags:
         return not self.__eq__(other)
 
     def __and__(self, other: Self) -> Self:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"unsupported operand type(s) for &: '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
         return self._from_value(self.value & other.value)
 
     def __iand__(self, other: Self) -> Self:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"unsupported operand type(s) for &=: '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
         self.value &= other.value
         return self
 
     def __or__(self, other: Self) -> Self:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"unsupported operand type(s) for |: '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
         return self._from_value(self.value | other.value)
 
     def __ior__(self, other: Self) -> Self:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"unsupported operand type(s) for |=: '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
         self.value |= other.value
         return self
 
     def __xor__(self, other: Self) -> Self:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"unsupported operand type(s) for ^: '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
         return self._from_value(self.value ^ other.value)
 
     def __ixor__(self, other: Self) -> Self:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"unsupported operand type(s) for ^=: '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
         self.value ^= other.value
         return self
 
     def __le__(self, other: Self) -> bool:
-        if isinstance(other, type(self)):
-            return (self.value & other.value) == self.value
-        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"'<=' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
+        return (self.value & other.value) == self.value
 
     def __ge__(self, other: Self) -> bool:
-        if isinstance(other, type(self)):
-            return (self.value | other.value) == self.value
-        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"'>=' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
+        return (self.value | other.value) == self.value
 
     def __lt__(self, other: Self) -> bool:
-        if isinstance(other, type(self)):
-            return (self.value & other.value) == self.value and self.value != other.value
-        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"'<' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
+        return (self.value & other.value) == self.value and self.value != other.value
 
     def __gt__(self, other: Self) -> bool:
-        if isinstance(other, type(self)):
-            return (self.value | other.value) == self.value and self.value != other.value
-        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"'>' not supported between instances of '{self.__class__.__name__}' and '{other.__class__.__name__}'"
+            )
+        return (self.value | other.value) == self.value and self.value != other.value
 
     def __invert__(self) -> Self:
         # invert the bit but make sure all truthy values are valid flags

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -269,15 +269,23 @@ class SystemChannelFlags(BaseFlags):
         .. describe:: x <= y
 
             Checks if a SystemChannelFlags instance is a subset of another SystemChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x >= y
 
             Checks if a SystemChannelFlags instance is a superset of another SystemChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x < y
 
-             Checks if a SystemChannelFlags instance is a strict subset of another SystemChannelFlags instance.
+            Checks if a SystemChannelFlags instance is a strict subset of another SystemChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x > y
 
-             Checks if a SystemChannelFlags instance is a strict superset of another SystemChannelFlags instance.
+            Checks if a SystemChannelFlags instance is a strict superset of another SystemChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x | y, x |= y
 
             Returns a new SystemChannelFlags instance with all enabled flags from both x and y.
@@ -381,15 +389,23 @@ class MessageFlags(BaseFlags):
         .. describe:: x <= y
 
             Checks if a MessageFlags instance is a subset of another MessageFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x >= y
 
             Checks if a MessageFlags instance is a superset of another MessageFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x < y
 
-             Checks if a MessageFlags instance is a strict subset of another MessageFlags instance.
+            Checks if a MessageFlags instance is a strict subset of another MessageFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x > y
 
-             Checks if a MessageFlags instance is a strict superset of another MessageFlags instance.
+            Checks if a MessageFlags instance is a strict superset of another MessageFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x | y, x |= y
 
             Returns a new MessageFlags instance with all enabled flags from both x and y.
@@ -512,15 +528,23 @@ class PublicUserFlags(BaseFlags):
         .. describe:: x <= y
 
             Checks if a PublicUserFlags instance is a subset of another PublicUserFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x >= y
 
             Checks if a PublicUserFlags instance is a superset of another PublicUserFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x < y
 
-             Checks if a PublicUserFlags instance is a strict subset of another PublicUserFlags instance.
+            Checks if a PublicUserFlags instance is a strict subset of another PublicUserFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x > y
 
-             Checks if a PublicUserFlags instance is a strict superset of another PublicUserFlags instance.
+            Checks if a PublicUserFlags instance is a strict superset of another PublicUserFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x | y, x |= y
 
             Returns a new PublicUserFlags instance with all enabled flags from both x and y.
@@ -696,15 +720,23 @@ class Intents(BaseFlags):
         .. describe:: x <= y
 
             Checks if an Intents instance is a subset of another Intents instance.
+
+            .. versionadded:: 2.6
         .. describe:: x >= y
 
             Checks if an Intents instance is a superset of another Intents instance.
+
+            .. versionadded:: 2.6
         .. describe:: x < y
 
-             Checks if an Intents instance is a strict subset of another Intents instance.
+            Checks if an Intents instance is a strict subset of another Intents instance.
+
+            .. versionadded:: 2.6
         .. describe:: x > y
 
-             Checks if an Intents instance is a strict superset of another Intents instance.
+            Checks if an Intents instance is a strict superset of another Intents instance.
+
+            .. versionadded:: 2.6
         .. describe:: x | y, x |= y
 
             Returns a new Intents instance with all enabled intents from both x and y.
@@ -1253,15 +1285,23 @@ class MemberCacheFlags(BaseFlags):
         .. describe:: x <= y
 
             Checks if an MemberCacheFlags instance is a subset of another MemberCacheFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x >= y
 
             Checks if an MemberCacheFlags instance is a superset of another MemberCacheFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x < y
 
-             Checks if an MemberCacheFlags instance is a strict subset of another MemberCacheFlags instance.
+            Checks if an MemberCacheFlags instance is a strict subset of another MemberCacheFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x > y
 
-             Checks if an MemberCacheFlags instance is a strict superset of another MemberCacheFlags instance.
+            Checks if an MemberCacheFlags instance is a strict superset of another MemberCacheFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x | y, x |= y
 
             Returns a new MemberCacheFlags instance with all enabled flags from both x and y.
@@ -1400,15 +1440,23 @@ class ApplicationFlags(BaseFlags):
         .. describe:: x <= y
 
             Checks if an ApplicationFlags instance is a subset of another ApplicationFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x >= y
 
             Checks if an ApplicationFlags instance is a superset of another ApplicationFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x < y
 
-             Checks if an ApplicationFlags instance is a strict subset of another ApplicationFlags instance.
+            Checks if an ApplicationFlags instance is a strict subset of another ApplicationFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x > y
 
-             Checks if an ApplicationFlags instance is a strict superset of another ApplicationFlags instance.
+            Checks if an ApplicationFlags instance is a strict superset of another ApplicationFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x | y, x |= y
 
             Returns a new ApplicationFlags instance with all enabled flags from both x and y.
@@ -1522,15 +1570,23 @@ class ChannelFlags(BaseFlags):
         .. describe:: x <= y
 
             Checks if an ChannelFlags instance is a subset of another ChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x >= y
 
             Checks if an ChannelFlags instance is a superset of another ChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x < y
 
-             Checks if an ChannelFlags instance is a strict subset of another ChannelFlags instance.
+            Checks if an ChannelFlags instance is a strict subset of another ChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x > y
 
-             Checks if an ChannelFlags instance is a strict superset of another ChannelFlags instance.
+            Checks if an ChannelFlags instance is a strict superset of another ChannelFlags instance.
+
+            .. versionadded:: 2.6
         .. describe:: x | y, x |= y
 
             Returns a new ChannelFlags instance with all enabled flags from both x and y.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -1343,8 +1343,7 @@ class MemberCacheFlags(BaseFlags):
     __slots__ = ()
 
     def __init__(self, **kwargs: bool):
-        bits = max(self.VALID_FLAGS.values()).bit_length()
-        self.value = (1 << bits) - 1
+        self.value = all_flags_value(self.VALID_FLAGS)
         for key, value in kwargs.items():
             if key not in self.VALID_FLAGS:
                 raise TypeError(f"{key!r} is not a valid flag name.")

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -154,7 +154,7 @@ class Permissions(BaseFlags):
                 raise TypeError(f"{key!r} is not a valid permission name.")
             setattr(self, key, value)
 
-    def is_subset(self, other: Permissions) -> bool:
+    def is_subset(self, other: Self) -> bool:
         """Returns ``True`` if self has the same or fewer permissions as other."""
         if isinstance(other, Permissions):
             return (self.value & other.value) == self.value
@@ -163,7 +163,7 @@ class Permissions(BaseFlags):
                 f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}"
             )
 
-    def is_superset(self, other: Permissions) -> bool:
+    def is_superset(self, other: Self) -> bool:
         """Returns ``True`` if self has the same or more permissions as other."""
         if isinstance(other, Permissions):
             return (self.value | other.value) == self.value
@@ -172,11 +172,11 @@ class Permissions(BaseFlags):
                 f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}"
             )
 
-    def is_strict_subset(self, other: Permissions) -> bool:
+    def is_strict_subset(self, other: Self) -> bool:
         """Returns ``True`` if the permissions on self are a strict subset of those on other."""
         return self.is_subset(other) and self != other
 
-    def is_strict_superset(self, other: Permissions) -> bool:
+    def is_strict_superset(self, other: Self) -> bool:
         """Returns ``True`` if the permissions on self are a strict superset of those on other."""
         return self.is_superset(other) and self != other
 

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -100,6 +100,29 @@ class Permissions(BaseFlags):
         .. describe:: x > y
 
              Checks if a permission is a strict superset of another permission.
+        .. describe:: x | y, x |= y
+
+            Returns a new Permissions with all enabled permissions from both x and y.
+            (Using `|=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x & y, x &= y
+
+            Returns a new Permissions with only permissions enabled on both x and y.
+            (Using `&=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe x ^ y, x ^= y
+
+            Returns a new Permissions with only permissions enabled on one of x or y, but not both.
+            (Using `^=` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe ~x
+
+            Returns a new Permissions with all permissions inverted from x.
+
+            .. versionadded:: 2.6
         .. describe:: hash(x)
 
                Return the permission's hash.

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -102,25 +102,25 @@ class Permissions(BaseFlags):
              Checks if a permission is a strict superset of another permission.
         .. describe:: x | y, x |= y
 
-            Returns a new Permissions with all enabled permissions from both x and y.
-            (Using `|=` will update in place).
+            Returns a new Permissions instance with all enabled permissions from both x and y.
+            (Using ``|=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe x & y, x &= y
+        .. describe:: x & y, x &= y
 
-            Returns a new Permissions with only permissions enabled on both x and y.
-            (Using `&=` will update in place).
-
-            .. versionadded:: 2.6
-        .. describe x ^ y, x ^= y
-
-            Returns a new Permissions with only permissions enabled on one of x or y, but not both.
-            (Using `^=` will update in place).
+            Returns a new Permissions instance with only permissions enabled on both x and y.
+            (Using ``&=`` will update in place).
 
             .. versionadded:: 2.6
-        .. describe ~x
+        .. describe:: x ^ y, x ^= y
 
-            Returns a new Permissions with all permissions inverted from x.
+            Returns a new Permissions instance with only permissions enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+            .. versionadded:: 2.6
+        .. describe:: ~x
+
+            Returns a new Permissions instance with all permissions from x inverted.
 
             .. versionadded:: 2.6
         .. describe:: hash(x)

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -180,6 +180,7 @@ class Permissions(BaseFlags):
         """Returns ``True`` if the permissions on self are a strict superset of those on other."""
         return self.is_superset(other) and self != other
 
+    # the parent uses `Self` for the `other` typehint but we use `Permissions` here for backwards compat.
     __le__ = is_subset  # type: ignore
     __ge__ = is_superset  # type: ignore
     __lt__ = is_strict_subset  # type: ignore

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -154,7 +154,7 @@ class Permissions(BaseFlags):
                 raise TypeError(f"{key!r} is not a valid permission name.")
             setattr(self, key, value)
 
-    def is_subset(self, other: Self) -> bool:
+    def is_subset(self, other: Permissions) -> bool:
         """Returns ``True`` if self has the same or fewer permissions as other."""
         if isinstance(other, Permissions):
             return (self.value & other.value) == self.value
@@ -163,7 +163,7 @@ class Permissions(BaseFlags):
                 f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}"
             )
 
-    def is_superset(self, other: Self) -> bool:
+    def is_superset(self, other: Permissions) -> bool:
         """Returns ``True`` if self has the same or more permissions as other."""
         if isinstance(other, Permissions):
             return (self.value | other.value) == self.value
@@ -172,18 +172,18 @@ class Permissions(BaseFlags):
                 f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}"
             )
 
-    def is_strict_subset(self, other: Self) -> bool:
+    def is_strict_subset(self, other: Permissions) -> bool:
         """Returns ``True`` if the permissions on self are a strict subset of those on other."""
         return self.is_subset(other) and self != other
 
-    def is_strict_superset(self, other: Self) -> bool:
+    def is_strict_superset(self, other: Permissions) -> bool:
         """Returns ``True`` if the permissions on self are a strict superset of those on other."""
         return self.is_superset(other) and self != other
 
-    __le__ = is_subset
-    __ge__ = is_superset
-    __lt__ = is_strict_subset
-    __gt__ = is_strict_superset
+    __le__ = is_subset  # type: ignore
+    __ge__ = is_superset  # type: ignore
+    __lt__ = is_strict_subset  # type: ignore
+    __gt__ = is_strict_superset  # type: ignore
 
     @classmethod
     @cached_creation

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -96,10 +96,10 @@ class Permissions(BaseFlags):
             Checks if a permission is a superset of another permission.
         .. describe:: x < y
 
-             Checks if a permission is a strict subset of another permission.
+            Checks if a permission is a strict subset of another permission.
         .. describe:: x > y
 
-             Checks if a permission is a strict superset of another permission.
+            Checks if a permission is a strict superset of another permission.
         .. describe:: x | y, x |= y
 
             Returns a new Permissions instance with all enabled permissions from both x and y.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds `&`, `|`, `^`, `~`, `<`, `<=`, `>`, and `>=` support to flags.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
