### PR TITLE
typing: use `typing_extensions.Self` instead of `TypeVar`s where applicable

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -74,6 +74,8 @@ T = TypeVar("T", bound=VoiceProtocol)
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from typing_extensions import Self
+
     from .asset import Asset
     from .channel import CategoryChannel, DMChannel, PartialMessageable
     from .client import Client
@@ -218,9 +220,6 @@ class _Overwrites:
 
     def is_member(self) -> bool:
         return self.type == 1
-
-
-GCH = TypeVar("GCH", bound="GuildChannel")
 
 
 class GuildChannel(ABC):
@@ -891,12 +890,12 @@ class GuildChannel(ABC):
             raise TypeError("Invalid overwrite type provided.")
 
     async def _clone_impl(
-        self: GCH,
+        self,
         base_attrs: Dict[str, Any],
         *,
         name: Optional[str] = None,
         reason: Optional[str] = None,
-    ) -> GCH:
+    ) -> Self:
         base_attrs["permission_overwrites"] = [x._asdict() for x in self._overwrites]
         base_attrs["parent_id"] = self.category_id
         base_attrs["name"] = name or self.name
@@ -911,7 +910,7 @@ class GuildChannel(ABC):
         self.guild._channels[obj.id] = obj  # type: ignore
         return obj
 
-    async def clone(self: GCH, *, name: Optional[str] = None, reason: Optional[str] = None) -> GCH:
+    async def clone(self, *, name: Optional[str] = None, reason: Optional[str] = None) -> Self:
         """|coro|
 
         Clones this channel. This creates a channel with the same properties

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -42,6 +42,8 @@ from .permissions import Permissions
 from .utils import MISSING, _get_as_snowflake, _maybe_cast
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .i18n import LocalizationProtocol, LocalizationValue, LocalizedOptional, LocalizedRequired
     from .state import ConnectionState
     from .types.interactions import (
@@ -650,7 +652,7 @@ class APIUserCommand(UserCommand, _APIApplicationCommandMixin):
     __repr_info__ = UserCommand.__repr_info__ + _APIApplicationCommandMixin.__repr_info__
 
     @classmethod
-    def from_dict(cls, data: ApplicationCommandPayload) -> APIUserCommand:
+    def from_dict(cls, data: ApplicationCommandPayload) -> Self:
         cmd_type = data.get("type", 0)
         if cmd_type != ApplicationCommandType.user.value:
             raise ValueError(f"Invalid payload type for UserCommand: {cmd_type}")
@@ -733,7 +735,7 @@ class APIMessageCommand(MessageCommand, _APIApplicationCommandMixin):
     __repr_info__ = MessageCommand.__repr_info__ + _APIApplicationCommandMixin.__repr_info__
 
     @classmethod
-    def from_dict(cls, data: ApplicationCommandPayload) -> APIMessageCommand:
+    def from_dict(cls, data: ApplicationCommandPayload) -> Self:
         cmd_type = data.get("type", 0)
         if cmd_type != ApplicationCommandType.message.value:
             raise ValueError(f"Invalid payload type for MessageCommand: {cmd_type}")
@@ -912,7 +914,7 @@ class APISlashCommand(SlashCommand, _APIApplicationCommandMixin):
     __repr_info__ = SlashCommand.__repr_info__ + _APIApplicationCommandMixin.__repr_info__
 
     @classmethod
-    def from_dict(cls, data: ApplicationCommandPayload) -> APISlashCommand:
+    def from_dict(cls, data: ApplicationCommandPayload) -> Self:
         cmd_type = data.get("type", 0)
         if cmd_type != ApplicationCommandType.chat_input.value:
             raise ValueError(f"Invalid payload type for SlashCommand: {cmd_type}")

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -42,7 +42,6 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    TypeVar,
     Union,
     cast,
     overload,
@@ -77,6 +76,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import Snowflake, SnowflakeTime
     from .asset import AssetBytes
     from .embeds import Embed
@@ -2871,9 +2872,6 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         return Webhook.from_state(data, state=self._state)
 
 
-DMC = TypeVar("DMC", bound="DMChannel")
-
-
 class DMChannel(disnake.abc.Messageable, Hashable):
     """Represents a Discord direct message channel.
 
@@ -2942,8 +2940,8 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         return f"<DMChannel id={self.id} recipient={self.recipient!r}>"
 
     @classmethod
-    def _from_message(cls: Type[DMC], state: ConnectionState, channel_id: int, user_id: int) -> DMC:
-        self: DMC = cls.__new__(cls)
+    def _from_message(cls, state: ConnectionState, channel_id: int, user_id: int) -> Self:
+        self = cls.__new__(cls)
         self._state = state
         self.id = channel_id
         # state.user won't be None here

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -102,7 +102,7 @@ if TYPE_CHECKING:
 
 __all__ = ("Client", "SessionStartLimit")
 
-Coro = TypeVar("Coro", bound=Callable[..., Coroutine[Any, Any, Any]])
+CoroT = TypeVar("CoroT", bound=Callable[..., Coroutine[Any, Any, Any]])
 
 
 _log = logging.getLogger(__name__)
@@ -1475,7 +1475,7 @@ class Client:
 
     # event registration
 
-    def event(self, coro: Coro) -> Coro:
+    def event(self, coro: CoroT) -> CoroT:
         """A decorator that registers an event to listen to.
 
         You can find more info about the events on the :ref:`documentation below <discord-api-events>`.

--- a/disnake/colour.py
+++ b/disnake/colour.py
@@ -23,16 +23,20 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+from __future__ import annotations
+
 import colorsys
 import random
-from typing import Any, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 
 __all__ = (
     "Colour",
     "Color",
 )
-
-CT = TypeVar("CT", bound="Colour")
 
 
 class Colour:
@@ -118,25 +122,23 @@ class Colour:
         return (self.r, self.g, self.b)
 
     @classmethod
-    def from_rgb(cls: Type[CT], r: int, g: int, b: int) -> CT:
+    def from_rgb(cls, r: int, g: int, b: int) -> Self:
         """Constructs a :class:`Colour` from an RGB tuple."""
         return cls((r << 16) + (g << 8) + b)
 
     @classmethod
-    def from_hsv(cls: Type[CT], h: float, s: float, v: float) -> CT:
+    def from_hsv(cls, h: float, s: float, v: float) -> Self:
         """Constructs a :class:`Colour` from an HSV tuple."""
         rgb = colorsys.hsv_to_rgb(h, s, v)
         return cls.from_rgb(*(int(x * 255) for x in rgb))
 
     @classmethod
-    def default(cls: Type[CT]) -> CT:
+    def default(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0``."""
         return cls(0)
 
     @classmethod
-    def random(
-        cls: Type[CT], *, seed: Optional[Union[int, str, float, bytes, bytearray]] = None
-    ) -> CT:
+    def random(cls, *, seed: Optional[Union[int, str, float, bytes, bytearray]] = None) -> Self:
         """A factory method that returns a :class:`Colour` with a random hue.
 
         .. note::
@@ -157,17 +159,17 @@ class Colour:
         return cls.from_hsv(rand.random(), 1, 1)
 
     @classmethod
-    def teal(cls: Type[CT]) -> CT:
+    def teal(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x1abc9c``."""
         return cls(0x1ABC9C)
 
     @classmethod
-    def dark_teal(cls: Type[CT]) -> CT:
+    def dark_teal(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x11806a``."""
         return cls(0x11806A)
 
     @classmethod
-    def brand_green(cls: Type[CT]) -> CT:
+    def brand_green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x57F287``.
 
         .. versionadded:: 2.0
@@ -175,67 +177,67 @@ class Colour:
         return cls(0x57F287)
 
     @classmethod
-    def green(cls: Type[CT]) -> CT:
+    def green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x2ecc71``."""
         return cls(0x2ECC71)
 
     @classmethod
-    def dark_green(cls: Type[CT]) -> CT:
+    def dark_green(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x1f8b4c``."""
         return cls(0x1F8B4C)
 
     @classmethod
-    def blue(cls: Type[CT]) -> CT:
+    def blue(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x3498db``."""
         return cls(0x3498DB)
 
     @classmethod
-    def dark_blue(cls: Type[CT]) -> CT:
+    def dark_blue(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x206694``."""
         return cls(0x206694)
 
     @classmethod
-    def purple(cls: Type[CT]) -> CT:
+    def purple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x9b59b6``."""
         return cls(0x9B59B6)
 
     @classmethod
-    def dark_purple(cls: Type[CT]) -> CT:
+    def dark_purple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x71368a``."""
         return cls(0x71368A)
 
     @classmethod
-    def magenta(cls: Type[CT]) -> CT:
+    def magenta(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe91e63``."""
         return cls(0xE91E63)
 
     @classmethod
-    def dark_magenta(cls: Type[CT]) -> CT:
+    def dark_magenta(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xad1457``."""
         return cls(0xAD1457)
 
     @classmethod
-    def gold(cls: Type[CT]) -> CT:
+    def gold(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xf1c40f``."""
         return cls(0xF1C40F)
 
     @classmethod
-    def dark_gold(cls: Type[CT]) -> CT:
+    def dark_gold(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xc27c0e``."""
         return cls(0xC27C0E)
 
     @classmethod
-    def orange(cls: Type[CT]) -> CT:
+    def orange(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe67e22``."""
         return cls(0xE67E22)
 
     @classmethod
-    def dark_orange(cls: Type[CT]) -> CT:
+    def dark_orange(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xa84300``."""
         return cls(0xA84300)
 
     @classmethod
-    def brand_red(cls: Type[CT]) -> CT:
+    def brand_red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xED4245``.
 
         .. versionadded:: 2.0
@@ -243,62 +245,62 @@ class Colour:
         return cls(0xED4245)
 
     @classmethod
-    def red(cls: Type[CT]) -> CT:
+    def red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xe74c3c``."""
         return cls(0xE74C3C)
 
     @classmethod
-    def dark_red(cls: Type[CT]) -> CT:
+    def dark_red(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x992d22``."""
         return cls(0x992D22)
 
     @classmethod
-    def lighter_grey(cls: Type[CT]) -> CT:
+    def lighter_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x95a5a6``."""
         return cls(0x95A5A6)
 
     lighter_gray = lighter_grey
 
     @classmethod
-    def dark_grey(cls: Type[CT]) -> CT:
+    def dark_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x607d8b``."""
         return cls(0x607D8B)
 
     dark_gray = dark_grey
 
     @classmethod
-    def light_grey(cls: Type[CT]) -> CT:
+    def light_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x979c9f``."""
         return cls(0x979C9F)
 
     light_gray = light_grey
 
     @classmethod
-    def darker_grey(cls: Type[CT]) -> CT:
+    def darker_grey(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x546e7a``."""
         return cls(0x546E7A)
 
     darker_gray = darker_grey
 
     @classmethod
-    def og_blurple(cls: Type[CT]) -> CT:
+    def og_blurple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x7289da``."""
         return cls(0x7289DA)
 
     old_blurple = og_blurple
 
     @classmethod
-    def blurple(cls: Type[CT]) -> CT:
+    def blurple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x5865F2``."""
         return cls(0x5865F2)
 
     @classmethod
-    def greyple(cls: Type[CT]) -> CT:
+    def greyple(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x99aab5``."""
         return cls(0x99AAB5)
 
     @classmethod
-    def dark_theme(cls: Type[CT]) -> CT:
+    def dark_theme(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0x36393F``.
         This will appear transparent on Discord's dark theme.
 
@@ -307,7 +309,7 @@ class Colour:
         return cls(0x36393F)
 
     @classmethod
-    def fuchsia(cls: Type[CT]) -> CT:
+    def fuchsia(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xEB459E``.
 
         .. versionadded:: 2.0
@@ -315,7 +317,7 @@ class Colour:
         return cls(0xEB459E)
 
     @classmethod
-    def yellow(cls: Type[CT]) -> CT:
+    def yellow(cls) -> Self:
         """A factory method that returns a :class:`Colour` with a value of ``0xFEE75C``.
 
         .. versionadded:: 2.0

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -45,6 +45,8 @@ from .partial_emoji import PartialEmoji, _EmojiTag
 from .utils import MISSING, get_slots
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .emoji import Emoji
     from .types.components import (
         ActionRow as ActionRowPayload,
@@ -107,8 +109,8 @@ class Component:
         return f"<{self.__class__.__name__} {attrs}>"
 
     @classmethod
-    def _raw_construct(cls: Type[C], **kwargs) -> C:
-        self: C = cls.__new__(cls)
+    def _raw_construct(cls, **kwargs) -> Self:
+        self = cls.__new__(cls)
         for slot in get_slots(cls):
             try:
                 value = kwargs[slot]

--- a/disnake/context_managers.py
+++ b/disnake/context_managers.py
@@ -26,15 +26,15 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Optional, Type, Union
 
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from typing_extensions import Self
+
     from .abc import Messageable
     from .channel import ForumChannel
-
-    TypingT = TypeVar("TypingT", bound="Typing")
 
 __all__ = ("Typing",)
 
@@ -64,7 +64,7 @@ class Typing:
             await typing(channel.id)
             await asyncio.sleep(5)
 
-    def __enter__(self: TypingT) -> TypingT:
+    def __enter__(self) -> Self:
         self.task: asyncio.Task = self.loop.create_task(self.do_typing())
         self.task.add_done_callback(_typing_done_callback)
         return self
@@ -77,7 +77,7 @@ class Typing:
     ) -> None:
         self.task.cancel()
 
-    async def __aenter__(self: TypingT) -> TypingT:
+    async def __aenter__(self) -> Self:
         self._channel = channel = await self.messageable._get_channel()
         await channel._state.http.send_typing(channel.id)
         return self.__enter__()

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -37,7 +37,7 @@ from .cooldowns import BucketType, CooldownMapping, MaxConcurrency
 from .errors import *
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec
+    from typing_extensions import Concatenate, ParamSpec, Self
 
     from disnake.interactions import ApplicationCommandInteraction
 
@@ -132,7 +132,7 @@ class InvokableApplicationCommand(ABC):
     __original_kwargs__: Dict[str, Any]
     body: ApplicationCommand
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> InvokableApplicationCommand:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         self = super().__new__(cls)
         # todo: refactor to not require None and change this to be based on the presence of a kwarg
         self.__original_kwargs__ = {k: v for k, v in kwargs.items() if v is not None}

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from disnake.interactions import ApplicationCommandInteraction
 
     from ._types import Check, Coro, Error, Hook
-    from .cog import Cog, CogT
+    from .cog import Cog
 
     ApplicationCommandInteractionT = TypeVar(
         "ApplicationCommandInteractionT", bound=ApplicationCommandInteraction, covariant=True
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
     CommandCallback = Callable[..., Coro[Any]]
     InteractionCommandCallback = Union[
-        Callable[Concatenate[CogT, ApplicationCommandInteractionT, P], Coro[Any]],
+        Callable[Concatenate["CogT", ApplicationCommandInteractionT, P], Coro[Any]],
         Callable[Concatenate[ApplicationCommandInteractionT, P], Coro[Any]],
     ]
 

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -25,17 +25,12 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any
 
 import disnake
 
 from .bot_base import BotBase, when_mentioned, when_mentioned_or
-from .context import Context
 from .interaction_bot_base import InteractionBotBase
-
-if TYPE_CHECKING:
-    from ._types import CoroFunc
-
 
 __all__ = (
     "when_mentioned",
@@ -48,10 +43,6 @@ __all__ = (
 )
 
 MISSING: Any = disnake.utils.MISSING
-
-T = TypeVar("T")
-CFT = TypeVar("CFT", bound="CoroFunc")
-CXT = TypeVar("CXT", bound="Context")
 
 
 class Bot(BotBase, InteractionBotBase, disnake.Client):

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -71,6 +71,7 @@ __all__ = (
 
 MISSING: Any = disnake.utils.MISSING
 
+T = TypeVar("T")
 CFT = TypeVar("CFT", bound="CoroFunc")
 CXT = TypeVar("CXT", bound="Context")
 
@@ -265,7 +266,7 @@ class BotBase(CommonBotBase, GroupMixin):
         except ValueError:
             pass
 
-    def check(self, func: CFT) -> CFT:
+    def check(self, func: T) -> T:
         """
         A decorator that adds a global check to the bot.
 
@@ -293,7 +294,8 @@ class BotBase(CommonBotBase, GroupMixin):
                 return ctx.command.qualified_name in allowed_commands
 
         """
-        self.add_check(func)
+        # T was used instead of Check to ensure the type matches on return
+        self.add_check(func)  # type: ignore
         return func
 
     def check_once(self, func: CFT) -> CFT:

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -71,7 +71,6 @@ __all__ = (
 
 MISSING: Any = disnake.utils.MISSING
 
-T = TypeVar("T")
 CFT = TypeVar("CFT", bound="CoroFunc")
 CXT = TypeVar("CXT", bound="Context")
 
@@ -266,7 +265,7 @@ class BotBase(CommonBotBase, GroupMixin):
         except ValueError:
             pass
 
-    def check(self, func: T) -> T:
+    def check(self, func: CFT) -> CFT:
         """
         A decorator that adds a global check to the bot.
 
@@ -294,8 +293,7 @@ class BotBase(CommonBotBase, GroupMixin):
                 return ctx.command.qualified_name in allowed_commands
 
         """
-        # T was used instead of Check to ensure the type matches on return
-        self.add_check(func)  # type: ignore
+        self.add_check(func)
         return func
 
     def check_once(self, func: CFT) -> CFT:

--- a/disnake/ext/commands/cog.py
+++ b/disnake/ext/commands/cog.py
@@ -50,6 +50,8 @@ from .ctx_menus_core import InvokableMessageCommand, InvokableUserCommand
 from .slash_core import InvokableSlashCommand
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from disnake.interactions import ApplicationCommandInteraction
 
     from .bot import AutoShardedBot, AutoShardedInteractionBot, Bot, InteractionBot
@@ -63,7 +65,6 @@ __all__ = (
     "Cog",
 )
 
-CogT = TypeVar("CogT", bound="Cog")
 FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 
 MISSING: Any = disnake.utils.MISSING
@@ -263,7 +264,7 @@ class Cog(metaclass=CogMeta):
     __cog_app_commands__: ClassVar[List[InvokableApplicationCommand]]
     __cog_listeners__: ClassVar[List[Tuple[str, str]]]
 
-    def __new__(cls: Type[CogT], *args: Any, **kwargs: Any) -> CogT:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # For issue 426, we need to store a copy of the command objects
         # since we modify them to inject `self` to them.
         # To do this, we need to interfere with the Cog creation process.
@@ -745,7 +746,7 @@ class Cog(metaclass=CogMeta):
         """Similar to :meth:`cog_after_slash_command_invoke` but for message commands."""
         pass
 
-    def _inject(self: CogT, bot: AnyBot) -> CogT:
+    def _inject(self, bot: AnyBot) -> Self:
         cls = self.__class__
 
         # realistically, the only thing that can cause loading errors

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
 __all__ = ("CommonBotBase",)
 
 CogT = TypeVar("CogT", bound="Cog")
-FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 CFT = TypeVar("CFT", bound="CoroFunc")
 
 MISSING: Any = disnake.utils.MISSING

--- a/disnake/ext/commands/cooldowns.py
+++ b/disnake/ext/commands/cooldowns.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import deque
-from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Optional
 
 from disnake.enums import Enum
 
@@ -36,6 +36,8 @@ from ...abc import PrivateChannel
 from .errors import MaxConcurrencyReached
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ...message import Message
 
 __all__ = (
@@ -45,9 +47,6 @@ __all__ = (
     "DynamicCooldownMapping",
     "MaxConcurrency",
 )
-
-C = TypeVar("C", bound="CooldownMapping")
-MC = TypeVar("MC", bound="MaxConcurrency")
 
 
 class BucketType(Enum):
@@ -222,7 +221,7 @@ class CooldownMapping:
         return self._type
 
     @classmethod
-    def from_cooldown(cls: Type[C], rate, per, type) -> C:
+    def from_cooldown(cls, rate, per, type) -> Self:
         return cls(Cooldown(rate, per), type)
 
     def _bucket_key(self, msg: Message) -> Any:
@@ -365,7 +364,7 @@ class MaxConcurrency:
         if not isinstance(per, BucketType):
             raise TypeError(f"max_concurrency 'per' must be of type BucketType not {type(per)!r}")
 
-    def copy(self: MC) -> MC:
+    def copy(self) -> Self:
         return self.__class__(self.number, per=self.per, wait=self.wait)
 
     def __repr__(self) -> str:

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -58,7 +58,7 @@ from .cooldowns import BucketType, Cooldown, CooldownMapping, DynamicCooldownMap
 from .errors import *
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec, TypeGuard
+    from typing_extensions import Concatenate, ParamSpec, Self, TypeGuard
 
     from disnake.message import Message
 
@@ -287,7 +287,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
     __original_kwargs__: Dict[str, Any]
 
-    def __new__(cls: Type[CommandT], *args: Any, **kwargs: Any) -> CommandT:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         # if you're wondering why this is done, it's because we need to ensure
         # we have a complete original copy of **kwargs even for classes that
         # mess with it by popping before delegating to the subclass __init__.

--- a/disnake/ext/commands/flags.py
+++ b/disnake/ext/commands/flags.py
@@ -40,8 +40,6 @@ from typing import (
     Pattern,
     Set,
     Tuple,
-    Type,
-    TypeVar,
     Union,
     get_args,
     get_origin,
@@ -67,6 +65,8 @@ __all__ = (
 
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .context import Context
 
 
@@ -276,7 +276,7 @@ class FlagsMeta(type):
         __commands_flag_prefix__: str
 
     def __new__(
-        cls: Type[type],
+        cls,
         name: str,
         bases: Tuple[type, ...],
         attrs: Dict[str, Any],
@@ -450,9 +450,6 @@ async def convert_flag(ctx: Context, argument: str, flag: Flag, annotation: Any 
         raise BadFlagArgument(flag) from e
 
 
-F = TypeVar("F", bound="FlagConverter")
-
-
 class FlagConverter(metaclass=FlagsMeta):
     """A converter that allows for a user-friendly flag syntax.
 
@@ -499,8 +496,8 @@ class FlagConverter(metaclass=FlagsMeta):
             yield (flag.name, getattr(self, flag.attribute))
 
     @classmethod
-    async def _construct_default(cls: Type[F], ctx: Context) -> F:
-        self: F = cls.__new__(cls)
+    async def _construct_default(cls, ctx: Context) -> Self:
+        self = cls.__new__(cls)
         flags = cls.__commands_flags__
         for flag in flags.values():
             if callable(flag.default):
@@ -570,7 +567,7 @@ class FlagConverter(metaclass=FlagsMeta):
         return result
 
     @classmethod
-    async def convert(cls: Type[F], ctx: Context, argument: str) -> F:
+    async def convert(cls, ctx: Context, argument: str) -> Self:
         """|coro|
 
         The method that actually converters an argument to the flag mapping.
@@ -599,7 +596,7 @@ class FlagConverter(metaclass=FlagsMeta):
         arguments = cls.parse_flags(argument)
         flags = cls.__commands_flags__
 
-        self: F = cls.__new__(cls)
+        self = cls.__new__(cls)
         for name, flag in flags.items():
             try:
                 values = arguments[name]

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -81,6 +81,7 @@ __all__ = ("InteractionBotBase",)
 
 MISSING: Any = disnake.utils.MISSING
 
+T = TypeVar("T")
 CFT = TypeVar("CFT", bound="CoroFunc")
 
 
@@ -1005,10 +1006,10 @@ class InteractionBotBase(CommonBotBase):
             except ValueError:
                 pass
 
-    def slash_command_check(self, func: CFT) -> CFT:
+    def slash_command_check(self, func: T) -> T:
         """Similar to :meth:`.check` but for slash commands."""
         # T was used instead of Check to ensure the type matches on return
-        self.add_app_command_check(func, slash_commands=True)
+        self.add_app_command_check(func, slash_commands=True)  # type: ignore
         return func
 
     def slash_command_check_once(self, func: CFT) -> CFT:
@@ -1016,10 +1017,10 @@ class InteractionBotBase(CommonBotBase):
         self.add_app_command_check(func, call_once=True, slash_commands=True)
         return func
 
-    def user_command_check(self, func: CFT) -> CFT:
+    def user_command_check(self, func: T) -> T:
         """Similar to :meth:`.check` but for user commands."""
         # T was used instead of Check to ensure the type matches on return
-        self.add_app_command_check(func, user_commands=True)
+        self.add_app_command_check(func, user_commands=True)  # type: ignore
         return func
 
     def user_command_check_once(self, func: CFT) -> CFT:
@@ -1027,10 +1028,10 @@ class InteractionBotBase(CommonBotBase):
         self.add_app_command_check(func, call_once=True, user_commands=True)
         return func
 
-    def message_command_check(self, func: CFT) -> CFT:
+    def message_command_check(self, func: T) -> T:
         """Similar to :meth:`.check` but for message commands."""
         # T was used instead of Check to ensure the type matches on return
-        self.add_app_command_check(func, message_commands=True)
+        self.add_app_command_check(func, message_commands=True)  # type: ignore
         return func
 
     def message_command_check_once(self, func: CFT) -> CFT:

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -51,7 +51,6 @@ from disnake.enums import ApplicationCommandType
 from . import errors
 from .base_core import InvokableApplicationCommand
 from .common_bot_base import CommonBotBase
-from .context import Context
 from .ctx_menus_core import (
     InvokableMessageCommand,
     InvokableUserCommand,
@@ -82,9 +81,7 @@ __all__ = ("InteractionBotBase",)
 
 MISSING: Any = disnake.utils.MISSING
 
-T = TypeVar("T")
 CFT = TypeVar("CFT", bound="CoroFunc")
-CXT = TypeVar("CXT", bound="Context")
 
 
 _log = logging.getLogger(__name__)
@@ -1008,10 +1005,10 @@ class InteractionBotBase(CommonBotBase):
             except ValueError:
                 pass
 
-    def slash_command_check(self, func: T) -> T:
+    def slash_command_check(self, func: CFT) -> CFT:
         """Similar to :meth:`.check` but for slash commands."""
         # T was used instead of Check to ensure the type matches on return
-        self.add_app_command_check(func, slash_commands=True)  # type: ignore
+        self.add_app_command_check(func, slash_commands=True)
         return func
 
     def slash_command_check_once(self, func: CFT) -> CFT:
@@ -1019,10 +1016,10 @@ class InteractionBotBase(CommonBotBase):
         self.add_app_command_check(func, call_once=True, slash_commands=True)
         return func
 
-    def user_command_check(self, func: T) -> T:
+    def user_command_check(self, func: CFT) -> CFT:
         """Similar to :meth:`.check` but for user commands."""
         # T was used instead of Check to ensure the type matches on return
-        self.add_app_command_check(func, user_commands=True)  # type: ignore
+        self.add_app_command_check(func, user_commands=True)
         return func
 
     def user_command_check_once(self, func: CFT) -> CFT:
@@ -1030,10 +1027,10 @@ class InteractionBotBase(CommonBotBase):
         self.add_app_command_check(func, call_once=True, user_commands=True)
         return func
 
-    def message_command_check(self, func: T) -> T:
+    def message_command_check(self, func: CFT) -> CFT:
         """Similar to :meth:`.check` but for message commands."""
         # T was used instead of Check to ensure the type matches on return
-        self.add_app_command_check(func, message_commands=True)  # type: ignore
+        self.add_app_command_check(func, message_commands=True)
         return func
 
     def message_command_check_once(self, func: CFT) -> CFT:

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -64,6 +64,8 @@ from . import errors
 from .converter import CONVERTER_MAPPING
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from disnake.app_commands import Choices
     from disnake.i18n import LocalizationValue, LocalizedOptional
     from disnake.types.interactions import ApplicationCommandOptionChoiceValue
@@ -464,7 +466,7 @@ class ParamInfo:
         param: inspect.Parameter,
         type_hints: Dict[str, Any],
         parsed_docstring: Dict[str, disnake.utils._DocstringParam] = None,
-    ) -> ParamInfo:
+    ) -> Self:
         # hopefully repeated parsing won't cause any problems
         parsed_docstring = parsed_docstring or {}
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import functools
 import operator
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -43,6 +44,10 @@ from typing import (
 
 from .enums import UserFlags
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+
 __all__ = (
     "SystemChannelFlags",
     "MessageFlags",
@@ -53,7 +58,6 @@ __all__ = (
     "ChannelFlags",
 )
 
-FV = TypeVar("FV", bound="flag_value")
 BF = TypeVar("BF", bound="BaseFlags")
 
 
@@ -63,7 +67,7 @@ class flag_value:
         self.__doc__ = func.__doc__
 
     @overload
-    def __get__(self: FV, instance: None, owner: Type[BF]) -> FV:
+    def __get__(self, instance: None, owner: Type[BF]) -> Self:
         ...
 
     @overload
@@ -87,7 +91,7 @@ class alias_flag_value(flag_value):
 
 
 def fill_with_flags(*, inverted: bool = False):
-    def decorator(cls: Type[BF]):
+    def decorator(cls: Type[BF]) -> Type[BF]:
         cls.VALID_FLAGS = {
             name: value.flag
             for name, value in cls.__dict__.items()
@@ -122,7 +126,7 @@ class BaseFlags:
             setattr(self, key, value)
 
     @classmethod
-    def _from_value(cls, value):
+    def _from_value(cls, value: int) -> Self:
         self = cls.__new__(cls)
         self.value = value
         return self
@@ -526,21 +530,21 @@ class Intents(BaseFlags):
             setattr(self, key, value)
 
     @classmethod
-    def all(cls: Type[Intents]) -> Intents:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything enabled."""
         self = cls.__new__(cls)
         self.value = functools.reduce(operator.or_, cls.VALID_FLAGS.values())
         return self
 
     @classmethod
-    def none(cls: Type[Intents]) -> Intents:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything disabled."""
         self = cls.__new__(cls)
         self.value = self.DEFAULT_VALUE
         return self
 
     @classmethod
-    def default(cls: Type[Intents]) -> Intents:
+    def default(cls) -> Self:
         """A factory method that creates a :class:`Intents` with everything enabled
         except :attr:`presences`, :attr:`members`, and :attr:`message_content`.
         """
@@ -1036,7 +1040,7 @@ class MemberCacheFlags(BaseFlags):
             setattr(self, key, value)
 
     @classmethod
-    def all(cls: Type[MemberCacheFlags]) -> MemberCacheFlags:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` with everything enabled."""
         bits = max(cls.VALID_FLAGS.values()).bit_length()
         value = (1 << bits) - 1
@@ -1045,7 +1049,7 @@ class MemberCacheFlags(BaseFlags):
         return self
 
     @classmethod
-    def none(cls: Type[MemberCacheFlags]) -> MemberCacheFlags:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` with everything disabled."""
         self = cls.__new__(cls)
         self.value = self.DEFAULT_VALUE
@@ -1077,7 +1081,7 @@ class MemberCacheFlags(BaseFlags):
         return 2
 
     @classmethod
-    def from_intents(cls: Type[MemberCacheFlags], intents: Intents) -> MemberCacheFlags:
+    def from_intents(cls, intents: Intents) -> Self:
         """A factory method that creates a :class:`MemberCacheFlags` based on
         the currently selected :class:`Intents`.
 

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -47,7 +47,6 @@ from typing import (
     NamedTuple,
     Optional,
     Protocol,
-    Type,
     TypeVar,
     Union,
 )
@@ -60,6 +59,8 @@ from .enums import SpeakingState
 from .errors import ConnectionClosed
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .client import Client
     from .state import ConnectionState
     from .types.gateway import (
@@ -82,8 +83,6 @@ if TYPE_CHECKING:
     from .voice_client import VoiceClient
 
     T = TypeVar("T")
-    WebSocketT = TypeVar("WebSocketT", bound="DiscordWebSocket")
-    VoiceWebSocketT = TypeVar("VoiceWebSocketT", bound="DiscordVoiceWebSocket")
 
     class DispatchFunc(Protocol):
         def __call__(self, event: str, *args: Any) -> None:
@@ -407,7 +406,7 @@ class DiscordWebSocket:
 
     @classmethod
     async def from_client(
-        cls: Type[WebSocketT],
+        cls,
         client: Client,
         *,
         initial: bool = False,
@@ -416,7 +415,7 @@ class DiscordWebSocket:
         session: Optional[str] = None,
         sequence: Optional[int] = None,
         resume: bool = False,
-    ) -> WebSocketT:
+    ) -> Self:
         """Creates a main websocket for Discord from a :class:`Client`.
 
         This is for internal use only.
@@ -932,12 +931,12 @@ class DiscordVoiceWebSocket:
 
     @classmethod
     async def from_client(
-        cls: Type[VoiceWebSocketT],
+        cls,
         client: VoiceClient,
         *,
         resume: bool = False,
         hook: Optional[HookFunc] = None,
-    ) -> VoiceWebSocketT:
+    ) -> Self:
         """Creates a voice websocket for the :class:`VoiceClient`."""
         gateway = f"wss://{client.endpoint}/?v=4"
         http = client._state.http

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -68,6 +68,8 @@ _log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from typing_extensions import Self
+
     from .enums import InteractionResponseType
     from .file import File
     from .message import Attachment
@@ -99,8 +101,6 @@ if TYPE_CHECKING:
     from .types.snowflake import Snowflake, SnowflakeList
 
     T = TypeVar("T")
-    BE = TypeVar("BE", bound=BaseException)
-    MU = TypeVar("MU", bound="MaybeUnlock")
     Response = Coroutine[Any, Any, T]
 
 _API_VERSION = 10
@@ -219,7 +219,7 @@ class MaybeUnlock:
         self.lock: asyncio.Lock = lock
         self._unlock: bool = True
 
-    def __enter__(self: MU) -> MU:
+    def __enter__(self) -> Self:
         return self
 
     def defer(self) -> None:
@@ -227,8 +227,8 @@ class MaybeUnlock:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BE]],
-        exc: Optional[BE],
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
         if self._unlock:

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Union
 
 from .. import utils
 from ..channel import _threaded_channel_factory
@@ -82,9 +82,6 @@ if TYPE_CHECKING:
         VoiceChannel,
         ForumChannel,
     ]
-
-
-AppCmdDataOptionT = TypeVar("AppCmdDataOptionT", bound="ApplicationCommandInteractionDataOption")
 
 
 class ApplicationCommandInteraction(Interaction):

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from .appinfo import PartialAppInfo
 from .asset import Asset
@@ -43,6 +43,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import GuildChannel
     from .guild import Guild
     from .state import ConnectionState
@@ -273,9 +275,6 @@ class PartialInviteGuild:
         return Asset._from_guild_image(self._state, self.id, self._splash, path="splashes")
 
 
-I = TypeVar("I", bound="Invite")
-
-
 class Invite(Hashable):
     """
     Represents a Discord :class:`Guild` or :class:`abc.GuildChannel` invite.
@@ -475,7 +474,7 @@ class Invite(Hashable):
             self.guild_scheduled_event: Optional[GuildScheduledEvent] = None
 
     @classmethod
-    def from_incomplete(cls: Type[I], *, state: ConnectionState, data: InvitePayload) -> I:
+    def from_incomplete(cls, *, state: ConnectionState, data: InvitePayload) -> Self:
         guild: Optional[Union[Guild, PartialInviteGuild]]
         try:
             guild_data = data["guild"]
@@ -502,7 +501,7 @@ class Invite(Hashable):
         return cls(state=state, data=data, guild=guild, channel=channel)
 
     @classmethod
-    def from_gateway(cls: Type[I], *, state: ConnectionState, data: GatewayInvitePayload) -> I:
+    def from_gateway(cls, *, state: ConnectionState, data: GatewayInvitePayload) -> Self:
         guild_id: Optional[int] = _get_as_snowflake(data, "guild_id")
         guild: Optional[Union[Guild, Object]] = state._get_guild(guild_id)
         channel_id = int(data["channel_id"])

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -39,8 +39,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
-    TypeVar,
     Union,
     cast,
     overload,
@@ -64,6 +62,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import Snowflake
     from .channel import DMChannel, StageChannel, VoiceChannel
     from .flags import PublicUserFlags
@@ -227,9 +227,6 @@ def flatten_user(cls):
     return cls
 
 
-M = TypeVar("M", bound="Member")
-
-
 @flatten_user
 class Member(disnake.abc.Messageable, _UserTag):
     """Represents a Discord member to a :class:`Guild`.
@@ -381,7 +378,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         return hash(self._user)
 
     @classmethod
-    def _from_message(cls: Type[M], *, message: Message, data: MemberPayload) -> M:
+    def _from_message(cls, *, message: Message, data: MemberPayload) -> Self:
         user_data = message.author._to_minimal_user_json()  # type: ignore
         return cls(
             data=data,
@@ -399,8 +396,8 @@ class Member(disnake.abc.Messageable, _UserTag):
 
     @classmethod
     def _try_upgrade(
-        cls: Type[M], *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState
-    ) -> Union[User, M]:
+        cls, *, data: UserWithMemberPayload, guild: Guild, state: ConnectionState
+    ) -> Union[User, Self]:
         # A User object with a 'member' key
         try:
             member_data = data.pop("member")
@@ -410,8 +407,8 @@ class Member(disnake.abc.Messageable, _UserTag):
             return cls(data=member_data, user_data=data, guild=guild, state=state)
 
     @classmethod
-    def _copy(cls: Type[M], member: M) -> M:
-        self: M = cls.__new__(cls)  # to bypass __init__
+    def _copy(cls, member: Member) -> Self:
+        self = cls.__new__(cls)  # to bypass __init__
 
         self._roles = utils.SnowflakeList(member._roles, is_sorted=True)
         self.joined_at = member.joined_at

--- a/disnake/mentions.py
+++ b/disnake/mentions.py
@@ -25,13 +25,15 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, List, Union
 
 from .enums import MessageType
 
 __all__ = ("AllowedMentions",)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import Snowflake
     from .message import Message
     from .types.message import AllowedMentions as AllowedMentionsPayload
@@ -49,8 +51,6 @@ class _FakeBool:
 
 
 default: Any = _FakeBool()
-
-A = TypeVar("A", bound="AllowedMentions")
 
 
 class AllowedMentions:
@@ -99,7 +99,7 @@ class AllowedMentions:
         self.replied_user = replied_user
 
     @classmethod
-    def all(cls: Type[A]) -> A:
+    def all(cls) -> Self:
         """A factory method that returns a :class:`AllowedMentions` with all fields explicitly set to ``True``
 
         .. versionadded:: 1.5
@@ -107,7 +107,7 @@ class AllowedMentions:
         return cls(everyone=True, users=True, roles=True, replied_user=True)
 
     @classmethod
-    def none(cls: Type[A]) -> A:
+    def none(cls) -> Self:
         """A factory method that returns a :class:`AllowedMentions` with all fields set to ``False``
 
         .. versionadded:: 1.5
@@ -115,7 +115,7 @@ class AllowedMentions:
         return cls(everyone=False, users=False, roles=False, replied_user=False)
 
     @classmethod
-    def from_message(cls: Type[A], message: Message) -> A:
+    def from_message(cls, message: Message) -> Self:
         """A factory method that returns a :class:`AllowedMentions` dervived from the current :class:`.Message` state.
 
         Note that this is not what AllowedMentions the message was sent with, but what the message actually mentioned.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -39,8 +39,6 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Type,
-    TypeVar,
     Union,
     cast,
     overload,
@@ -66,6 +64,8 @@ from .user import User
 from .utils import MISSING, escape_mentions
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .abc import GuildChannel, MessageableChannel, Snowflake
     from .channel import DMChannel
     from .guild import GuildMessageable
@@ -93,7 +93,6 @@ if TYPE_CHECKING:
     from .ui.action_row import Components, MessageUIComponent
     from .ui.view import View
 
-    MR = TypeVar("MR", bound="MessageReference")
     EmojiInputType = Union[Emoji, PartialEmoji, str]
 
 __all__ = (
@@ -573,7 +572,7 @@ class MessageReference:
         self.fail_if_not_exists: bool = fail_if_not_exists
 
     @classmethod
-    def with_state(cls: Type[MR], state: ConnectionState, data: MessageReferencePayload) -> MR:
+    def with_state(cls, state: ConnectionState, data: MessageReferencePayload) -> Self:
         self = cls.__new__(cls)
         self.message_id = utils._get_as_snowflake(data, "message_id")
         self.channel_id = int(data.pop("channel_id"))
@@ -584,7 +583,7 @@ class MessageReference:
         return self
 
     @classmethod
-    def from_message(cls: Type[MR], message: Message, *, fail_if_not_exists: bool = True) -> MR:
+    def from_message(cls, message: Message, *, fail_if_not_exists: bool = True) -> Self:
         """Creates a :class:`MessageReference` from an existing :class:`~disnake.Message`.
 
         .. versionadded:: 1.6

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -26,7 +26,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from . import utils
 from .asset import Asset, AssetMixin
@@ -35,6 +35,8 @@ __all__ = ("PartialEmoji",)
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from typing_extensions import Self
 
     from .state import ConnectionState
     from .types.activity import ActivityEmoji as ActivityEmojiPayload
@@ -48,9 +50,6 @@ class _EmojiTag:
 
     def _to_partial(self) -> PartialEmoji:
         raise NotImplementedError
-
-
-PE = TypeVar("PE", bound="PartialEmoji")
 
 
 class PartialEmoji(_EmojiTag, AssetMixin):
@@ -108,8 +107,8 @@ class PartialEmoji(_EmojiTag, AssetMixin):
 
     @classmethod
     def from_dict(
-        cls: Type[PE], data: Union[PartialEmojiPayload, ActivityEmojiPayload, Dict[str, Any]]
-    ) -> PE:
+        cls, data: Union[PartialEmojiPayload, ActivityEmojiPayload, Dict[str, Any]]
+    ) -> Self:
         return cls(
             animated=data.get("animated", False),
             id=utils._get_as_snowflake(data, "id"),
@@ -117,7 +116,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         )
 
     @classmethod
-    def from_str(cls: Type[PE], value: str) -> PE:
+    def from_str(cls, value: str) -> Self:
         """Converts a Discord string representation of an emoji to a :class:`PartialEmoji`.
 
         The formats accepted are:
@@ -164,13 +163,13 @@ class PartialEmoji(_EmojiTag, AssetMixin):
 
     @classmethod
     def with_state(
-        cls: Type[PE],
+        cls,
         state: ConnectionState,
         *,
         name: str,
         animated: bool = False,
         id: Optional[int] = None,
-    ) -> PE:
+    ) -> Self:
         self = cls(name=name, animated=animated, id=id)
         self._state = state
         return self

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -26,21 +26,13 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 from functools import wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Iterator,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Iterator, Optional, Set, Tuple
 
 from .flags import BaseFlags, alias_flag_value, fill_with_flags, flag_value
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 
 __all__ = (
     "Permissions",
@@ -74,9 +66,6 @@ def cached_creation(func):
         return cls(value)
 
     return wrapped
-
-
-P = TypeVar("P", bound="Permissions")
 
 
 @fill_with_flags()
@@ -175,14 +164,14 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def none(cls: Type[P]) -> P:
+    def none(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``False``."""
         return cls(0)
 
     @classmethod
     @cached_creation
-    def all(cls: Type[P]) -> P:
+    def all(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         permissions set to ``True``.
         """
@@ -190,7 +179,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def all_channel(cls: Type[P]) -> P:
+    def all_channel(cls) -> Self:
         """A :class:`Permissions` with all channel-specific permissions set to
         ``True`` and the guild-specific ones set to ``False``. The guild-specific
         permissions are currently:
@@ -234,7 +223,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def general(cls: Type[P]) -> P:
+    def general(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "General" permissions from the official Discord UI set to ``True``.
 
@@ -257,7 +246,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def membership(cls: Type[P]) -> P:
+    def membership(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Membership" permissions from the official Discord UI set to ``True``.
 
@@ -277,7 +266,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def text(cls: Type[P]) -> P:
+    def text(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Text" permissions from the official Discord UI set to ``True``.
 
@@ -309,7 +298,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def voice(cls: Type[P]) -> P:
+    def voice(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Voice" permissions from the official Discord UI set to ``True``.
 
@@ -330,7 +319,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def stage(cls: Type[P]) -> P:
+    def stage(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Stage Channel" permissions from the official Discord UI set to ``True``.
 
@@ -342,7 +331,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def stage_moderator(cls: Type[P]) -> P:
+    def stage_moderator(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Stage Moderator" permissions from the official Discord UI set to ``True``.
 
@@ -356,7 +345,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def events(cls: Type[P]) -> P:
+    def events(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Events" permissions from the official Discord UI set to ``True``.
 
@@ -368,7 +357,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def advanced(cls: Type[P]) -> P:
+    def advanced(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with all
         "Advanced" permissions from the official Discord UI set to ``True``.
 
@@ -380,7 +369,7 @@ class Permissions(BaseFlags):
 
     @classmethod
     @cached_creation
-    def private_channel(cls: Type[P]) -> P:
+    def private_channel(cls) -> Self:
         """A factory method that creates a :class:`Permissions` with the
         best representation of a PrivateChannel's permissions.
 
@@ -744,9 +733,6 @@ class Permissions(BaseFlags):
         return 1 << 40
 
 
-PO = TypeVar("PO", bound="PermissionOverwrite")
-
-
 def _augment_from_permissions(cls):
     cls.VALID_NAMES = set(Permissions.VALID_FLAGS)
     aliases = set()
@@ -899,7 +885,7 @@ class PermissionOverwrite:
         return allow, deny
 
     @classmethod
-    def from_pair(cls: Type[PO], allow: Permissions, deny: Permissions) -> PO:
+    def from_pair(cls, allow: Permissions, deny: Permissions) -> Self:
         """Creates an overwrite from an allow/deny pair of :class:`Permissions`."""
         ret = cls()
         for key, value in allow:

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -35,7 +35,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, Type, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, TypeVar, Union
 
 from . import utils
 from .errors import ClientException
@@ -43,13 +43,15 @@ from .oggparse import OggStream
 from .opus import Encoder as OpusEncoder
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .voice_client import VoiceClient
+
 
 MISSING = utils.MISSING
 
 
 AT = TypeVar("AT", bound="AudioSource")
-FT = TypeVar("FT", bound="FFmpegOpusAudio")
 
 _log = logging.getLogger(__name__)
 
@@ -432,14 +434,14 @@ class FFmpegOpusAudio(FFmpegAudio):
 
     @classmethod
     async def from_probe(
-        cls: Type[FT],
+        cls,
         source: str,
         *,
         method: Optional[
             Union[str, Callable[[str, str], Tuple[Optional[str], Optional[int]]]]
         ] = None,
         **kwargs: Any,
-    ) -> FT:
+    ) -> Self:
         """|coro|
 
         A factory method that creates a :class:`FFmpegOpusAudio` after probing

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from .asset import Asset
 from .colour import Colour
@@ -41,6 +41,8 @@ __all__ = (
 
 if TYPE_CHECKING:
     import datetime
+
+    from typing_extensions import Self
 
     from .asset import AssetBytes
     from .guild import Guild
@@ -110,9 +112,6 @@ class RoleTags:
             f"<RoleTags bot_id={self.bot_id} integration_id={self.integration_id} "
             f"premium_subscriber={self.is_premium_subscriber()}>"
         )
-
-
-R = TypeVar("R", bound="Role")
 
 
 class Role(Hashable):
@@ -210,7 +209,7 @@ class Role(Hashable):
     def __repr__(self) -> str:
         return f"<Role id={self.id} name={self.name!r}>"
 
-    def __lt__(self: R, other: R) -> bool:
+    def __lt__(self, other: Self) -> bool:
         if not isinstance(other, Role) or not isinstance(self, Role):
             return NotImplemented
 
@@ -231,16 +230,16 @@ class Role(Hashable):
 
         return False
 
-    def __le__(self: R, other: R) -> bool:
+    def __le__(self, other: Self) -> bool:
         r = Role.__lt__(other, self)
         if r is NotImplemented:
             return NotImplemented
         return not r
 
-    def __gt__(self: R, other: R) -> bool:
+    def __gt__(self, other: Self) -> bool:
         return Role.__lt__(other, self)
 
-    def __ge__(self: R, other: R) -> bool:
+    def __ge__(self, other: Self) -> bool:
         r = Role.__lt__(self, other)
         if r is NotImplemented:
             return NotImplemented

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
 
 import aiohttp
 
@@ -46,10 +46,10 @@ from .gateway import *
 from .state import AutoShardedConnectionState
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .activity import BaseActivity
     from .gateway import DiscordWebSocket
-
-    EI = TypeVar("EI", bound="EventItem")
 
 __all__ = (
     "AutoShardedClient",
@@ -76,12 +76,12 @@ class EventItem:
         self.shard: Optional["Shard"] = shard
         self.error: Optional[Exception] = error
 
-    def __lt__(self: EI, other: EI) -> bool:
+    def __lt__(self, other: Self) -> bool:
         if not isinstance(other, EventItem):
             return NotImplemented
         return self.type < other.type
 
-    def __eq__(self: EI, other: EI) -> bool:
+    def __eq__(self, other: Self) -> bool:
         if not isinstance(other, EventItem):
             return NotImplemented
         return self.type == other.type

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -104,7 +104,6 @@ if TYPE_CHECKING:
     from .voice_client import VoiceProtocol
 
     T = TypeVar("T")
-    CS = TypeVar("CS", bound="ConnectionState")
     Channel = Union[GuildChannel, VocalGuildChannel, PrivateChannel]
     PartialChannel = Union[Channel, PartialMessageable]
 

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import TYPE_CHECKING, Callable, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Callable, Optional, Tuple, TypeVar, Union, overload
 
 from ..components import Button as ButtonComponent
 from ..enums import ButtonStyle, ComponentType
@@ -41,11 +41,12 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..emoji import Emoji
     from .item import ItemCallbackType
     from .view import View
 
-B = TypeVar("B", bound="Button")
 V = TypeVar("V", bound="Optional[View]", covariant=True)
 
 
@@ -236,7 +237,7 @@ class Button(Item[V]):
             self._underlying.emoji = None
 
     @classmethod
-    def from_component(cls: Type[B], button: ButtonComponent) -> B:
+    def from_component(cls, button: ButtonComponent) -> Self:
         return cls(
             style=button.style,
             label=button.label,

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -35,7 +35,6 @@ from typing import (
     Optional,
     Protocol,
     Tuple,
-    Type,
     TypeVar,
     overload,
 )
@@ -46,6 +45,8 @@ I = TypeVar("I", bound="Item")
 V = TypeVar("V", bound="Optional[View]", covariant=True)
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..components import NestedComponent
     from ..enums import ComponentType
     from ..interactions import MessageInteraction
@@ -134,7 +135,7 @@ class Item(WrappedComponent, Generic[V]):
         return None
 
     @classmethod
-    def from_component(cls: Type[I], component: NestedComponent) -> I:
+    def from_component(cls, component: NestedComponent) -> Self:
         return cls()
 
     def is_dispatchable(self) -> bool:

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -27,18 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, TypeVar, Union, overload
 
 from ..components import SelectMenu, SelectOption
 from ..enums import ComponentType
@@ -52,12 +41,13 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..emoji import Emoji
     from ..interactions import MessageInteraction
     from .item import ItemCallbackType
     from .view import View
 
-S = TypeVar("S", bound="Select")
 V = TypeVar("V", bound="Optional[View]", covariant=True)
 
 
@@ -322,7 +312,7 @@ class Select(Item[V]):
         self._selected_values = interaction.values  # type: ignore
 
     @classmethod
-    def from_component(cls: Type[S], component: SelectMenu) -> S:
+    def from_component(cls, component: SelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import disnake.abc
 
@@ -37,6 +37,8 @@ from .utils import MISSING, _assetbytes_to_base64_data, snowflake_time
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from typing_extensions import Self
 
     from .asset import AssetBytes
     from .channel import DMChannel
@@ -51,8 +53,6 @@ __all__ = (
     "User",
     "ClientUser",
 )
-
-BU = TypeVar("BU", bound="BaseUser")
 
 
 class _UserTag:
@@ -122,7 +122,7 @@ class BaseUser(_UserTag):
         self.system = data.get("system", False)
 
     @classmethod
-    def _copy(cls: Type[BU], user: BU) -> BU:
+    def _copy(cls, user: BaseUser) -> Self:
         self = cls.__new__(cls)  # bypass __init__
 
         self.name = user.name
@@ -466,7 +466,7 @@ class User(BaseUser, disnake.abc.Messageable):
             pass
 
     @classmethod
-    def _copy(cls, user: User):
+    def _copy(cls, user: User) -> Self:
         self = super()._copy(user)
         self._stored = False
         return self

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -130,7 +130,7 @@ class _cached_property:
 if TYPE_CHECKING:
     from functools import cached_property as cached_property
 
-    from typing_extensions import ParamSpec
+    from typing_extensions import ParamSpec, Self
 
     from .abc import Snowflake
     from .asset import AssetBytes
@@ -160,7 +160,7 @@ class CachedSlotProperty(Generic[T, T_co]):
         self.__doc__ = getattr(function, "__doc__")
 
     @overload
-    def __get__(self, instance: None, owner: Type[T]) -> CachedSlotProperty[T, T_co]:
+    def __get__(self, instance: None, owner: Type[T]) -> Self:
         ...
 
     @overload


### PR DESCRIPTION
## Summary

Replaces patterns like `def f(cls: Type[T]) -> T:` with `def f(cls) -> Self:`, using the `typing_extensions` backport as `Self` is only available from 3.11 onwards.

see also https://github.com/DisnakeDev/disnake/pull/606#discussion_r915016389

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
