### PR TITLE
feat: check for venv before installing dependencies in nox setup

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -220,7 +220,7 @@ def setup(session: nox.Session):
             " Consider using a virtual environment (virtualenv/venv) instead. Continue anyway? [y/N]"
         )
         if confirm.lower() != "y":
-            session.error("Canceled")
+            session.error("Cancelled")
 
     session.log("Installing dependencies to the external environment.")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import re
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, TypeVar
 
@@ -95,6 +96,16 @@ def install(
         session.run("python", "-m", "pip", "install", *install_args)
     else:
         session.install(*install_args)
+
+
+def is_venv() -> bool:
+    # https://stackoverflow.com/a/42580137/5080607
+    return (
+        # virtualenv < v20
+        hasattr(sys, "real_prefix")
+        # virtualenv >= v20, others
+        or sys.base_prefix != sys.prefix
+    )
 
 
 @nox.session()
@@ -202,6 +213,15 @@ def coverage(session: nox.Session):
 @nox.session(python=False)
 def setup(session: nox.Session):
     """Set up the external environment."""
+    if session.interactive and not is_venv():
+        confirm = input(
+            "It looks like you are about to install the dependencies into your *global* python environment."
+            " This may overwrite other versions of the dependencies that you already have installed, including disnake itself."
+            " Consider using a virtual environment (virtualenv/venv) instead. Continue anyway? [y/N]"
+        )
+        if confirm.lower() != "y":
+            session.error("Canceled")
+
     session.log("Installing dependencies to the external environment.")
 
     if session.posargs:


### PR DESCRIPTION
## Summary

Adds a confirmation prompt when running `task setup_env`/`nox -s setup` outside of a virtual environment, which is generally not recommended.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
