### PR TITLE
ci: run check-pull-labels on synchronize

### DIFF
--- a/.github/workflows/check-pull-labels.yaml
+++ b/.github/workflows/check-pull-labels.yaml
@@ -2,20 +2,18 @@ name: check-pull-labels
 
 on:
   pull_request_target:
-    types: [opened, labeled, unlabeled, reopened]
+    types: [opened, synchronize, labeled, unlabeled, reopened]
 
 permissions:
   pull-requests: read
 
 jobs:
   check-pull-labels:
-    name:
-
     runs-on: ubuntu-latest
 
     steps:
       - name: Check for the do not merge label
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'do not merge') == true }}
+        if: "${{ contains(github.event.pull_request.labels.*.name, 'do not merge') == true }}"
         run: exit 1
 
       - name: Check for the blocked label


### PR DESCRIPTION
## Summary

If the check is skipped entirely, it'll be stuck as "pending" if another commit is pushed without changing labels
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

regression from #600

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
