### PR TITLE
deps: update pyright to 1.1.258

### DIFF
--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -1216,7 +1216,7 @@ async def _actual_conversion(
             if inspect.ismethod(converter.convert):
                 return await converter.convert(ctx, argument)
             else:
-                return await converter().convert(ctx, argument)  # type: ignore
+                return await converter().convert(ctx, argument)
         elif isinstance(converter, Converter):
             return await converter.convert(ctx, argument)  # type: ignore
     except CommandError:

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -80,6 +80,9 @@ if TYPE_CHECKING:
 
 if sys.version_info >= (3, 10):
     from types import EllipsisType, UnionType
+elif TYPE_CHECKING:
+    UnionType = object()
+    EllipsisType = ellipsis  # noqa: F821
 else:
     UnionType = object()
     EllipsisType = type(Ellipsis)

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -885,7 +885,7 @@ class DiscordVoiceWebSocket:
         self.secret_key: Optional[List[int]] = None
         self.thread_id: int = threading.get_ident()
         if hook:
-            self._hook = hook  # type: ignore
+            self._hook = hook
 
         # set in `from_client`
         self.gateway: str

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -316,7 +316,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
             elif self.limit == 101:
                 self.limit = 100  # Thanks Discord
 
-            self._retrieve_messages = self._retrieve_messages_around_strategy  # type: ignore
+            self._retrieve_messages = self._retrieve_messages_around_strategy
             if self.before and self.after:
                 self._filter = lambda m: self.after.id < int(m["id"]) < self.before.id  # type: ignore
             elif self.before:
@@ -325,11 +325,11 @@ class HistoryIterator(_AsyncIterator["Message"]):
                 self._filter = lambda m: self.after.id < int(m["id"])
         else:
             if self.reverse:
-                self._retrieve_messages = self._retrieve_messages_after_strategy  # type: ignore
+                self._retrieve_messages = self._retrieve_messages_after_strategy
                 if self.before:
                     self._filter = lambda m: int(m["id"]) < self.before.id  # type: ignore
             else:
-                self._retrieve_messages = self._retrieve_messages_before_strategy  # type: ignore
+                self._retrieve_messages = self._retrieve_messages_before_strategy
                 if self.after and self.after != OLDEST_OBJECT:
                     self._filter = lambda m: int(m["id"]) > self.after.id
 

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -273,8 +273,8 @@ class ConnectionState:
         self._intents: Intents = intents
 
         if not intents.members or cache_flags._empty:
-            self.store_user = self.create_user  # type: ignore
-            self.deref_user = self.deref_user_no_intents  # type: ignore
+            self.store_user = self.create_user
+            self.deref_user = self.deref_user_no_intents
 
         self.parsers = parsers = {}
         for attr, func in inspect.getmembers(self):

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -3,7 +3,7 @@
 ## type checking
 typing_extensions~=4.2.0
 # this is not pyright itself, but the python wrapper
-pyright==1.1.254
+pyright==1.1.258
 
 
 ## linting

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -248,7 +248,7 @@ def test_components_to_rows__invalid():
             components_to_rows(value)  # type: ignore
     for value in ([[[]]], [[[ActionRow()]]]):
         with pytest.raises(TypeError, match=r"components should be of type"):
-            components_to_rows(value)
+            components_to_rows(value)  # type: ignore
 
 
 def test_components_to_dict():


### PR DESCRIPTION
## Summary

Updates pyright to 1.1.258 - not using the currently latest version 1.1.261 due to performance issues (~2.5x slowdown, unknown origin).

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
