### PR TITLE
fix: replace old command objects in cogs with new copies

### DIFF
--- a/changelog/575.bugfix.rst
+++ b/changelog/575.bugfix.rst
@@ -1,0 +1,1 @@
+Replace old application command objects in cogs with the new/copied objects.

--- a/disnake/ext/commands/cog.py
+++ b/disnake/ext/commands/cog.py
@@ -271,8 +271,6 @@ class Cog(metaclass=CogMeta):
         message_cmd_attrs = cls.__cog_message_settings__
 
         # Either update the command with the cog provided defaults or copy it.
-        # r.e type ignore, type-checker complains about overriding a ClassVar
-        self.__cog_commands__ = tuple(c._update_copy(cmd_attrs) for c in cls.__cog_commands__)  # type: ignore
         cog_app_commands: List[InvokableApplicationCommand] = []
         for c in cls.__cog_app_commands__:
             if isinstance(c, InvokableSlashCommand):
@@ -284,11 +282,14 @@ class Cog(metaclass=CogMeta):
 
             cog_app_commands.append(c)
 
-        self.__cog_app_commands__ = tuple(cog_app_commands)  # type: ignore
+        self.__cog_app_commands__ = tuple(cog_app_commands)  # type: ignore  # overriding ClassVar
+        # Replace the old command objects with the new copies
+        for app_command in self.__cog_app_commands__:
+            setattr(self, app_command.callback.__name__, app_command)
+
+        self.__cog_commands__ = tuple(c._update_copy(cmd_attrs) for c in cls.__cog_commands__)  # type: ignore  # overriding ClassVar
 
         lookup = {cmd.qualified_name: cmd for cmd in self.__cog_commands__}
-
-        # Update the Command instances dynamically as well
         for command in self.__cog_commands__:
             setattr(self, command.callback.__name__, command)
             parent = command.parent


### PR DESCRIPTION
## Summary

Fixes #575.
Previously, accessing `self.<command_name>` in a cog would return the old/original command object, not the copied one, which resulted in a few issues.
This applies a fix that's effectively the same as what prefix commands were already doing.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
