### PR TITLE
fix(docs): float the footer when it clips the nav aside

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -279,6 +279,9 @@ footer {
   font-size: 14px;
   text-align: center;
   color: var(--footer-text);
+  /* Elevate above the aside */
+  position: relative;
+  z-index: 5;
 }
 
 footer a {
@@ -304,6 +307,8 @@ aside {
   color: var(--nav-text);
   left: 0;
   padding: 12px;
+  /* Space for footer overlap on bottom */
+  padding-bottom: calc(calc(calc(0.8em * 2) + 12px) + 1em);
   overflow: auto;
   z-index: 3;
   top: 50px; /* Space for sticky header */


### PR DESCRIPTION
## Summary

Fixes an issue where on some screens the footer was being clipped by the navigation tree and wasn't fully visible

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
