### PR TITLE
feat: allow setting ChannelFlags directly when editing a channel or thread

### DIFF
--- a/changelog/642.feature.rst
+++ b/changelog/642.feature.rst
@@ -1,0 +1,1 @@
+Add support for setting :class:`ChannelFlags` directly when editing a channel or thread.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -324,6 +324,7 @@ class GuildChannel(ABC):
         user_limit: int = MISSING,
         rtc_region: Optional[Union[str, VoiceRegion]] = MISSING,
         video_quality_mode: VideoQualityMode = MISSING,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = None,
     ) -> Optional[ChannelPayload]:
         parent_id: Optional[int]
@@ -413,6 +414,7 @@ class GuildChannel(ABC):
             "rtc_region": rtc_region_payload,
             "video_quality_mode": video_quality_mode_payload,
             "default_auto_archive_duration": default_auto_archive_duration_payload,
+            "flags": flags.value if flags is not MISSING else flags,
         }
         options = {k: v for k, v in options.items() if v is not MISSING}
 

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -400,6 +400,13 @@ class GuildChannel(ABC):
         else:
             type_payload = MISSING
 
+        if flags is not MISSING:
+            if not isinstance(flags, ChannelFlags):
+                raise TypeError("flags field must be of type ChannelFlags")
+            flags_payload = flags.value
+        else:
+            flags_payload = MISSING
+
         options: Dict[str, Any] = {
             "name": name,
             "parent_id": parent_id,
@@ -414,7 +421,7 @@ class GuildChannel(ABC):
             "rtc_region": rtc_region_payload,
             "video_quality_mode": video_quality_mode_payload,
             "default_auto_archive_duration": default_auto_archive_duration_payload,
-            "flags": flags.value if flags is not MISSING else flags,
+            "flags": flags_payload,
         }
         options = {k: v for k, v in options.items() if v is not MISSING}
 

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -365,6 +365,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         default_auto_archive_duration: Optional[AnyThreadArchiveDuration] = MISSING,
         type: ChannelType = MISSING,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = MISSING,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = None,
         **kwargs: Never,
     ) -> Optional[TextChannel]:
@@ -416,6 +417,11 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         default_auto_archive_duration: Optional[Union[:class:`int`, :class:`ThreadArchiveDuration`]]
             The new default auto archive duration in minutes for threads created in this channel.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
+        flags: :class:`ChannelFlags`
+            The new flags to set for this channel.
+
+            .. versionadded:: 2.6
+
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
 
@@ -447,6 +453,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             default_auto_archive_duration=default_auto_archive_duration,
             type=type,
             overwrites=overwrites,
+            flags=flags,
             reason=reason,
             **kwargs,
         )
@@ -1295,6 +1302,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
         video_quality_mode: VideoQualityMode = ...,
         nsfw: bool = ...,
         slowmode_delay: Optional[int] = ...,
+        flags: ChannelFlags = ...,
         reason: Optional[str] = ...,
     ) -> VoiceChannel:
         ...
@@ -1313,6 +1321,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
         video_quality_mode: VideoQualityMode = MISSING,
         nsfw: bool = MISSING,
         slowmode_delay: Optional[int] = MISSING,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = None,
         **kwargs: Never,
     ) -> Optional[VoiceChannel]:
@@ -1375,6 +1384,11 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
 
             .. versionadded:: 2.3
 
+        flags: :class:`ChannelFlags`
+            The new flags to set for this channel.
+
+            .. versionadded:: 2.6
+
         Raises
         ------
         Forbidden
@@ -1404,6 +1418,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
             video_quality_mode=video_quality_mode,
             nsfw=nsfw,
             slowmode_delay=slowmode_delay,
+            flags=flags,
             reason=reason,
             **kwargs,
         )
@@ -1930,6 +1945,7 @@ class StageChannel(VocalGuildChannel):
         rtc_region: Optional[Union[str, VoiceRegion]] = ...,
         video_quality_mode: VideoQualityMode = ...,
         bitrate: int = MISSING,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = ...,
     ) -> StageChannel:
         ...
@@ -1945,6 +1961,7 @@ class StageChannel(VocalGuildChannel):
         rtc_region: Optional[Union[str, VoiceRegion]] = MISSING,
         video_quality_mode: VideoQualityMode = MISSING,
         bitrate: int = MISSING,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = None,
         **kwargs: Never,
     ) -> Optional[StageChannel]:
@@ -1992,6 +2009,11 @@ class StageChannel(VocalGuildChannel):
 
             .. versionadded:: 2.6
 
+        flags: :class:`ChannelFlags`
+            The new flags to set for this channel.
+
+            .. versionadded:: 2.6
+
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
 
@@ -2021,6 +2043,7 @@ class StageChannel(VocalGuildChannel):
             rtc_region=rtc_region,
             video_quality_mode=video_quality_mode,
             bitrate=bitrate,
+            flags=flags,
             reason=reason,
             **kwargs,
         )
@@ -2155,6 +2178,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         position: int = MISSING,
         nsfw: bool = MISSING,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = MISSING,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = None,
         **kwargs: Never,
     ) -> Optional[CategoryChannel]:
@@ -2185,6 +2209,11 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         overwrites: :class:`Mapping`
             A :class:`Mapping` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply to the category.
+        flags: :class:`ChannelFlags`
+            The new flags to set for this channel.
+
+            .. versionadded:: 2.6
+
         reason: Optional[:class:`str`]
             The reason for editing this category. Shows up on the audit log.
 
@@ -2210,6 +2239,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
             position=position,
             nsfw=nsfw,
             overwrites=overwrites,
+            flags=flags,
             reason=reason,
             **kwargs,
         )
@@ -2630,6 +2660,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         slowmode_delay: Optional[int] = ...,
         default_auto_archive_duration: Optional[AnyThreadArchiveDuration] = ...,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = ...,
+        flags: ChannelFlags = ...,
         reason: Optional[str] = ...,
     ) -> ForumChannel:
         ...
@@ -2646,6 +2677,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         slowmode_delay: Optional[int] = MISSING,
         default_auto_archive_duration: Optional[AnyThreadArchiveDuration] = MISSING,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = MISSING,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = None,
         **kwargs: Never,
     ) -> Optional[ForumChannel]:
@@ -2684,6 +2716,11 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         default_auto_archive_duration: Optional[Union[:class:`int`, :class:`ThreadArchiveDuration`]]
             The new default auto archive duration in minutes for threads created in this channel.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
+        flags: :class:`ChannelFlags`
+            The new flags to set for this channel.
+
+            .. versionadded:: 2.6
+
         reason: Optional[:class:`str`]
             The reason for editing this channel. Shows up on the audit log.
 
@@ -2714,6 +2751,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
             slowmode_delay=slowmode_delay,
             default_auto_archive_duration=default_auto_archive_duration,
             overwrites=overwrites,
+            flags=flags,
             reason=reason,
             **kwargs,
         )

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -348,6 +348,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         default_auto_archive_duration: Optional[AnyThreadArchiveDuration] = ...,
         type: ChannelType = ...,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = ...,
+        flags: ChannelFlags = ...,
         reason: Optional[str] = ...,
     ) -> TextChannel:
         ...
@@ -1944,8 +1945,8 @@ class StageChannel(VocalGuildChannel):
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = ...,
         rtc_region: Optional[Union[str, VoiceRegion]] = ...,
         video_quality_mode: VideoQualityMode = ...,
-        bitrate: int = MISSING,
-        flags: ChannelFlags = MISSING,
+        bitrate: int = ...,
+        flags: ChannelFlags = ...,
         reason: Optional[str] = ...,
     ) -> StageChannel:
         ...
@@ -2167,6 +2168,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         position: int = ...,
         nsfw: bool = ...,
         overwrites: Mapping[Union[Role, Member], PermissionOverwrite] = ...,
+        flags: ChannelFlags = ...,
         reason: Optional[str] = ...,
     ) -> CategoryChannel:
         ...

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -419,7 +419,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             The new default auto archive duration in minutes for threads created in this channel.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         flags: :class:`ChannelFlags`
-            The new flags to set for this channel.
+            The new flags to set for this channel. This will overwrite any existing flags set on this channel.
 
             .. versionadded:: 2.6
 
@@ -1386,7 +1386,7 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
             .. versionadded:: 2.3
 
         flags: :class:`ChannelFlags`
-            The new flags to set for this channel.
+            The new flags to set for this channel. This will overwrite any existing flags set on this channel.
 
             .. versionadded:: 2.6
 
@@ -2011,7 +2011,7 @@ class StageChannel(VocalGuildChannel):
             .. versionadded:: 2.6
 
         flags: :class:`ChannelFlags`
-            The new flags to set for this channel.
+            The new flags to set for this channel. This will overwrite any existing flags set on this channel.
 
             .. versionadded:: 2.6
 
@@ -2212,7 +2212,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
             A :class:`Mapping` of target (either a role or a member) to
             :class:`PermissionOverwrite` to apply to the category.
         flags: :class:`ChannelFlags`
-            The new flags to set for this channel.
+            The new flags to set for this channel. This will overwrite any existing flags set on this channel.
 
             .. versionadded:: 2.6
 
@@ -2719,7 +2719,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
             The new default auto archive duration in minutes for threads created in this channel.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
         flags: :class:`ChannelFlags`
-            The new flags to set for this channel.
+            The new flags to set for this channel. This will overwrite any existing flags set on this channel.
 
             .. versionadded:: 2.6
 

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -620,6 +620,7 @@ class Thread(Messageable, Hashable):
         slowmode_delay: int = MISSING,
         auto_archive_duration: AnyThreadArchiveDuration = MISSING,
         pinned: bool = MISSING,
+        flags: ChannelFlags = None,
         reason: Optional[str] = None,
     ) -> Thread:
         """|coro|
@@ -655,6 +656,11 @@ class Thread(Messageable, Hashable):
 
             .. versionadded:: 2.5
 
+        flags: :class:`ChannelFlags`
+            The new channel flags to set for this thread.
+
+            .. versionadded:: 2.6
+
         reason: Optional[:class:`str`]
             The reason for editing this thread. Shows up on the audit log.
 
@@ -685,9 +691,14 @@ class Thread(Messageable, Hashable):
             payload["invitable"] = invitable
         if slowmode_delay is not MISSING:
             payload["rate_limit_per_user"] = slowmode_delay
+
         if pinned is not MISSING:
-            flags = ChannelFlags._from_value(self._flags)
+            # create base flags if flags are provided, otherwise use the internal flags.
+            if flags is None:
+                flags = ChannelFlags._from_value(self._flags)
             flags.pinned = pinned
+            payload["flags"] = flags.value
+        if flags is not None:
             payload["flags"] = flags.value
 
         data = await self._state.http.edit_channel(self.id, **payload, reason=reason)

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -694,10 +694,9 @@ class Thread(Messageable, Hashable):
 
         if pinned is not MISSING:
             # create base flags if flags are provided, otherwise use the internal flags.
-            if flags is None:
-                flags = ChannelFlags._from_value(self._flags)
+            flags = ChannelFlags._from_value(self._flags if flags is None else flags.value)
             flags.pinned = pinned
-            payload["flags"] = flags.value
+
         if flags is not None:
             payload["flags"] = flags.value
 

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -620,7 +620,7 @@ class Thread(Messageable, Hashable):
         slowmode_delay: int = MISSING,
         auto_archive_duration: AnyThreadArchiveDuration = MISSING,
         pinned: bool = MISSING,
-        flags: ChannelFlags = None,
+        flags: ChannelFlags = MISSING,
         reason: Optional[str] = None,
     ) -> Thread:
         """|coro|
@@ -695,10 +695,12 @@ class Thread(Messageable, Hashable):
 
         if pinned is not MISSING:
             # create base flags if flags are provided, otherwise use the internal flags.
-            flags = ChannelFlags._from_value(self._flags if flags is None else flags.value)
+            flags = ChannelFlags._from_value(self._flags if flags is MISSING else flags.value)
             flags.pinned = pinned
 
-        if flags is not None:
+        if flags is not MISSING:
+            if not isinstance(flags, ChannelFlags):
+                raise TypeError("flags field must be of type ChannelFlags")
             payload["flags"] = flags.value
 
         data = await self._state.http.edit_channel(self.id, **payload, reason=reason)

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -657,7 +657,8 @@ class Thread(Messageable, Hashable):
             .. versionadded:: 2.5
 
         flags: :class:`ChannelFlags`
-            The new channel flags to set for this thread.
+            The new channel flags to set for this thread. This will overwrite any existing flags set on this channel.
+            If parameter ``pinned`` is provided, that will override the setting of :attr:`ChannelFlags.pinned`.
 
             .. versionadded:: 2.6
 


### PR DESCRIPTION
## Summary
```py
await channel.edit(flags=disnake.ChannelFlags(pinned=True)
```
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
