### PR TITLE
refactor: standardize id regex to {17,19}

### DIFF
--- a/changelog/651.misc.rst
+++ b/changelog/651.misc.rst
@@ -1,1 +1,1 @@
-Update and standardise all internal Snowflake regexes to be between 17 and 19 characters (inclusive).
+Update and standardise all internal Snowflake regexes to match between 17 and 19 characters (inclusive).

--- a/changelog/651.misc.rst
+++ b/changelog/651.misc.rst
@@ -1,0 +1,1 @@
+Update and standardise all internal Snowflake regexes to be between 17 and 19 characters (inclusive).

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -166,7 +166,7 @@ class Converter(Protocol[T_co]):
         raise NotImplementedError("Derived classes need to implement this.")
 
 
-_ID_REGEX = re.compile(r"([0-9]{15,20})$")
+_ID_REGEX = re.compile(r"([0-9]{17,19})$")
 
 
 class IDConverter(Converter[T_co]):
@@ -190,7 +190,7 @@ class ObjectConverter(IDConverter[disnake.Object]):
 
     async def convert(self, ctx: AnyContext, argument: str) -> disnake.Object:
         match = self._get_id_match(argument) or re.match(
-            r"<(?:@(?:!|&)?|#)([0-9]{15,20})>$", argument
+            r"<(?:@(?:!|&)?|#)([0-9]{17,19})>$", argument
         )
 
         if match is None:
@@ -260,7 +260,7 @@ class MemberConverter(IDConverter[disnake.Member]):
 
     async def convert(self, ctx: AnyContext, argument: str) -> disnake.Member:
         bot: disnake.Client = ctx.bot
-        match = self._get_id_match(argument) or re.match(r"<@!?([0-9]{15,20})>$", argument)
+        match = self._get_id_match(argument) or re.match(r"<@!?([0-9]{17,19})>$", argument)
         guild = ctx.guild
         result: Optional[disnake.Member] = None
         user_id: Optional[int] = None
@@ -321,7 +321,7 @@ class UserConverter(IDConverter[disnake.User]):
     """
 
     async def convert(self, ctx: AnyContext, argument: str) -> disnake.User:
-        match = self._get_id_match(argument) or re.match(r"<@!?([0-9]{15,20})>$", argument)
+        match = self._get_id_match(argument) or re.match(r"<@!?([0-9]{17,19})>$", argument)
         state = ctx._state
         bot: disnake.Client = ctx.bot
         result: Optional[Union[disnake.User, disnake.Member]] = None
@@ -385,11 +385,11 @@ class PartialMessageConverter(Converter[disnake.PartialMessage]):
 
     @staticmethod
     def _get_id_matches(ctx: AnyContext, argument: str) -> Tuple[Optional[int], int, int]:
-        id_regex = re.compile(r"(?:(?P<channel_id>[0-9]{15,20})-)?(?P<message_id>[0-9]{15,20})$")
+        id_regex = re.compile(r"(?:(?P<channel_id>[0-9]{17,19})-)?(?P<message_id>[0-9]{17,19})$")
         link_regex = re.compile(
             r"https?://(?:(ptb|canary|www)\.)?discord(?:app)?\.com/channels/"
-            r"(?P<guild_id>[0-9]{15,20}|@me)"
-            r"/(?P<channel_id>[0-9]{15,20})/(?P<message_id>[0-9]{15,20})/?$"
+            r"(?P<guild_id>[0-9]{17,19}|@me)"
+            r"/(?P<channel_id>[0-9]{17,19})/(?P<message_id>[0-9]{17,19})/?$"
         )
         match = id_regex.match(argument) or link_regex.match(argument)
         if not match:
@@ -481,7 +481,7 @@ class GuildChannelConverter(IDConverter[disnake.abc.GuildChannel]):
     def _resolve_channel(ctx: AnyContext, argument: str, attribute: str, type: Type[CT]) -> CT:
         bot: disnake.Client = ctx.bot
 
-        match = IDConverter._get_id_match(argument) or re.match(r"<#([0-9]{15,20})>$", argument)
+        match = IDConverter._get_id_match(argument) or re.match(r"<#([0-9]{17,19})>$", argument)
         result: Optional[disnake.abc.GuildChannel] = None
         guild = ctx.guild
 
@@ -508,7 +508,7 @@ class GuildChannelConverter(IDConverter[disnake.abc.GuildChannel]):
 
     @staticmethod
     def _resolve_thread(ctx: AnyContext, argument: str, attribute: str, type: Type[TT]) -> TT:
-        match = IDConverter._get_id_match(argument) or re.match(r"<#([0-9]{15,20})>$", argument)
+        match = IDConverter._get_id_match(argument) or re.match(r"<#([0-9]{17,19})>$", argument)
         result: Optional[disnake.Thread] = None
         guild = ctx.guild
 
@@ -763,7 +763,7 @@ class RoleConverter(IDConverter[disnake.Role]):
         if not guild:
             raise NoPrivateMessage()
 
-        match = self._get_id_match(argument) or re.match(r"<@&([0-9]{15,20})>$", argument)
+        match = self._get_id_match(argument) or re.match(r"<@&([0-9]{17,19})>$", argument)
         if match:
             result = guild.get_role(int(match.group(1)))
         else:
@@ -843,7 +843,7 @@ class EmojiConverter(IDConverter[disnake.Emoji]):
 
     async def convert(self, ctx: AnyContext, argument: str) -> disnake.Emoji:
         match = self._get_id_match(argument) or re.match(
-            r"<a?:[a-zA-Z0-9\_]{1,32}:([0-9]{15,20})>$", argument
+            r"<a?:[a-zA-Z0-9\_]{1,32}:([0-9]{17,19})>$", argument
         )
         result: Optional[disnake.Emoji] = None
         bot = ctx.bot
@@ -876,7 +876,7 @@ class PartialEmojiConverter(Converter[disnake.PartialEmoji]):
     """
 
     async def convert(self, ctx: AnyContext, argument: str) -> disnake.PartialEmoji:
-        match = re.match(r"<(a?):([a-zA-Z0-9\_]{1,32}):([0-9]{15,20})>$", argument)
+        match = re.match(r"<(a?):([a-zA-Z0-9\_]{1,32}):([0-9]{17,19})>$", argument)
 
         if match:
             emoji_animated = bool(match.group(1))
@@ -987,7 +987,7 @@ class GuildScheduledEventConverter(IDConverter[disnake.GuildScheduledEvent]):
     async def convert(self, ctx: AnyContext, argument: str) -> disnake.GuildScheduledEvent:
         event_regex = re.compile(
             r"https?://(?:(?:ptb|canary|www)\.)?discord(?:app)?\.com/events/"
-            r"([0-9]{15,20})/([0-9]{15,20})/?$"
+            r"([0-9]{17,19})/([0-9]{17,19})/?$"
         )
         bot: disnake.Client = ctx.bot
         result: Optional[disnake.GuildScheduledEvent] = None
@@ -1080,7 +1080,7 @@ class clean_content(Converter[str]):
             id = int(match[2])
             return transforms[type](id)
 
-        result = re.sub(r"<(@[!&]?|#)([0-9]{15,20})>", repl, argument)
+        result = re.sub(r"<(@[!&]?|#)([0-9]{17,19})>", repl, argument)
         if self.escape_markdown:
             result = disnake.utils.escape_markdown(result)
         elif self.remove_markdown:

--- a/disnake/ext/commands/help.py
+++ b/disnake/ext/commands/help.py
@@ -298,8 +298,8 @@ class HelpCommand:
     MENTION_TRANSFORMS = {
         "@everyone": "@\u200beveryone",
         "@here": "@\u200bhere",
-        r"<@!?[0-9]{17,22}>": "@deleted-user",
-        r"<@&[0-9]{17,22}>": "@deleted-role",
+        r"<@!?[0-9]{17,19}>": "@deleted-user",
+        r"<@&[0-9]{17,19}>": "@deleted-role",
     }
 
     MENTION_PATTERN = re.compile("|".join(MENTION_TRANSFORMS.keys()))

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1154,21 +1154,21 @@ class Message(Hashable):
         This allows you to receive the user IDs of mentioned users
         even in a private message context.
         """
-        return [int(x) for x in re.findall(r"<@!?([0-9]{15,20})>", self.content)]
+        return [int(x) for x in re.findall(r"<@!?([0-9]{17,19})>", self.content)]
 
     @utils.cached_slot_property("_cs_raw_channel_mentions")
     def raw_channel_mentions(self) -> List[int]:
         """List[:class:`int`]: A property that returns an array of channel IDs matched with
         the syntax of ``<#channel_id>`` in the message content.
         """
-        return [int(x) for x in re.findall(r"<#([0-9]{15,20})>", self.content)]
+        return [int(x) for x in re.findall(r"<#([0-9]{17,19})>", self.content)]
 
     @utils.cached_slot_property("_cs_raw_role_mentions")
     def raw_role_mentions(self) -> List[int]:
         """List[:class:`int`]: A property that returns an array of role IDs matched with
         the syntax of ``<@&role_id>`` in the message content.
         """
-        return [int(x) for x in re.findall(r"<@&([0-9]{15,20})>", self.content)]
+        return [int(x) for x in re.findall(r"<@&([0-9]{17,19})>", self.content)]
 
     @utils.cached_slot_property("_cs_channel_mentions")
     def channel_mentions(self) -> List[GuildChannel]:

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -93,7 +93,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
     __slots__ = ("animated", "name", "id")
 
     _CUSTOM_EMOJI_RE = re.compile(
-        r"<?(?P<animated>a)?:?(?P<name>[A-Za-z0-9\_]+):(?P<id>[0-9]{13,20})>?"
+        r"<?(?P<animated>a)?:?(?P<name>[A-Za-z0-9\_]+):(?P<id>[0-9]{17,19})>?"
     )
 
     if TYPE_CHECKING:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -923,7 +923,7 @@ def escape_mentions(text: str) -> str:
     :class:`str`
         The text with the mentions removed.
     """
-    return re.sub(r"@(everyone|here|[!&]?[0-9]{17,20})", "@\u200b\\1", text)
+    return re.sub(r"@(everyone|here|[!&]?[0-9]{17,19})", "@\u200b\\1", text)
 
 
 # Custom docstring parser

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1193,7 +1193,7 @@ class Webhook(BaseWebhook):
             A partial webhook is just a webhook object with an ID and a token.
         """
         m = re.search(
-            r"discord(?:app)?.com/api/webhooks/(?P<id>[0-9]{17,20})/(?P<token>[A-Za-z0-9\.\-\_]{60,68})",
+            r"discord(?:app)?.com/api/webhooks/(?P<id>[0-9]{17,19})/(?P<token>[A-Za-z0-9\.\-\_]{60,68})",
             url,
         )
         if m is None:

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -671,7 +671,7 @@ class SyncWebhook(BaseWebhook):
             A partial webhook is just a webhook object with an ID and a token.
         """
         m = re.search(
-            r"discord(?:app)?.com/api/webhooks/(?P<id>[0-9]{17,20})/(?P<token>[A-Za-z0-9\.\-\_]{60,68})",
+            r"discord(?:app)?.com/api/webhooks/(?P<id>[0-9]{17,19})/(?P<token>[A-Za-z0-9\.\-\_]{60,68})",
             url,
         )
         if m is None:


### PR DESCRIPTION
The oldest ID is 17 characters, and 20 digit IDs won't be around for decades (if ever)

## Summary

Gets rid of ID regexes checking for 15 character IDs, and switches to a max of 19 characters because that's the maximum ID length for the foreseeable future.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
