### PR TITLE
fix: check the type of the name when validating slash command and option names

### DIFF
--- a/changelog/653.bugfix.rst
+++ b/changelog/653.bugfix.rst
@@ -1,0 +1,1 @@
+Check the type of the provided parameter when validating names to improve end-user errors when passing an incorrect object to slash command and option names.

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -98,6 +98,11 @@ def _validate_name(name: str) -> None:
     # used for slash command names and option names
     # see https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-naming
 
+    if not isinstance(name, str):
+        raise TypeError(
+            f"slash command name and option names must be an instance of class 'str', received '{name.__class__}'"
+        )
+
     if name != name.lower() or not re.fullmatch(r"[\w-]{1,32}", name):
         raise ValueError(
             f"Slash command or option name '{name}' should be lowercase, "

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -100,7 +100,7 @@ def _validate_name(name: str) -> None:
 
     if not isinstance(name, str):
         raise TypeError(
-            f"slash command name and option names must be an instance of class 'str', received '{name.__class__}'"
+            f"Slash command name and option names must be an instance of class 'str', received '{name.__class__}'"
         )
 
     if name != name.lower() or not re.fullmatch(r"[\w-]{1,32}", name):


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
