### PR TITLE
chore(docs): replace broken links and formatting in contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ A PR cannot be merged as long as there are any failing tasks.
 
 ### Changelogs
 
-We use [towncrier](https://github.com/twisted/towncrier) for managing our changelogs. Each change is required to have at least one file in the [`changes/`](changes/README.md) directory. There is more documentation in that directory on how to create a changelog entry.
+We use [towncrier](https://github.com/twisted/towncrier) for managing our changelogs. Each change is required to have at least one file in the [`changelog/`](changelog/README.rst) directory. There is more documentation in that directory on how to create a changelog entry.
 
 ### Git Commit Guidelines
 

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -4,11 +4,11 @@ text that will be added to the next changelog.
 The changelog will be read by **users**, so this description should be aimed at users
 instead of describing internal changes which are only relevant to the developers.
 
-Make sure to use full sentences in the **present tense** and use punctuation, examples::
+Make sure to use full sentences in the **present tense** and use punctuation, examples:
 
-    Improve Guild.create_text_channel by returning the channel type.
+- Improve Guild.create_text_channel by returning the channel type.
 
-    Command syncing now uses logging instead of print.
+- Command syncing now uses logging instead of print.
 
 Each file should use the following naming: ``<ISSUE>.<TYPE>.rst``, where
 ``<ISSUE>`` is an issue number, and ``<TYPE>`` is one of:

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -40,4 +40,4 @@ with the draft changelog (http://127.0.0.1:8009/whats_new.html) if you want to g
 
 ~~~~~
 
-This file is adapted from [pytest's changelog documentation](https://github.com/pytest-dev/pytest/blob/4414c4adaeb06f1c883df2ccc3f4d469886b788d/changelog/README.rst).
+This file is adapted from `pytest's changelog documentation <https://github.com/pytest-dev/pytest/blob/4414c4adaeb06f1c883df2ccc3f4d469886b788d/changelog/README.rst>`_


### PR DESCRIPTION
## Summary

Fix the broken link in CONTRIBUTING.md, plus a few formatting issues in changelog/README.rst
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
