### PR TITLE
typing: update pyright, reconfigure rules

### DIFF
--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -792,6 +792,7 @@ class CustomActivity(BaseActivity):
         return ActivityType.custom
 
     def to_dict(self) -> Dict[str, Any]:
+        o: Dict[str, Any]
         if self.name == self.state:
             o = {
                 "type": ActivityType.custom.value,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -212,12 +212,15 @@ class Button(Component):
             self.emoji = None
 
     def to_dict(self) -> ButtonComponentPayload:
-        payload = {
+        payload: ButtonComponentPayload = {
             "type": 2,
-            "style": int(self.style),
-            "label": self.label,
+            "style": self.style.value,
             "disabled": self.disabled,
         }
+
+        if self.label:
+            payload["label"] = self.label
+
         if self.custom_id:
             payload["custom_id"] = self.custom_id
 
@@ -227,7 +230,7 @@ class Button(Component):
         if self.emoji:
             payload["emoji"] = self.emoji.to_dict()
 
-        return payload  # type: ignore
+        return payload
 
 
 class SelectMenu(Component):
@@ -397,7 +400,7 @@ class SelectOption:
         }
 
         if self.emoji:
-            payload["emoji"] = self.emoji.to_dict()  # type: ignore
+            payload["emoji"] = self.emoji.to_dict()
 
         if self.description:
             payload["description"] = self.description

--- a/disnake/ext/commands/help.py
+++ b/disnake/ext/commands/help.py
@@ -88,7 +88,13 @@ class Paginator:
             .. versionadded:: 1.7
     """
 
-    def __init__(self, prefix="```", suffix="```", max_size=2000, linesep="\n"):
+    def __init__(
+        self,
+        prefix: Optional[str] = "```",
+        suffix: Optional[str] = "```",
+        max_size: int = 2000,
+        linesep: str = "\n",
+    ):
         self.prefix = prefix
         self.suffix = suffix
         self.max_size = max_size

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2022,7 +2022,7 @@ class HTTPClient:
         reason: Optional[str] = None,
     ) -> Response[guild_scheduled_event.GuildScheduledEvent]:
         r = Route("POST", "/guilds/{guild_id}/scheduled-events", guild_id=guild_id)
-        payload = {
+        payload: Dict[str, Any] = {
             "name": name,
             "privacy_level": privacy_level,
             "scheduled_start_time": scheduled_start_time,

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -854,7 +854,7 @@ class Member(disnake.abc.Messageable, _UserTag):
             if self.voice is None or self.voice.channel is None:
                 raise Exception("Cannot suppress a member which isn't in a vc")
 
-            voice_state_payload = {
+            voice_state_payload: Dict[str, Any] = {
                 "channel_id": self.voice.channel.id,
                 "suppress": suppress,
             }

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from .state import ConnectionState
     from .types.activity import ActivityEmoji as ActivityEmojiPayload
-    from .types.message import PartialEmoji as PartialEmojiPayload
+    from .types.emoji import Emoji as EmojiPayload, PartialEmoji as PartialEmojiPayload
 
 
 class _EmojiTag:
@@ -150,10 +150,11 @@ class PartialEmoji(_EmojiTag, AssetMixin):
 
         return cls(name=value, id=None, animated=False)
 
-    def to_dict(self) -> Dict[str, Any]:
-        o: Dict[str, Any] = {"name": self.name}
-        if self.id:
-            o["id"] = self.id
+    def to_dict(self) -> EmojiPayload:
+        o: EmojiPayload = {
+            "name": self.name,
+            "id": self.id,
+        }
         if self.animated:
             o["animated"] = self.animated
         return o

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ exclude-modules = '''
 
 
 [tool.pyright]
-typeCheckingMode = "basic"
+typeCheckingMode = "strict"
 include = [
     "disnake",
     "docs",
@@ -89,22 +89,35 @@ ignore = [
     "noxfile.py",  # this is ignored because nox is not installed in the environment when running pyright
 ]
 
-strictParameterNoneValue = false
-reportInvalidStringEscapeSequence = false
-reportDuplicateImport = true
-reportUntypedFunctionDecorator = true
-reportUntypedClassDecorator = true
-reportUntypedBaseClass = true
-reportInvalidTypeVarUse = true
-reportUnnecessaryCast = true
-reportSelfClsParameterName = true
-reportUnsupportedDunderAll = true
-reportUnusedImport = true
-reportUnusedVariable = true
-reportUntypedNamedTuple = true
-reportUnnecessaryComparison = true
+# this is one of the diagnostics that aren't enabled by default, even in strict mode
 reportUnnecessaryTypeIgnoreComment = true
-reportUnknownLambdaType = true
+
+# it's unlikely that these will ever be enabled
+reportOverlappingOverload = false
+reportPrivateUsage = false
+reportUnnecessaryIsInstance = false
+reportFunctionMemberAccess = false
+reportMissingTypeStubs = false
+reportUnusedFunction = false
+reportUnusedClass = false
+reportConstantRedefinition = false
+reportImportCycles = false
+reportIncompatibleMethodOverride = false
+reportIncompatibleVariableOverride = false
+
+# TODO: fix these
+strictListInference = false
+strictDictionaryInference = false
+strictSetInference = false
+
+# these are largely due to missing type hints, and make up most of the error count
+reportUnknownMemberType = false
+reportUnknownParameterType = false
+reportUnknownArgumentType = false
+reportMissingParameterType = false
+reportUnknownVariableType = false
+reportMissingTypeArgument = false
+strictParameterNoneValue = false
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,6 @@ reportImportCycles = false
 reportIncompatibleMethodOverride = false
 reportIncompatibleVariableOverride = false
 
-# TODO: fix these
-strictListInference = false
-strictDictionaryInference = false
-strictSetInference = false
-
 # these are largely due to missing type hints, and make up most of the error count
 reportUnknownMemberType = false
 reportUnknownParameterType = false

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -3,7 +3,7 @@
 ## type checking
 typing_extensions~=4.2.0
 # this is not pyright itself, but the python wrapper
-pyright==1.1.258
+pyright==1.1.264
 
 
 ## linting


### PR DESCRIPTION
## Summary

- Update pyright from 1.1.258 to 1.1.264 (slowdowns and minor bugs as seen in .262 seem to be fixed)
- Instead of using `basic` mode and enabling a bunch of rules, use `strict` mode and disable those we (currently) don't want
- Enable `strictListInference`, `strictDictionaryInference`, and `strictSetInference` rules

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
