### PR TITLE
docs: port changelog from v2.4.1

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -238,6 +238,50 @@ Miscellaneous
 - Add low-level component example (:issue:`452`)
 - Update Discord server invite links (:issue:`476`)
 
+.. _vp2p4p1:
+
+v2.4.1
+------
+
+This release is a bugfix release with backports from v2.5.0 up to v2.5.2.
+
+Bug Fixes
+~~~~~~~~~~
+
+- Fix missing ``create_public_threads`` permission in :attr:`Permissions.private_channel` (:issue:`373`)
+- Fix :attr:`PartialInviteChannel.__str__ <PartialInviteChannel>` (:issue:`383`)
+- Fix role icon/emoji editing (:issue:`403`)
+- Remove cached scheduled events if associated channel was deleted (:issue:`406`)
+- Update some types/parameters of roles, scheduled events and voice states (:issue:`407`)
+- Allow ``content`` parameters in send/edit methods to be positional (:issue:`411`)
+- Fix gateway ratelimiter being too strict (:issue:`413`)
+- Fix caching of stage instances andd scheduled events (:issue:`416`)
+- Fix memory leaks on shard reconnect (:issue:`424`, :issue:`425`)
+- Improve :class:`PartialMessageable` channel handling (:issue:`426`)
+- Fix :func:`~PartialEmoji.read` for activity emojis (:issue:`430`)
+- Fix delay of ``after`` callback in :class:`AudioPlayer` when stopping (:issue:`508`)
+- Change the default guild :class:`.GuildSticker` limit to 5. (:issue:`531`)
+- Dispatch :func:`disnake.on_reaction_remove` for :class:`.Thread` instances. (:issue:`536`)
+- Update :attr:`Guild.bitrate_limit` to use the correct value for the ``VIP_REGIONS`` feature flag. (:issue:`538`)
+- Remove the ``$`` prefix from ``IDENTIFY`` payload properties. (:issue:`572`)
+- Fix opus function calls on arm64 macOS. (:issue:`620`)
+- Improve channel/guild fallback in resolved interaction data, using :class:`PartialMessageable` for unhandled/unknown channels instead of using ``None``. (:issue:`646`)
+- |commands| Fix :class:`~ext.commands.clean_content` converter (:issue:`396`)
+- |commands| Support interactions in :class:`~ext.commands.UserConverter`, :class:`~ext.commands.MemberConverter` (:issue:`429`)
+- |commands| Fix unloading of listeners with custom names (:issue:`444`)
+- |commands| Handle :class:`.VoiceChannel` in :func:`commands.is_nsfw`. (:issue:`536`)
+
+
+Documentation
+~~~~~~~~~~~~~~
+
+- Update the requests intersphinx url to the new url of the requests documentation. (:issue:`539`)
+
+
+Miscellaneous
+~~~~~~~~~~~~~~
+
+- Update dev dependencies and CI (:issue:`451`)
 
 .. _vp2p4p0:
 


### PR DESCRIPTION
## Summary
Port the changelog from v2.4.1 to the default branch so it shows up on the latest docs. 
Also added a small line about the changes being backports from v2.6.0 (which is currently unreleased).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
