### PR TITLE
docs: port changelog from v2.5.2

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -15,6 +15,41 @@ in specific versions.
 
 .. towncrier release notes start
 
+.. _vp2p5p2:
+
+v2.5.2
+------
+
+This release is a bugfix release with backports from upto v2.6.0.
+
+Bug Fixes
+~~~~~~~~~~
+
+- Warn the user that bools are not supported for ``default_member_permissions``. (:issue:`520`)
+- Update the Guild Iterator to not get stuck in an infinite loop. (:issue:`526`)
+    - Add a missing import for the scheduled event user iterator.
+- Change the default guild :class:`.GuildSticker` limit to 5. (:issue:`531`)
+- Handle optional :class:`Locale` instances (no longer create an enum value). (:issue:`533`)
+- |commands| Handle :class:`.VoiceChannel` in :func:`commands.is_nsfw`. (:issue:`536`)
+- Dispatch :func:`disnake.on_reaction_remove` for :class:`.Thread` instances. (:issue:`536`)
+- Update :attr:`Guild.bitrate_limit` to use the correct value for the ``VIP_REGIONS`` feature flag. (:issue:`538`)
+- Make all \*InteractionData dataclasses dicts (:class:`MessageInteractionData`, :class:`ApplicationCommandInteractionData`, and so on). (:issue:`549`)
+- Handle :class:`ThreadAutoArchiveDuration` instances for ``default_auto_archive_duration`` when editing channels. (:issue:`568`)
+- Assume that ``None`` is an empty channel name and keep ``channel.name`` a string. (:issue:`569`)
+- Remove the ``$`` prefix from ``IDENTIFY`` payload properties. (:issue:`572`)
+- Replace old application command objects in cogs with the new/copied objects. (:issue:`575`)
+- |commands| Handle ``Union[User, Member]`` annotations on slash commands arguments when using the decorator interface. (:issue:`584`)
+- Fix opus function calls on arm64 macOS. (:issue:`620`)
+- Improve channel/guild fallback in resolved interaction data, using :class:`PartialMessageable` for unhandled/unknown channels instead of using ``None``. (:issue:`646`)
+
+Documentation
+~~~~~~~~~~~~~~
+
+- Remove notes that global application command rollout takes up to an hour. (:issue:`518`)
+- Update the requests intersphinx url to the new url of the requests documentation. (:issue:`539`)
+- Clarify the targets of :func:`Permissions.is_strict_subset` and :func:`Permissions.is_strict_superset`. (:issue:`612`)
+- Update :attr:`InteractionReference.name` description, now includes group and subcommand. (:issue:`625`, :issue:`648`)
+
 .. _vp2p5p1:
 
 v2.5.1


### PR DESCRIPTION
## Summary
Port the changelog from v2.5.2 to the default branch so it shows up on the latest docs. 
Also added a small line about the changes being backports from v2.6.0 (which is currently unreleased).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
