### PR TITLE
feat :RPC Endpoint support (Client.fetch_application)

### DIFF
--- a/disnake/client.py
+++ b/disnake/client.py
@@ -607,6 +607,84 @@ class Client:
         :return type: :class:`bool`
         """
         return self._ready.is_set()
+    
+    async def fetch_application(self, application_id: int, /) -> PartialAppInfo:
+        """|coro|
+
+        Retrieves a :class:`.PartialAppInfo` from an application ID.
+
+        Parameters
+        -----------
+        application_id: :class:`int`
+            The application ID to retrieve information from.
+
+        Raises
+        -------
+        NotFound
+            An application with this ID does not exist.
+        HTTPException
+            Retrieving the application failed.
+
+        Returns
+        --------
+        :class:`.PartialAppInfo`
+            The application information.
+        """
+        data = await self.http.get_application(application_id)
+        return PartialAppInfo(state=self._connection, data=data)
+
+    async def fetch_widget(self, guild_id: int, /) -> Widget:
+        """|coro|
+
+        Gets a :class:`.Widget` from a guild ID.
+
+        .. note::
+
+            The guild must have the widget enabled to get this information.
+
+       
+
+        Parameters
+        -----------
+        guild_id: :class:`int`
+            The ID of the guild.
+
+        Raises
+        -------
+        Forbidden
+            The widget for this guild is disabled.
+        HTTPException
+            Retrieving the widget failed.
+
+        Returns
+        --------
+        :class:`.Widget`
+            The guild's widget.
+        """
+        data = await self.http.get_widget(guild_id)
+
+        return Widget(state=self._connection, data=data)
+
+    async def application_info(self) -> AppInfo:
+        """|coro|
+
+        Retrieves the bot's application information.
+
+        Raises
+        -------
+        HTTPException
+            Retrieving the information failed somehow.
+
+        Returns
+        --------
+        :class:`.AppInfo`
+            The bot's application information.
+        """
+        data = await self.http.application_info()
+        if 'rpc_origins' not in data:
+            data['rpc_origins'] = None
+        return AppInfo(self._connection, data)
+
 
     async def _run_event(
         self,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -517,6 +517,11 @@ class HTTPClient:
             json=payload,
             reason=reason,
         )
+    def get_application(self, application_id: Snowflake, /) -> Response[appinfo.PartialAppInfo]:
+        return self.request(Route('GET', '/applications/{application_id}/rpc', application_id=application_id))
+
+    def application_info(self) -> Response[appinfo.AppInfo]:
+        return self.request(Route('GET', '/oauth2/applications/@me'))
 
     # Group functionality
 


### PR DESCRIPTION
## Summary

This pull request is feature which will add Client.fetch_application.
This method allows users to get the a PartialAppInfo object with an application id, It Uses the following path: `/applications/:id/rpc`
*It is not documented yet in discord documentation*
## Checklist



- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
