### PR TITLE
Fix TextChannel.clone() to copy default_auto_archive_duration property identically to Discord client

### DIFF
--- a/changelog/635.bugfix.rst
+++ b/changelog/635.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug with the :func:`clone` method of :class:`TextChannel` not properly copying the `default_auto_archive_duration` attribute into the newly-cloned channel.

--- a/changelog/635.bugfix.rst
+++ b/changelog/635.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug with the :func:`clone` method of :class:`TextChannel` not properly copying the `default_auto_archive_duration` attribute into the newly-cloned channel.
+Fix bug with the :func:`clone` method of :class:`GuildChannel` not properly copying the `default_auto_archive_duration` attribute into the newly-cloned channel.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -937,7 +937,7 @@ class GuildChannel(ABC):
         * Default Thread Auto-Archive Duration
 
         .. note::
-            This does ***not*** clone *all* attributes/properties of the current channel to a new
+            This does **not** clone *all* attributes/properties of the current channel to a new
             channel. Only the above properties are copied to the new channel.
 
         You must have :attr:`.Permissions.manage_channels` permission to

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -928,8 +928,17 @@ class GuildChannel(ABC):
     async def clone(self, *, name: Optional[str] = None, reason: Optional[str] = None) -> Self:
         """|coro|
 
-        Clones this channel. This creates a channel with the same properties
-        as this channel.
+        Clones this channel identically to how a user's Discord client would clone the channel.
+        This creates a channel with the following identical properties as the current channel:
+
+        * Topic
+        * NSFW
+        * Rate Limit (Slowmode)
+        * Default Thread Auto-Archive Duration
+
+        .. note::
+            This does ***not*** clone *all* attributes/properties of the current channel to a new
+            channel. Only the above properties are copied to the new channel.
 
         You must have :attr:`.Permissions.manage_channels` permission to
         do this.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -467,7 +467,12 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         self, *, name: Optional[str] = None, reason: Optional[str] = None
     ) -> TextChannel:
         return await self._clone_impl(
-            {"topic": self.topic, "nsfw": self.nsfw, "rate_limit_per_user": self.slowmode_delay},
+            {
+                "topic": self.topic,
+                "nsfw": self.nsfw,
+                "rate_limit_per_user": self.slowmode_delay,
+                "default_auto_archive_duration": self.default_auto_archive_duration,
+            },
             name=name,
             reason=reason,
         )


### PR DESCRIPTION
## Summary
As described in #635, `disnake.TextChannel.clone()` previously did not copy the `default_auto_archive_duration` property into the new channel. This behavior differs from the behavior of the Discord client. This PR resolves this and updates the docstring of `disnake.GuildChannel.clone()` to indicate that the default intent of `disnake.GuildChannel.clone()` is to mimic the Discord client's functionality.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
