### PR TITLE
fix: check for `command_prefix=None` before warning about message content intent

### DIFF
--- a/changelog/689.bugfix.rst
+++ b/changelog/689.bugfix.rst
@@ -1,1 +1,0 @@
-|commands| Disable message content intent warning when using ``command_prefix=None``.

--- a/changelog/689.bugfix.rst
+++ b/changelog/689.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Disable message content intent warning when using ``command_prefix=None``.

--- a/changelog/689.deprecate.rst
+++ b/changelog/689.deprecate.rst
@@ -1,0 +1,1 @@
+|commands| Using ``command_prefix=None`` with :class:`~disnake.ext.commands.Bot` is now deprecated in favour of :class:`~disnake.ext.commands.InteractionBot`.

--- a/changelog/689.doc.rst
+++ b/changelog/689.doc.rst
@@ -1,0 +1,1 @@
+|commands| Improve documentation around using ``None`` for :attr:`Bot.command_prefix <disnake.ext.commands.Bot.command_prefix>`.

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -77,6 +77,11 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
         :attr:`.Context.prefix`. To avoid confusion empty iterables are not
         allowed.
 
+        If the prefix is ``None``, the bot won't listen to any prefixes, and prefix
+        commands will not be processed. If you don't need prefix commands, consider
+        using :class:`InteractionBot` or :class:`AutoShardedInteractionBot` instead,
+        which are drop-in replacements, just without prefix command support.
+
         .. note::
 
             When passing multiple prefixes be careful to not pass a prefix

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -152,10 +152,12 @@ class BotBase(CommonBotBase, GroupMixin):
         super().__init__(**options)
         self.command_prefix = command_prefix
         if (
-            command_prefix is not when_mentioned
+            # note: no need to check for empty iterables,
+            # as they won't be allowed by `get_prefix`
+            command_prefix is not None
+            and command_prefix is not when_mentioned
             and not self.intents.message_content  # type: ignore
         ):
-
             warnings.warn(
                 "Message Content intent is not enabled and a prefix is configured. "
                 "This may cause limited functionality for prefix commands. "

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -181,10 +181,10 @@ class BotBase(CommonBotBase, GroupMixin):
             )
 
         self._checks: List[Check] = []
-        self._check_once = []
+        self._check_once: List[Check] = []
 
-        self._before_invoke = None
-        self._after_invoke = None
+        self._before_invoke: Optional[CoroFunc] = None
+        self._after_invoke: Optional[CoroFunc] = None
 
         self._help_command = None
         self.description: str = inspect.cleandoc(description) if description else ""

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -150,7 +150,9 @@ class BotBase(CommonBotBase, GroupMixin):
         **options: Any,
     ):
         super().__init__(**options)
-        self.command_prefix = command_prefix
+
+        if not isinstance(self, disnake.Client):
+            raise RuntimeError("BotBase mixin must be used with disnake.Client")
 
         alternative = (
             "AutoShardedInteractionBot"
@@ -168,7 +170,7 @@ class BotBase(CommonBotBase, GroupMixin):
             # note: no need to check for empty iterables,
             # as they won't be allowed by `get_prefix`
             command_prefix is not when_mentioned
-            and not self.intents.message_content  # type: ignore
+            and not self.intents.message_content
         ):
             warnings.warn(
                 "Message Content intent is not enabled and a prefix is configured. "
@@ -179,6 +181,8 @@ class BotBase(CommonBotBase, GroupMixin):
                 MessageContentPrefixWarning,
                 stacklevel=2,
             )
+
+        self.command_prefix = command_prefix
 
         self._checks: List[Check] = []
         self._check_once: List[Check] = []

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -163,7 +163,7 @@ class BotBase(CommonBotBase, GroupMixin):
             disnake.utils.warn_deprecated(
                 "Using `command_prefix=None` is deprecated and will result in "
                 "an error in future versions. "
-                f"If you don't need any prefix functionality, consider using {alternative} instead.",
+                f"If you don't need any prefix functionality, consider using {alternative}.",
                 stacklevel=2,
             )
         elif (
@@ -176,7 +176,7 @@ class BotBase(CommonBotBase, GroupMixin):
                 "Message Content intent is not enabled and a prefix is configured. "
                 "This may cause limited functionality for prefix commands. "
                 "If you want prefix commands, pass an intents object with message_content set to True. "
-                f"If you don't need any prefix functionality, consider using {alternative} instead. "
+                f"If you don't need any prefix functionality, consider using {alternative}. "
                 "Alternatively, set prefix to disnake.ext.commands.when_mentioned to silence this warning.",
                 MessageContentPrefixWarning,
                 stacklevel=2,

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -151,19 +151,30 @@ class BotBase(CommonBotBase, GroupMixin):
     ):
         super().__init__(**options)
         self.command_prefix = command_prefix
-        if (
+
+        alternative = (
+            "AutoShardedInteractionBot"
+            if isinstance(self, disnake.AutoShardedClient)
+            else "InteractionBot"
+        )
+        if command_prefix is None:
+            disnake.utils.warn_deprecated(
+                "Using `command_prefix=None` is deprecated and will result in "
+                "an error in future versions. "
+                f"If you don't need any prefix functionality, consider using {alternative} instead.",
+                stacklevel=2,
+            )
+        elif (
             # note: no need to check for empty iterables,
             # as they won't be allowed by `get_prefix`
-            command_prefix is not None
-            and command_prefix is not when_mentioned
+            command_prefix is not when_mentioned
             and not self.intents.message_content  # type: ignore
         ):
             warnings.warn(
                 "Message Content intent is not enabled and a prefix is configured. "
                 "This may cause limited functionality for prefix commands. "
                 "If you want prefix commands, pass an intents object with message_content set to True. "
-                "If you don't need any prefix functionality, "
-                "consider using InteractionBot instead. "
+                f"If you don't need any prefix functionality, consider using {alternative} instead. "
                 "Alternatively, set prefix to disnake.ext.commands.when_mentioned to silence this warning.",
                 MessageContentPrefixWarning,
                 stacklevel=2,


### PR DESCRIPTION
## Summary

Shows a deprecation warning instead of message content intent warning when using `Bot(command_prefix=None)`, and improves the docs regarding `None` prefixes.

Resolves #688.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
