### PR TITLE
fix(docs): enable `parallel_read_safe` for all sphinx extensions

### DIFF
--- a/changelog/690.misc.rst
+++ b/changelog/690.misc.rst
@@ -1,0 +1,1 @@
+Improve parallel documentation build speed.

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -278,7 +278,7 @@ def class_results_to_node(key: str, elements: List[TableElement]) -> attributeta
     return attributetablecolumn("", title, ul)
 
 
-def setup(app: Sphinx) -> None:
+def setup(app: Sphinx):
     app.add_directive("attributetable", PyAttributeTable)
     app.add_node(attributetable, html=(visit_attributetable_node, depart_attributetable_node))
     app.add_node(
@@ -296,3 +296,8 @@ def setup(app: Sphinx) -> None:
     )
     app.add_node(attributetableplaceholder)
     app.connect("doctree-resolved", process_attributetable)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/extensions/builder.py
+++ b/docs/extensions/builder.py
@@ -100,3 +100,8 @@ def setup(app):
     add_builders(app)
     app.connect("config-inited", disable_mathjax)
     app.connect("builder-inited", add_custom_jinja2)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/extensions/exception_hierarchy.py
+++ b/docs/extensions/exception_hierarchy.py
@@ -29,3 +29,8 @@ def setup(app):
         exception_hierarchy, html=(visit_exception_hierarchy_node, depart_exception_hierarchy_node)
     )
     app.add_directive("exception_hierarchy", ExceptionHierarchyDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/extensions/nitpick_file_ignorer.py
+++ b/docs/extensions/nitpick_file_ignorer.py
@@ -19,3 +19,8 @@ def setup(app: Sphinx):
     app.add_config_value("nitpick_ignore_files", [], "")
     f = NitpickFileIgnorer(app)
     sphinx_logging.getLogger("sphinx.transforms.post_transforms").logger.addFilter(f)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/extensions/resourcelinks.py
+++ b/docs/extensions/resourcelinks.py
@@ -4,7 +4,6 @@
 
 from typing import Any, Dict, List, Tuple
 
-import sphinx
 from docutils import nodes, utils
 from docutils.nodes import Node, system_message
 from docutils.parsers.rst.states import Inliner
@@ -41,4 +40,8 @@ def add_link_role(app: Sphinx) -> None:
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("resource_links", {}, "env")
     app.connect("builder-inited", add_link_role)
-    return {"version": sphinx.__display_version__, "parallel_read_safe": True}
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/noxfile.py
+++ b/noxfile.py
@@ -130,6 +130,8 @@ def docs(session: nox.Session):
                 "../changelog",
                 "--port",
                 "8009",
+                "-j",
+                "auto",
                 *args,
             )
         else:


### PR DESCRIPTION
## Summary

This allows `sphinx-build -j` to run faster by enabling parallel reads, which are not enabled by default (unlike parallel writes).
For these options to take effect they must be supported by *all* extensions, which is the case for all the other builtin and external extensions we're using.
See https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata.

Things to be considered:
- [ ] Use `-j auto` in the nox task (which would also apply to the ci build)?
- [ ] Use `-j` on RTD? Looks like we'd have to ask support about that, which shouldn't be a big deal: https://github.com/readthedocs/readthedocs.org/pull/7128#issuecomment-700145092
    - We'd have to make sure all our versions have this PR merged. or are at least not set to fail on warning.

### Benchmarks
```sh
# 1.
# sequential read + write
(master) $ time nox -Rs docs --non-interactive
real    0m47.710s
user    0m47.089s
sys     0m0.639s

# 2.
# sequential read, parallel write (why is this one slower? who knows.)
# also shows a warning, for obvious reasons
(master) $ time nox -Rs docs --non-interactive -- -j8
real    0m51.056s
user    0m51.076s
sys     0m0.879s

# 3.
# same as (1.)
(fix/docs-parallel) $ time nox -Rs docs --non-interactive
real    0m47.869s
user    0m47.186s
sys     0m0.524s

# 4.
# parallel read + write
(fix/docs-parallel) $ time nox -Rs docs --non-interactive -- -j8
real    0m36.224s
user    0m49.551s
sys     0m1.657s
```

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
