### PR TITLE
build(deps): update slotscheck to 0.15.0

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@ pyright==1.1.264
 
 
 ## linting
-slotscheck~=0.14.0
+slotscheck~=0.15.0
 flake8~=4.0.1
 flake8-bandit~=3.0.0
 flake8-bugbear==22.7.1


### PR DESCRIPTION
## Summary

Fixes slotscheck issue on Python 3.10 - [changelog](https://github.com/ariebovenberg/slotscheck/blob/main/CHANGELOG.rst#0150-2022-08-09).

<details>
<summary>slotscheck 0.14.0/0.15.0 runs</summary>

```py
$ python -V
Python 3.10.4

$ nox -s slotscheck
nox > Running session slotscheck
nox > Re-using existing virtual environment at .nox/slotscheck.
nox > python -m pip install -U -r requirements.txt -r requirements/requirements_dev.txt
nox > python -m slotscheck --verbose -m disnake
ERROR: 'disnake.utils:SnowflakeList' has slots but superclass does not.
       Superclasses without slots:
       - 'array:array'
Oh no, found some problems!
stats:
  modules:     102
    checked:   75
    excluded:  27
    skipped:   0

  classes:     342
    has slots: 157
    no slots:  185
    n/a:       0
nox > Command python -m slotscheck --verbose -m disnake failed with exit code 1
nox > Session slotscheck failed.

$ sed -i 's/0.14.0/0.15.0/' requirements/requirements_dev.txt 

$ nox -s slotscheck
nox > Running session slotscheck
nox > Re-using existing virtual environment at .nox/slotscheck.
nox > python -m pip install -U -r requirements.txt -r requirements/requirements_dev.txt
nox > python -m slotscheck --verbose -m disnake
All OK!
stats:
  modules:     102
    checked:   75
    excluded:  27
    skipped:   0

  classes:     342
    has slots: 157
    no slots:  185
    n/a:       0
nox > Session slotscheck was successful.
```

</details>

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
