### PR TITLE
feat(automod): add mention spam type and new audit log action types

### DIFF
--- a/changelog/698.feature.rst
+++ b/changelog/698.feature.rst
@@ -1,1 +1,8 @@
-530.feature.rst
+Implement auto moderation.
+- New types: :class:`AutoModAction`, :class:`AutoModTriggerMetadata`, :class:`AutoModRule`, :class:`AutoModActionExecution`
+- New enums: :class:`AutoModTriggerType`, :class:`AutoModEventType`, :class:`AutoModActionType`
+- New flags: :class:`AutoModKeywordPresets`
+- New methods: :func:`Guild.create_automod_rule`, :func:`Guild.fetch_automod_rule`, :func:`Guild.fetch_automod_rules`
+- New intents: :attr:`Intents.automod_configuration`, :attr:`Intents.automod_execution` (+ :attr:`Intents.automod` shortcut for both)
+- New events: :func:`on_automod_rule_create`, :func:`on_automod_rule_update`, :func:`on_automod_rule_delete`, :func:`on_automod_action_execution`
+- \+ all the relevant :class:`AuditLogEntry` and :class:`AuditLogChanges` fields.

--- a/changelog/698.feature.rst
+++ b/changelog/698.feature.rst
@@ -1,0 +1,1 @@
+530.feature.rst

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -608,7 +608,11 @@ class AuditLogEntry(Hashable):
                     "integration": self._get_integration_by_application_id(app_id) or Object(app_id)
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()
-            elif self.action is enums.AuditLogAction.automod_block_message:
+            elif self.action in (
+                enums.AuditLogAction.automod_block_message,
+                enums.AuditLogAction.automod_send_alert_message,
+                enums.AuditLogAction.automod_timeout,
+            ):
                 channel_id = int(extra["channel_id"])
                 elems = {
                     "channel": (

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -250,9 +250,17 @@ class AutoModTriggerMetadata:
 
     allow_list: Optional[Sequence[:class:`str`]]
         The keywords that should be exempt from a preset. Used with :attr:`AutoModTriggerType.keyword_preset`.
+
+    mention_total_limit: Optional[:class:`int`]
+        The maximum number of mentions (members + roles) allowed. Used with :attr:`AutoModTriggerType.mention_spam`.
     """
 
-    __slots__ = ("keyword_filter", "presets", "allow_list")
+    __slots__ = (
+        "keyword_filter",
+        "presets",
+        "allow_list",
+        "mention_total_limit",
+    )
 
     @overload
     def __init__(self, *, keyword_filter: Sequence[str]):
@@ -267,16 +275,22 @@ class AutoModTriggerMetadata:
     ):
         ...
 
+    @overload
+    def __init__(self, *, mention_total_limit: int):
+        ...
+
     def __init__(
         self,
         *,
         keyword_filter: Optional[Sequence[str]] = None,
         presets: Optional[AutoModKeywordPresets] = None,
         allow_list: Optional[Sequence[str]] = None,
+        mention_total_limit: Optional[int] = None,
     ):
         self.keyword_filter: Optional[Sequence[str]] = keyword_filter
         self.presets: Optional[AutoModKeywordPresets] = presets
         self.allow_list: Optional[Sequence[str]] = allow_list
+        self.mention_total_limit: Optional[int] = mention_total_limit
 
     def with_edits(
         self,
@@ -284,6 +298,7 @@ class AutoModTriggerMetadata:
         keyword_filter: Optional[Sequence[str]] = MISSING,
         presets: Optional[AutoModKeywordPresets] = MISSING,
         allow_list: Optional[Sequence[str]] = MISSING,
+        mention_total_limit: Optional[int] = MISSING,
     ) -> Self:
         """
         Returns a new instance with the given edits applied.
@@ -298,6 +313,9 @@ class AutoModTriggerMetadata:
             keyword_filter=self.keyword_filter if keyword_filter is MISSING else keyword_filter,
             presets=self.presets if presets is MISSING else presets,
             allow_list=self.allow_list if allow_list is MISSING else allow_list,
+            mention_total_limit=(
+                self.mention_total_limit if mention_total_limit is MISSING else mention_total_limit
+            ),
         )
 
     @classmethod
@@ -311,6 +329,7 @@ class AutoModTriggerMetadata:
             keyword_filter=data.get("keyword_filter"),
             presets=presets,
             allow_list=data.get("allow_list"),
+            mention_total_limit=data.get("mention_total_limit"),
         )
 
     def to_dict(self) -> AutoModTriggerMetadataPayload:
@@ -321,6 +340,8 @@ class AutoModTriggerMetadata:
             data["presets"] = self.presets.values  # type: ignore  # `values` contains ints instead of preset literal values
         if self.allow_list is not None:
             data["allow_list"] = list(self.allow_list)
+        if self.mention_total_limit is not None:
+            data["mention_total_limit"] = self.mention_total_limit
         return data
 
     def __repr__(self) -> str:
@@ -331,6 +352,8 @@ class AutoModTriggerMetadata:
             s += f" presets={self.presets!r}"
         if self.allow_list is not None:
             s += f" allow_list={self.allow_list!r}"
+        if self.mention_total_limit is not None:
+            s += f" mention_total_limit={self.mention_total_limit!r}"
         return f"{s}>"
 
 

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -805,6 +805,7 @@ class AutoModTriggerType(Enum):
     harmful_link = 2
     spam = 3
     keyword_preset = 4
+    mention_spam = 5
 
 
 T = TypeVar("T")

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -386,6 +386,8 @@ class AuditLogAction(Enum):
     automod_rule_update                   = 141
     automod_rule_delete                   = 142
     automod_block_message                 = 143
+    automod_send_alert_message            = 144
+    automod_timeout                       = 145
     # fmt: on
 
     @property
@@ -444,6 +446,8 @@ class AuditLogAction(Enum):
             AuditLogAction.automod_rule_update:                   AuditLogActionCategory.update,
             AuditLogAction.automod_rule_delete:                   AuditLogActionCategory.delete,
             AuditLogAction.automod_block_message:                 None,
+            AuditLogAction.automod_send_alert_message:            None,
+            AuditLogAction.automod_timeout:                       None,
         }
         # fmt: on
         return lookup[self]
@@ -487,7 +491,7 @@ class AuditLogAction(Enum):
             return None
         elif v < 143:
             return "automod_rule"
-        elif v == 143:
+        elif v < 146:
             return "user"
         else:
             return None

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4311,8 +4311,8 @@ class Guild(Hashable):
             The type of events that this rule will be applied to.
         trigger_type: :class:`AutoModTriggerType`
             The type of trigger that determines whether this rule's actions should run for a specific event.
-            If set to :attr:`~AutoModTriggerType.keyword` or :attr:`~AutoModTriggerType.keyword_preset`,
-            ``trigger_metadata`` must be set accordingly.
+            If set to :attr:`~AutoModTriggerType.keyword`, :attr:`~AutoModTriggerType.keyword_preset`,
+            or :attr:`~AutoModTriggerType.mention_spam`, ``trigger_metadata`` must be set accordingly.
             This cannot be changed after creation.
         actions: Sequence[Union[:class:`AutoModBlockMessageAction`, :class:`AutoModSendAlertAction`, :class:`AutoModTimeoutAction`, :class:`AutoModAction`]]
             The list of actions that will execute if a matching event triggered this rule.
@@ -4349,6 +4349,7 @@ class Guild(Hashable):
         if not trigger_metadata and trigger_type_int in (
             AutoModTriggerType.keyword.value,
             AutoModTriggerType.keyword_preset.value,
+            AutoModTriggerType.mention_spam.value,
         ):
             raise ValueError("Specified trigger type requires `trigger_metadata` to not be empty")
 

--- a/disnake/types/automod.py
+++ b/disnake/types/automod.py
@@ -28,7 +28,7 @@ from typing import List, Literal, TypedDict, Union
 
 from .snowflake import Snowflake, SnowflakeList
 
-AutoModTriggerType = Literal[1, 2, 3, 4]
+AutoModTriggerType = Literal[1, 2, 3, 4, 5]
 AutoModEventType = Literal[1]
 AutoModActionType = Literal[1, 2]
 AutoModPresetType = Literal[1, 2, 3]
@@ -65,6 +65,7 @@ class AutoModTriggerMetadata(TypedDict, total=False):
     keyword_filter: List[str]
     presets: List[AutoModPresetType]
     allow_list: List[str]
+    mention_total_limit: int
 
 
 class AutoModRule(TypedDict):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3652,6 +3652,12 @@ of :class:`enum.Enum`.
 
         This trigger type requires additional :class:`metadata <AutoModTriggerMetadata>`.
 
+    .. attribute:: mention_spam
+
+        The rule will filter messages based on the number of member/role mentions they contain.
+
+        This trigger type requires additional :class:`metadata <AutoModTriggerMetadata>`.
+
 Async Iterator
 ----------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3132,7 +3132,27 @@ of :class:`enum.Enum`.
 
         - ``channel``: A :class:`~abc.GuildChannel`, :class:`Thread` or :class:`Object` with the channel ID where the message got blocked.
         - ``rule_name``: A :class:`str` with the name of the rule that matched.
-        - ``rule_trigger_type``: A :class:`AutoModTriggerType` value with the trigger type of the rule.
+        - ``rule_trigger_type``: An :class:`AutoModTriggerType` value with the trigger type of the rule.
+
+    .. attribute:: automod_send_alert_message
+
+        An alert message was sent by an auto moderation rule.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        the :class:`Member` or :class:`User` who had their message flagged.
+
+        See :attr:`automod_block_message` for more information on how the
+        :attr:`~AuditLogEntry.extra` field is set.
+
+    .. attribute:: automod_timeout
+
+        A user was timed out by an auto moderation rule.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.target` is
+        the :class:`Member` or :class:`User` who was timed out.
+
+        See :attr:`automod_block_message` for more information on how the
+        :attr:`~AuditLogEntry.extra` field is set.
 
 .. class:: AuditLogActionCategory
 
@@ -3613,8 +3633,8 @@ of :class:`enum.Enum`.
 
         .. note::
             This action type is only available for rules with trigger type
-            :attr:`~AutoModTriggerType.keyword`, and :attr:`~Permissions.moderate_members`
-            permissions are required to use it.
+            :attr:`~AutoModTriggerType.keyword` or :attr:`~AutoModTriggerType.mention_spam`,
+            and :attr:`~Permissions.moderate_members` permissions are required to use it.
 
 .. class:: AutoModEventType
 


### PR DESCRIPTION
## Summary

- Add `AutoModTriggerType.mention_spam` with its corresponding `AutoModTriggerMetadata.mention_total_limit` field
- Add missing `AuditLogAction.automod_send_alert_message` and `.automod_timeout` action types - not documented yet, but they've been around for a while (June 30th) and presumably are stable

ref: https://github.com/discord/discord-api-docs/pull/5212

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
