### PR TITLE
fix(docs): remove symlinks, update lint config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -58,6 +58,7 @@ per-file-ignores =
     # S311: examples don't misuse random generation
     # S105: possible hardcoded passwords TODO
     examples/**:B008,S311,S105
+    test_bot/**:B008
     # usage of assert and interface binding, allowable for the third party lib at use
     # also have to reignore whatever is from the last check that pops up here
     examples/basic_voice.py:S101,S104

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,26 +25,25 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black", "--extend-skip", "examples"]
-        name: Running isort in all files.
+        name: "run isort in all files"
         exclude: ^examples/
       - id: isort
         args: ["--profile", "black", "--thirdparty", "disnake"]
-        name: Running isort in examples.
+        name: "run isort in examples"
         files: ^examples/
 
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        name: Running black in all files.
+        name: "run black in all files"
 
   - repo: local
     hooks:
       - id: flake8
         name: flake8
-        description: 'Lint all of our code'
+        description: "Lint all of our code"
         entry: flake8
-        exclude: ^test_bot/
-        language: python
+        language: system
         types: [python]
         require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: no-symlinks
         name: no symlinks
         description: "Check for symlinks"
-        entry: ".*"
+        entry: "symlinks may not be committed due to platform support"
         language: fail
         types: [symlink]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,15 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
 
+  - repo: local
+    hooks:
+      - id: no-symlinks
+        name: no symlinks
+        description: 'Check for symlinks'
+        entry: ".*"
+        language: fail
+        types: [symlink]
+
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: no-symlinks
         name: no symlinks
-        description: 'Check for symlinks'
+        description: "Check for symlinks"
         entry: ".*"
         language: fail
         types: [symlink]

--- a/changelog/590.breaking.rst
+++ b/changelog/590.breaking.rst
@@ -1,1 +1,1 @@
-548.breaking.rst
+Rename ``channel_id`` parameter to ``channel`` on :attr:`Guild.create_scheduled_event` and :meth:`GuildScheduledEvent.edit`.

--- a/changelog/615.feature.rst
+++ b/changelog/615.feature.rst
@@ -1,1 +1,6 @@
-605.feature.rst
+Add support of more operators to all ``Flag`` classes. This list includes :class:`Intents` and :class:`Permissions`.
+- ``&``, ``|``, ``^``, and ``~`` bitwise operator support.
+- ``<``, ``<=``, ``>``, and ``>=`` comparsion operator support.
+- Support ``|`` operators between flag instances and flag values.
+- Support ``~`` operator on flag values, which create a flag instance with all except this specific flag enabled.
+- Support ``|`` operators between flag values which create a flag instance with both flag values enabled.

--- a/changelog/648.doc.rst
+++ b/changelog/648.doc.rst
@@ -1,1 +1,1 @@
-625.doc.rst
+Update :attr:`InteractionReference.name` description, now includes group and subcommand.


### PR DESCRIPTION
## Summary

This removes the two symlinks currently present in the repo that are being used for linking related issue/PR IDs in the changelog. Since symlinks generally don't work on Windows, we unfortunately have to get rid of them as they'll make contributing more difficult.

Instead, these files that were previously symlinks now just have the same content as the files they were linking to, leading to the same result in the built changelog (as towncrier groups entries based on content). While this isn't a great solution, it's the only one (short of forking towncrier), as there isn't any way of hooking into the changelog generation process.

Also adds a pre-commit hook that prevents symlinks from being committed to the repo in the future.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
