### PR TITLE
fix(lint): ignore S311 due to flake8/bandit bug

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -47,6 +47,9 @@ per-file-ignores =
     disnake/player.py:S404,S603
     # ignore whitespacing after `:`
     disnake/ext/commands/params.py:E241
+    # upstream bug: https://github.com/PyCQA/bandit/issues/926
+    disnake/backoff.py:S311
+    disnake/colour.py:S311
     # pytest uses assert for testing
     tests/**: S101
     # ignore pytest issues outside of tests directory


### PR DESCRIPTION
## Summary

Adds per-file ignores for `S311` ("Standard pseudo-random generators are not suitable for security/cryptographic purposes.").

As far as I can tell, bandit should disallow `random.Random` on all platforms, however it currently only does so on Windows (the only platform where fnmatch is case-insensitive), see https://github.com/PyCQA/bandit/issues/926.
This means that:
- adding `# noqa: S311` to the affected lines won't work, as flake8-noqa would complain about an unnecessary noqa on macOS/Linux
- but not ignoring these `S311` results in them being shown as errors on Windows

It's a fairly minor issue, but it does make contributing on Windows slightly more annoying.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
