### PR TITLE
deps: don't install cchardet on py >3.9

### DIFF
--- a/changelog/702.misc.rst
+++ b/changelog/702.misc.rst
@@ -1,1 +1,1 @@
-Limit installation of ``cchardet`` in the ``[speed]`` extra to Python versions below 3.10.
+Limit installation of ``cchardet`` in the ``[speed]`` extra to Python versions below 3.10 (see `aiohttp#6857 <https://github.com/aio-libs/aiohttp/pull/6857>`__).

--- a/changelog/702.misc.rst
+++ b/changelog/702.misc.rst
@@ -1,0 +1,1 @@
+Limit installation of ``cchardet`` in the ``[speed]`` extra to Python versions below 3.10.

--- a/requirements/requirements_speed.txt
+++ b/requirements/requirements_speed.txt
@@ -2,4 +2,4 @@ orjson~=3.6
 # taken from aiohttp[speedups]
 aiodns>=1.1
 Brotli
-cchardet
+cchardet; python_version < "3.10"


### PR DESCRIPTION
## Summary

Limits the installation of `cchardet` to Python versions 3.9 and below, mirroring the aiohttp change https://github.com/aio-libs/aiohttp/pull/6857.
While `cchardet` appears to work fine on 3.10, it's been unmaintained for more than a year, and as such there are no wheels built for versions newer than 3.9. This breaks the install of the `[speed]` extra on systems using 3.10 without build tools.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
