### PR TITLE
lint: validate changelog names start with numbers and end with rst

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
         entry: "symlinks may not be committed due to platform support"
         language: fail
         types: [symlink]
+      - id: changelogs-name
+        name: check changelog fragment name
+        entry: changelog filenames should be formatted like `<issue>.<type>.rst`
+        language: fail
+        files: 'changelog/'
+        exclude: '/(\d+\.[a-z]+(\.\d+)?\.rst|_template.rst.jinja|README.rst)$'
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1


### PR DESCRIPTION
## Summary

as mentioned in #700, validates changelog entries end with `.rst` and start with numbers
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
