### PR TITLE
fix!: persist other features when changing the community feature

### DIFF
--- a/changelog/705.bugfix.rst
+++ b/changelog/705.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where it would be possible to remove other features when enabling or disabling the ``COMMUNITY`` feature for a :class:`.Guild`.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1975,13 +1975,9 @@ class Guild(Hashable):
             fields["system_channel_flags"] = system_channel_flags.value
 
         if community is not MISSING:
-            # if we don't have complete feature information for the guild
-            # it is possible to disable or enable other features that we didn't intend to touch
-            # The issue is removing community also removes partner status, and discord is adding the ability to
-            # enable or disable invite usage for guilds, which is problematically triggered by a feature.
-            # To enable or disable that feature, we will need to provide all of the existing features in advance.
-            # That is problematic to say the least. By reimplementing this list to only provide the features if we make a change
-            # we minimize the possible times that we will provide features when no changes are made, and possibly affect other features.
+            # If we don't have complete feature information for the guild,
+            # it is possible to disable or enable other features that we didn't intend to touch.
+            # To enable or disable a feature, we will need to provide all of the existing features in advance.
             if self.unavailable:
                 raise RuntimeError(
                     "cannot modify features of an unavailable guild due to potentially destructive results."

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1986,25 +1986,21 @@ class Guild(Hashable):
                 raise RuntimeError(
                     "cannot modify features of an unavailable guild due to potentially destructive results."
                 )
-            features = self.features
-            if community:
-                if "rules_channel_id" in fields and "public_updates_channel_id" in fields:
-                    if "COMMUNITY" not in features:
-                        features.append("COMMUNITY")
+            features = set(self.features)
+            if community is not MISSING:
+                if not isinstance(community, bool):
+                    raise TypeError("community must be a bool instance")
+                if community:
+                    if "rules_channel_id" in fields and "public_updates_channel_id" in fields:
+                        features.add("COMMUNITY")
                     else:
-                        features = MISSING
+                        raise ValueError(
+                            "community field requires both rules_channel and public_updates_channel fields to be provided"
+                        )
                 else:
-                    raise ValueError(
-                        "community field requires both rules_channel and public_updates_channel fields to be provided"
-                    )
-            else:
-                try:
-                    features.remove("COMMUNITY")
-                except ValueError:
-                    features = MISSING
+                    features.discard("COMMUNITY")
 
-            if features is not MISSING:
-                fields["features"] = features
+            fields["features"] = list(features)
 
         if premium_progress_bar_enabled is not MISSING:
             fields["premium_progress_bar_enabled"] = premium_progress_bar_enabled


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
