### PR TITLE
docs: remove note about appcmd localizations build override

### DIFF
--- a/changelog/711.doc.rst
+++ b/changelog/711.doc.rst
@@ -1,0 +1,1 @@
+Remove note about application command localization requiring a client build override.

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -525,14 +525,6 @@ We have them, look at `this example <https://github.com/DisnakeDev/disnake/blob/
 Localizations
 -------------
 
-.. note::
-    At the time of writing, Discord clients do not support localization right out of the box yet.
-    To enable localization support in your client, a build override from the `Discord Developers <https://discord.gg/discord-developers>`__
-    server is most likely required, which can be found by joining that server and looking around/asking for the override.
-
-    Note that the build override is not necessarily up to date with the other client branches/releases,
-    so you may want to only enable it while you're working on this feature.
-
 The names and descriptions of commands and options, as well as the names of choices
 (for use with fixed choices or autocompletion), support localization for a fixed set of locales.
 


### PR DESCRIPTION
## Summary

Application command localizations just rolled out today to all platforms (except the "old" Android client): https://canary.discord.com/channels/613425648685547541/697138785317814292/1009201109967052851
![image](https://user-images.githubusercontent.com/8530778/184995406-cc52ac2f-1dfb-4fda-8949-d3d7046e4f30.png)


## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
