### PR TITLE
fix: don't provide message content intent with Intents.all()

### DIFF
--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -25,6 +25,8 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
+import functools
+import operator
 from typing import (
     Any,
     Callable,
@@ -527,10 +529,8 @@ class Intents(BaseFlags):
     @classmethod
     def all(cls: Type[Intents]) -> Intents:
         """A factory method that creates a :class:`Intents` with everything enabled."""
-        bits = max(cls.VALID_FLAGS.values()).bit_length()
-        value = (1 << bits) - 1
         self = cls.__new__(cls)
-        self.value = value
+        self.value = functools.reduce(operator.or_, cls.VALID_FLAGS.values())
         return self
 
     @classmethod


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

backport to fix Intents.all() and Intents.default() providing the message content intent when they shouldn't.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
