### PR TITLE
docs: document that messages can be sent with only components

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1418,8 +1418,8 @@ class Messageable:
 
         The content must be a type that can convert to a string through ``str(content)``.
 
-        At least one of ``content``, ``embed``/``embeds``, ``file``/``files``
-        or ``stickers`` must be provided.
+        At least one of ``content``, ``embed``/``embeds``, ``file``/``files``,
+        ``stickers``, ``components``, or ``view`` must be provided.
 
         To upload a single file, the ``file`` parameter should be used with a
         single :class:`.File` object. To upload multiple files, the ``files``


### PR DESCRIPTION
## Summary

implements discord/discord-api-docs/pull/5435

depends on discord/discord-api-docs/pull/5435 being merged, too 🙃 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR is **not** a code change (e.g. documentation, README, ...)
