### PR TITLE
feat(client): Allow to configure `large_treshold`

### DIFF
--- a/changelog/734.feature.rst
+++ b/changelog/734.feature.rst
@@ -1,0 +1,1 @@
+Allow to configure ``large_treshold`` through keyword-only argument in ``disnake.Client``.

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -363,6 +363,9 @@ class Client:
         application commands.
 
         .. versionadded:: 2.5
+    large_treshold: :class:`int`
+        The count of members after which the :class:`Guild` is considered 'large'.
+        Defaults to ``250``. Usually you may not worry about this.
     """
 
     def __init__(
@@ -390,6 +393,7 @@ class Client:
         intents: Optional[Intents] = None,
         chunk_guilds_at_startup: Optional[bool] = None,
         member_cache_flags: Optional[MemberCacheFlags] = None,
+        large_treshold: Optional[int] = None
     ):
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
@@ -405,6 +409,8 @@ class Client:
             unsync_clock=assume_unsync_clock,
             loop=self.loop,
         )
+        
+        self.large_treshold: int = large_treshold or 250
 
         self._handlers: Dict[str, Callable] = {
             "ready": self._handle_ready,
@@ -425,7 +431,8 @@ class Client:
             status=status,
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
-            member_cache_flags=member_cache_flags,
+            member_cache_flags=member_cache_flags
+            large_treshold=large_treshold
         )
         self.shard_id: Optional[int] = shard_id
         self.shard_count: Optional[int] = shard_count

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -393,7 +393,7 @@ class Client:
         intents: Optional[Intents] = None,
         chunk_guilds_at_startup: Optional[bool] = None,
         member_cache_flags: Optional[MemberCacheFlags] = None,
-        large_treshold: Optional[int] = None
+        large_treshold: Optional[int] = None,
     ):
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
@@ -409,7 +409,7 @@ class Client:
             unsync_clock=assume_unsync_clock,
             loop=self.loop,
         )
-        
+
         self.large_treshold: int = large_treshold or 250
 
         self._handlers: Dict[str, Callable] = {
@@ -431,8 +431,8 @@ class Client:
             status=status,
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
-            member_cache_flags=member_cache_flags
-            large_treshold=large_treshold
+            member_cache_flags=member_cache_flags,
+            large_treshold=large_treshold,
         )
         self.shard_id: Optional[int] = shard_id
         self.shard_count: Optional[int] = shard_count
@@ -481,6 +481,7 @@ class Client:
         intents: Optional[Intents],
         chunk_guilds_at_startup: Optional[bool],
         member_cache_flags: Optional[MemberCacheFlags],
+        large_treshold: Optional[int],
     ) -> ConnectionState:
         return ConnectionState(
             dispatch=self.dispatch,
@@ -498,6 +499,7 @@ class Client:
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
             member_cache_flags=member_cache_flags,
+            large_treshold=large_treshold,
         )
 
     def _handle_ready(self) -> None:

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -410,7 +410,8 @@ class Client:
             loop=self.loop,
         )
 
-        self.large_treshold: int = large_treshold or 250
+        large_treshold_: int = large_treshold or 250
+        self.large_treshold: int = large_treshold_
 
         self._handlers: Dict[str, Callable] = {
             "ready": self._handle_ready,
@@ -432,7 +433,7 @@ class Client:
             intents=intents,
             chunk_guilds_at_startup=chunk_guilds_at_startup,
             member_cache_flags=member_cache_flags,
-            large_treshold=large_treshold,
+            large_treshold=large_treshold_,
         )
         self.shard_id: Optional[int] = shard_id
         self.shard_count: Optional[int] = shard_count

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -445,6 +445,7 @@ class DiscordWebSocket:
         ws.session_id = session
         ws.sequence = sequence
         ws._max_heartbeat_timeout = client._connection.heartbeat_timeout
+        ws.large_threshold = client.large_threshold
 
         if client._enable_debug_events:
             ws.send = ws.debug_send
@@ -512,7 +513,7 @@ class DiscordWebSocket:
                     "device": "disnake",
                 },
                 "compress": True,
-                "large_threshold": 250,
+                "large_threshold": self.large_threshold,
                 "intents": state._intents.value,
             },
         }

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -397,6 +397,7 @@ class DiscordWebSocket:
         self.shard_id: Optional[int]
         self.shard_count: Optional[int]
         self._max_heartbeat_timeout: float
+        self.large_treshold: int
 
     @property
     def open(self) -> bool:
@@ -445,7 +446,7 @@ class DiscordWebSocket:
         ws.session_id = session
         ws.sequence = sequence
         ws._max_heartbeat_timeout = client._connection.heartbeat_timeout
-        ws.large_threshold = client.large_threshold
+        ws.large_treshold = client.large_treshold
 
         if client._enable_debug_events:
             ws.send = ws.debug_send
@@ -513,7 +514,7 @@ class DiscordWebSocket:
                     "device": "disnake",
                 },
                 "compress": True,
-                "large_threshold": self.large_threshold,
+                "large_threshold": self.large_treshold,
                 "intents": state._intents.value,
             },
         }

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -590,7 +590,7 @@ class Guild(Hashable):
                 self._add_member(member)
 
         self._sync(guild)
-        self._large: Optional[bool] = None if member_count is None else self._member_count >= 250
+        self._large: Optional[bool] = None if member_count is None else self._member_count >= state.large_threshold
 
         self.owner_id: Optional[int] = utils._get_as_snowflake(guild, "owner_id")
         self.afk_channel: Optional[VocalGuildChannel] = self.get_channel(utils._get_as_snowflake(guild, "afk_channel_id"))  # type: ignore
@@ -641,14 +641,14 @@ class Guild(Hashable):
     def large(self) -> bool:
         """:class:`bool`: Whether the guild is a 'large' guild.
 
-        A large guild is defined as having more than ``large_threshold`` count
-        members, which for this library is set to the maximum of 250.
+        A large guild is defined as having more than :attr:`Client.large_threshold` count
+        members, which defaults to the maximum of 250, though can be configured.
         """
         if self._large is None:
             try:
-                return self._member_count >= 250
+                return self._member_count >= self._state.large_threshold
             except AttributeError:
-                return len(self._members) >= 250
+                return len(self._members) >= self._state.large_threshold
         return self._large
 
     @property

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -590,7 +590,9 @@ class Guild(Hashable):
                 self._add_member(member)
 
         self._sync(guild)
-        self._large: Optional[bool] = None if member_count is None else self._member_count >= state.large_threshold
+        self._large: Optional[bool] = (
+            None if member_count is None else self._member_count >= state.large_treshold
+        )
 
         self.owner_id: Optional[int] = utils._get_as_snowflake(guild, "owner_id")
         self.afk_channel: Optional[VocalGuildChannel] = self.get_channel(utils._get_as_snowflake(guild, "afk_channel_id"))  # type: ignore
@@ -646,9 +648,9 @@ class Guild(Hashable):
         """
         if self._large is None:
             try:
-                return self._member_count >= self._state.large_threshold
+                return self._member_count >= self._state.large_treshold
             except AttributeError:
-                return len(self._members) >= self._state.large_threshold
+                return len(self._members) >= self._state.large_treshold
         return self._large
 
     @property

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -643,7 +643,7 @@ class Guild(Hashable):
     def large(self) -> bool:
         """:class:`bool`: Whether the guild is a 'large' guild.
 
-        A large guild is defined as having more than :attr:`Client.large_threshold` count
+        A large guild is defined as having more than :attr:`Client.large_treshold` count
         members, which defaults to the maximum of 250, though can be configured.
         """
         if self._large is None:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -211,12 +211,15 @@ class ConnectionState:
         intents: Optional[Intents] = None,
         chunk_guilds_at_startup: Optional[bool] = None,
         member_cache_flags: Optional[MemberCacheFlags] = None,
+        large_treshold: Optional[int] = None
     ) -> None:
         self.loop: asyncio.AbstractEventLoop = loop
         self.http: HTTPClient = http
         self.max_messages: Optional[int] = max_messages
         if self.max_messages is not None and self.max_messages <= 0:
             self.max_messages = 1000
+        
+        self.large_treshold: int = large_treshold or 250
 
         self.dispatch: Callable = dispatch
         self.handlers: Dict[str, Callable] = handlers

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -211,14 +211,14 @@ class ConnectionState:
         intents: Optional[Intents] = None,
         chunk_guilds_at_startup: Optional[bool] = None,
         member_cache_flags: Optional[MemberCacheFlags] = None,
-        large_treshold: Optional[int] = None
+        large_treshold: Optional[int] = None,
     ) -> None:
         self.loop: asyncio.AbstractEventLoop = loop
         self.http: HTTPClient = http
         self.max_messages: Optional[int] = max_messages
         if self.max_messages is not None and self.max_messages <= 0:
             self.max_messages = 1000
-        
+
         self.large_treshold: int = large_treshold or 250
 
         self.dispatch: Callable = dispatch


### PR DESCRIPTION
## Summary

This PR allows users to configure the `large_treshold` through kwarg in `Client`.

## Details

As far as i know, `large_treshold` is only used for performance reasons, and while `250` is a sensible default for most use cases, hardware becoming more powerful and (hopefully :) cheaper every year, and in some specific cases user may want to adjust this value. This PR allows users to configure `large_treshold` without having modified fork of disnake or any other sort of "patching".

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
