### PR TITLE
feat: alias original_message methods to original_response to be less confusing

### DIFF
--- a/changelog/738.feature.rst
+++ b/changelog/738.feature.rst
@@ -1,0 +1,4 @@
+Add aliases to the ``original_message`` methods.
+- :func:`Interaction.original_response` is aliased to :func:`Interaction.original_message`
+- :func:`Interaction.edit_original_response` is aliased to :func:`Interaction.edit_original_message`
+- :func:`Interaction.delete_original_response` is aliased to :func:`Interaction.delete_original_message`

--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -322,7 +322,7 @@ class InteractionTimedOut(InteractionException):
             "Interaction took more than 3 seconds to be responded to. "
             'Please defer it using "interaction.response.defer" on the start of your command. '
             "Later you may send a response by editing the deferred message "
-            'using "interaction.edit_original_message"'
+            'using "interaction.edit_original_response"'
             "\n"
             "Note: This might also be caused by a misconfiguration in the components "
             "make sure you do not respond twice in case this is a component."

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -331,10 +331,10 @@ class Interaction:
 
         Fetches the original interaction response message associated with the interaction.
 
-        Here is a table with response types and their associated original message:
+        Here is a table with response types and their associated original response:
 
         .. csv-table::
-            :header: "Response type", "Original message"
+            :header: "Response type", "Original response"
 
             :meth:`InteractionResponse.send_message`, "The message you sent"
             :meth:`InteractionResponse.edit_message`, "The message you edited"
@@ -391,11 +391,11 @@ class Interaction:
         This is a lower level interface to :meth:`InteractionMessage.edit` in case
         you do not want to fetch the message and save an HTTP request.
 
-        This method is also the only way to edit the original message if
+        This method is also the only way to edit the original response if
         the message sent was ephemeral.
 
         .. note::
-            If the original message has embeds with images that were created from local files
+            If the original response message has embeds with images that were created from local files
             (using the ``file`` parameter with :meth:`Embed.set_image` or :meth:`Embed.set_thumbnail`),
             those images will be removed if the message's attachments are edited in any way
             (i.e. by setting ``file``/``files``/``attachments``, or adding an embed with local files).
@@ -523,7 +523,7 @@ class Interaction:
         ----------
         delay: :class:`float`
             If provided, the number of seconds to wait in the background
-            before deleting the original message. If the deletion fails,
+            before deleting the original response message. If the deletion fails,
             then it is silently ignored.
 
         Raises
@@ -985,7 +985,7 @@ class InteractionResponse:
 
         .. versionchanged:: 2.5
 
-            Now supports editing the original message of modal interactions.
+            Now supports editing the original message of modal interactions that started from a component.
 
         .. note::
             If the original message has embeds with images that were created from local files

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -163,7 +163,7 @@ class Interaction:
         "_permissions",
         "_state",
         "_session",
-        "_original_message",
+        "_original_response",
         "_cs_response",
         "_cs_followup",
         "_cs_channel",
@@ -176,7 +176,7 @@ class Interaction:
         # TODO: Maybe use a unique session
         self._session: ClientSession = state.http._HTTPClient__session  # type: ignore
         self.client: Client = state._get_client()
-        self._original_message: Optional[InteractionMessage] = None
+        self._original_response: Optional[InteractionMessage] = None
 
         self.id: int = int(data["id"])
         self.type: InteractionType = try_enum(InteractionType, data["type"])
@@ -357,8 +357,8 @@ class Interaction:
         InteractionMessage
             The original interaction response message.
         """
-        if self._original_message is not None:
-            return self._original_message
+        if self._original_response is not None:
+            return self._original_response
 
         adapter = async_context.get()
         data = await adapter.get_original_interaction_response(
@@ -368,7 +368,7 @@ class Interaction:
         )
         state = _InteractionMessageState(self, self._state)
         message = InteractionMessage(state=state, channel=self.channel, data=data)  # type: ignore
-        self._original_message = message
+        self._original_response = message
         return message
 
     async def edit_original_response(

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4910,6 +4910,7 @@ Interaction
 .. autoclass:: Interaction()
     :members:
     :inherited-members:
+    :exclude-members: original_message, edit_original_message, delete_original_message
 
 ApplicationCommandInteraction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test_bot/cogs/guild_scheduled_events.py
+++ b/test_bot/cogs/guild_scheduled_events.py
@@ -25,7 +25,7 @@ class GuildScheduledEvents(commands.Cog):
             gse2 = await gse.edit(image=image.fp.read())
         else:
             gse2 = await gse.edit(image=None)
-        await inter.edit_original_message(content=str(gse2.image))
+        await inter.edit_original_response(content=str(gse2.image))
 
     @commands.slash_command()
     async def create_event(


### PR DESCRIPTION
## Summary

start to shift original_message to original_response, but keep the old names around for quite a while.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
