### PR TITLE
feat: return self in actionrow row methods to allow chaining calls

### DIFF
--- a/changelog/740.feature.rst
+++ b/changelog/740.feature.rst
@@ -1,0 +1,6 @@
+Return the :class:`disnake.ui.ActionRow` instance on multiple methods to allow for fluent-style chaining.
+- :func:`ActionRow.append_item <disnake.ui.ActionRow.append_item>`
+- :func:`ActionRow.insert_item <disnake.ui.ActionRow.insert_item>`
+- :func:`ActionRow.add_button <disnake.ui.ActionRow.add_button>`
+- :func:`ActionRow.add_select <disnake.ui.ActionRow.add_select>`
+- :func:`ActionRow.add_text_input <disnake.ui.ActionRow.add_text_input>`

--- a/changelog/740.feature.rst
+++ b/changelog/740.feature.rst
@@ -1,8 +1,2 @@
 Return the :class:`disnake.ui.ActionRow` instance on multiple methods to allow for fluent-style chaining.
-- :func:`ActionRow.append_item <disnake.ui.ActionRow.append_item>`
-- :func:`ActionRow.insert_item <disnake.ui.ActionRow.insert_item>`
-- :func:`ActionRow.add_button <disnake.ui.ActionRow.add_button>`
-- :func:`ActionRow.add_select <disnake.ui.ActionRow.add_select>`
-- :func:`ActionRow.add_text_input <disnake.ui.ActionRow.add_text_input>`
-- :func:`ActionRow.clear_items <disnake.ui.ActionRow.clear_items>`
-- :func:`ActionRow.remove_item <disnake.ui.ActionRow.remove_item>`
+- This applies to :func:`ActionRow.append_item <disnake.ui.ActionRow.append_item>`, :func:`ActionRow.insert_item <disnake.ui.ActionRow.insert_item>`, :func:`ActionRow.add_button <disnake.ui.ActionRow.add_button>`, :func:`ActionRow.add_select <disnake.ui.ActionRow.add_select>`, :func:`ActionRow.add_text_input <disnake.ui.ActionRow.add_text_input>`, :func:`ActionRow.clear_items <disnake.ui.ActionRow.clear_items>`, and :func:`ActionRow.remove_item <disnake.ui.ActionRow.remove_item>`.

--- a/changelog/740.feature.rst
+++ b/changelog/740.feature.rst
@@ -4,3 +4,5 @@ Return the :class:`disnake.ui.ActionRow` instance on multiple methods to allow f
 - :func:`ActionRow.add_button <disnake.ui.ActionRow.add_button>`
 - :func:`ActionRow.add_select <disnake.ui.ActionRow.add_select>`
 - :func:`ActionRow.add_text_input <disnake.ui.ActionRow.add_text_input>`
+- :func:`ActionRow.clear_items <disnake.ui.ActionRow.clear_items>`
+- :func:`ActionRow.remove_item <disnake.ui.ActionRow.remove_item>`

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -85,16 +85,16 @@ Components = Union[
 ]
 
 # this is cursed
-ButtonCompatibleActionRow = TypeVar(
-    "ButtonCompatibleActionRow",
+ButtonCompatibleActionRowT = TypeVar(
+    "ButtonCompatibleActionRowT",
     bound="Union[ActionRow[MessageUIComponent], ActionRow[WrappedComponent]]",
 )
-SelectCompatibleActionRow = TypeVar(
-    "SelectCompatibleActionRow",
-    bound="Union[ActionRow[MessageUIComponent], ActionRow[WrappedComponent]]",  # to add: ActionRow[ModalUIComponent]
+SelectCompatibleActionRowT = TypeVar(
+    "SelectCompatibleActionRowT",
+    bound="Union[ActionRow[MessageUIComponent],ActionRow[WrappedComponent]]",  # to add: ActionRow[ModalUIComponent]
 )
-TextInputCompatibleActionRow = TypeVar(
-    "TextInputCompatibleActionRow",
+TextInputCompatibleActionRowT = TypeVar(
+    "TextInputCompatibleActionRowT",
     bound="Union[ActionRow[ModalUIComponent], ActionRow[WrappedComponent]]",
 )
 
@@ -247,7 +247,7 @@ class ActionRow(Generic[UIComponentT]):
         return self
 
     def add_button(
-        self: ButtonCompatibleActionRow,
+        self: ButtonCompatibleActionRowT,
         index: Optional[int] = None,
         *,
         style: ButtonStyle = ButtonStyle.secondary,
@@ -256,7 +256,7 @@ class ActionRow(Generic[UIComponentT]):
         custom_id: Optional[str] = None,
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
-    ) -> ButtonCompatibleActionRow:
+    ) -> ButtonCompatibleActionRowT:
         """Add a button to the action row. Can only be used if the action
         row holds message components.
 
@@ -307,7 +307,7 @@ class ActionRow(Generic[UIComponentT]):
         return self
 
     def add_select(
-        self: SelectCompatibleActionRow,
+        self: SelectCompatibleActionRowT,
         *,
         custom_id: str = MISSING,
         placeholder: Optional[str] = None,
@@ -315,7 +315,7 @@ class ActionRow(Generic[UIComponentT]):
         max_values: int = 1,
         options: List[SelectOption] = MISSING,
         disabled: bool = False,
-    ) -> SelectCompatibleActionRow:
+    ) -> SelectCompatibleActionRowT:
         """Add a select menu to the action row. Can only be used if the action
         row holds message components.
 
@@ -360,7 +360,7 @@ class ActionRow(Generic[UIComponentT]):
         return self
 
     def add_text_input(
-        self: TextInputCompatibleActionRow,
+        self: TextInputCompatibleActionRowT,
         *,
         label: str,
         custom_id: str,
@@ -370,7 +370,7 @@ class ActionRow(Generic[UIComponentT]):
         required: bool = True,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
-    ) -> TextInputCompatibleActionRow:
+    ) -> TextInputCompatibleActionRowT:
         """Add a text input to the action row. Can only be used if the action
         row holds modal components.
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -420,15 +420,20 @@ class ActionRow(Generic[UIComponentT]):
 
         return self
 
-    def clear_items(self) -> None:
+    def clear_items(self) -> Self:
         """Remove all components from the action row.
+
+        This function returns the class instance to allow for fluent-style chaining.
 
         .. versionadded:: 2.6
         """
         self._children.clear()
+        return self
 
-    def remove_item(self, item: UIComponentT) -> None:
+    def remove_item(self, item: UIComponentT) -> Self:
         """Remove a component from the action row.
+
+        This function returns the class instance to allow for fluent-style chaining.
 
         .. versionadded:: 2.6
 
@@ -443,6 +448,7 @@ class ActionRow(Generic[UIComponentT]):
             The component could not be found on the action row.
         """
         self._children.remove(item)
+        return self
 
     def pop(self, index: int) -> UIComponentT:
         """Pop the component at the provided index from the action row.

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -91,7 +91,7 @@ ButtonCompatibleActionRowT = TypeVar(
 )
 SelectCompatibleActionRowT = TypeVar(
     "SelectCompatibleActionRowT",
-    bound="Union[ActionRow[MessageUIComponent],ActionRow[WrappedComponent]]",  # to add: ActionRow[ModalUIComponent]
+    bound="Union[ActionRow[MessageUIComponent], ActionRow[WrappedComponent]]",  # to add: ActionRow[ModalUIComponent]
 )
 TextInputCompatibleActionRowT = TypeVar(
     "TextInputCompatibleActionRowT",

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -91,7 +91,7 @@ ButtonCompatibleActionRow = TypeVar(
 )
 SelectCompatibleActionRow = TypeVar(
     "SelectCompatibleActionRow",
-    bound="Union[ActionRow[MessageUIComponent],ActionRow[WrappedComponent]]",  # to add: ActionRow[ModalUIComponent]
+    bound="Union[ActionRow[MessageUIComponent], ActionRow[WrappedComponent]]",  # to add: ActionRow[ModalUIComponent]
 )
 TextInputCompatibleActionRow = TypeVar(
     "TextInputCompatibleActionRow",

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -56,6 +56,8 @@ from .select import Select
 from .text_input import TextInput
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..emoji import Emoji
     from ..message import Message
     from ..partial_emoji import PartialEmoji
@@ -81,6 +83,20 @@ Components = Union[
     UIComponentT,
     Sequence[Union["ActionRow[UIComponentT]", UIComponentT, Sequence[UIComponentT]]],
 ]
+
+# this is cursed
+ButtonCompatibleActionRow = TypeVar(
+    "ButtonCompatibleActionRow",
+    bound="Union[ActionRow[MessageUIComponent], ActionRow[WrappedComponent]]",
+)
+SelectCompatibleActionRow = TypeVar(
+    "SelectCompatibleActionRow",
+    bound="Union[ActionRow[MessageUIComponent],ActionRow[WrappedComponent]]",  # to add: ActionRow[ModalUIComponent]
+)
+TextInputCompatibleActionRow = TypeVar(
+    "TextInputCompatibleActionRow",
+    bound="Union[ActionRow[ModalUIComponent], ActionRow[WrappedComponent]]",
+)
 
 
 class ActionRow(Generic[UIComponentT]):
@@ -185,9 +201,11 @@ class ActionRow(Generic[UIComponentT]):
     def width(self) -> int:
         return sum(child.width for child in self._children)
 
-    def append_item(self, item: UIComponentT) -> None:
+    def append_item(self, item: UIComponentT) -> Self:
         """Append a component to the action row. The component's type must match that
         of the action row.
+
+        This function returns the class instance to allow for fluent-style chaining.
 
         Parameters
         ----------
@@ -200,10 +218,13 @@ class ActionRow(Generic[UIComponentT]):
             The width of the action row exceeds 5.
         """
         self.insert_item(len(self), item)
+        return self
 
-    def insert_item(self, index: int, item: UIComponentT) -> None:
+    def insert_item(self, index: int, item: UIComponentT) -> Self:
         """Insert a component to the action row at a given index. The component's
         type must match that of the action row.
+
+        This function returns the class instance to allow for fluent-style chaining.
 
         .. versionadded:: 2.6
 
@@ -223,9 +244,10 @@ class ActionRow(Generic[UIComponentT]):
             raise ValueError("Too many components in this row, can not append a new one.")
 
         self._children.insert(index, item)
+        return self
 
     def add_button(
-        self: Union[ActionRow[MessageUIComponent], ActionRow[WrappedComponent]],
+        self: ButtonCompatibleActionRow,
         index: Optional[int] = None,
         *,
         style: ButtonStyle = ButtonStyle.secondary,
@@ -234,12 +256,14 @@ class ActionRow(Generic[UIComponentT]):
         custom_id: Optional[str] = None,
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
-    ) -> None:
+    ) -> ButtonCompatibleActionRow:
         """Add a button to the action row. Can only be used if the action
         row holds message components.
 
         To append a pre-existing :class:`~disnake.ui.Button` use the
         :meth:`append_item` method instead.
+
+        This function returns the class instance to allow for fluent-style chaining.
 
         .. versionchanged:: 2.6
             Now allows for inserting at a given index. The default behaviour of
@@ -280,13 +304,10 @@ class ActionRow(Generic[UIComponentT]):
                 emoji=emoji,
             ),
         )
+        return self
 
     def add_select(
-        self: Union[
-            ActionRow[MessageUIComponent],
-            # ActionRow[ModalUIComponent],
-            ActionRow[WrappedComponent],
-        ],
+        self: SelectCompatibleActionRow,
         *,
         custom_id: str = MISSING,
         placeholder: Optional[str] = None,
@@ -294,12 +315,14 @@ class ActionRow(Generic[UIComponentT]):
         max_values: int = 1,
         options: List[SelectOption] = MISSING,
         disabled: bool = False,
-    ) -> None:
+    ) -> SelectCompatibleActionRow:
         """Add a select menu to the action row. Can only be used if the action
         row holds message components.
 
         To append a pre-existing :class:`~disnake.ui.Select` use the
         :meth:`append_item` method instead.
+
+        This function returns the class instance to allow for fluent-style chaining.
 
         Parameters
         ----------
@@ -334,9 +357,10 @@ class ActionRow(Generic[UIComponentT]):
                 disabled=disabled,
             ),
         )
+        return self
 
     def add_text_input(
-        self: Union[ActionRow[ModalUIComponent], ActionRow[WrappedComponent]],
+        self: TextInputCompatibleActionRow,
         *,
         label: str,
         custom_id: str,
@@ -346,12 +370,14 @@ class ActionRow(Generic[UIComponentT]):
         required: bool = True,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
-    ) -> None:
+    ) -> TextInputCompatibleActionRow:
         """Add a text input to the action row. Can only be used if the action
         row holds modal components.
 
         To append a pre-existing :class:`~disnake.ui.TextInput` use the
         :meth:`append_item` method instead.
+
+        This function returns the class instance to allow for fluent-style chaining.
 
         .. versionadded:: 2.4
 
@@ -391,6 +417,8 @@ class ActionRow(Generic[UIComponentT]):
                 max_length=max_length,
             ),
         )
+
+        return self
 
     def clear_items(self) -> None:
         """Remove all components from the action row.


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
same as #733 but for action rows (suggested in [this comment](https://github.com/DisnakeDev/disnake/pull/733#issuecomment-1241973146) by @shiftinv)
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
