### PR TITLE
feat: add Guild.max_stage_video_channel_users

### DIFF
--- a/changelog/741.feature.rst
+++ b/changelog/741.feature.rst
@@ -1,0 +1,1 @@
+Add :attr:`Guild.max_stage_video_channel_users`.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -184,6 +184,11 @@ class Guild(Hashable):
 
         .. versionadded:: 1.4
 
+    max_stage_video_channel_users: Optional[:class:`int`]
+        The maximum amount of users in a stage video channel.
+
+        .. versionadded: 2.9
+
     description: Optional[:class:`str`]
         The guild's description.
     mfa_level: :class:`int`
@@ -316,6 +321,7 @@ class Guild(Hashable):
         "max_presences",
         "max_members",
         "max_video_channel_users",
+        "max_stage_video_channel_users",
         "premium_progress_bar_enabled",
         "premium_tier",
         "premium_subscription_count",
@@ -546,6 +552,9 @@ class Guild(Hashable):
         self.max_presences: Optional[int] = guild.get("max_presences")
         self.max_members: Optional[int] = guild.get("max_members")
         self.max_video_channel_users: Optional[int] = guild.get("max_video_channel_users")
+        self.max_stage_video_channel_users: Optional[int] = guild.get(
+            "max_stage_video_channel_users"
+        )
         self.premium_tier: int = guild.get("premium_tier", 0)
         self.premium_subscription_count: int = guild.get("premium_subscription_count") or 0
         self._system_channel_flags: int = guild.get("system_channel_flags", 0)

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -122,6 +122,7 @@ class Guild(_BaseGuildPreview):
     preferred_locale: str
     public_updates_channel_id: Optional[Snowflake]
     max_video_channel_users: NotRequired[int]
+    max_stage_video_channel_users: NotRequired[int]
     approximate_member_count: NotRequired[int]
     approximate_presence_count: NotRequired[int]
     nsfw_level: NSFWLevel


### PR DESCRIPTION
## Summary
implements and blocked by discord/discord-api-docs#5273
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
