### PR TITLE
typing: update options parameter type in `ui.ActionRow.add_select`

### DIFF
--- a/changelog/744.misc.rst
+++ b/changelog/744.misc.rst
@@ -1,0 +1,1 @@
+Update annotation and description of ``options`` parameter of :func:`ui.ActionRow.add_select <disnake.ui.ActionRow.add_select>` to match :class:`ui.Select <disnake.ui.Select>`.

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -46,13 +46,12 @@ from ..components import (
     Button as ButtonComponent,
     NestedComponent,
     SelectMenu as SelectComponent,
-    SelectOption,
 )
 from ..enums import ButtonStyle, ComponentType, TextInputStyle
 from ..utils import MISSING, SequenceProxy
 from .button import Button
 from .item import WrappedComponent
-from .select import Select
+from .select import Select, SelectOptionInput
 from .text_input import TextInput
 
 if TYPE_CHECKING:
@@ -313,7 +312,7 @@ class ActionRow(Generic[UIComponentT]):
         placeholder: Optional[str] = None,
         min_values: int = 1,
         max_values: int = 1,
-        options: List[SelectOption] = MISSING,
+        options: SelectOptionInput = MISSING,
         disabled: bool = False,
     ) -> SelectCompatibleActionRowT:
         """Add a select menu to the action row. Can only be used if the action

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -336,8 +336,10 @@ class ActionRow(Generic[UIComponentT]):
         max_values: :class:`int`
             The maximum number of items that must be chosen for this select menu.
             Defaults to 1 and must be between 1 and 25.
-        options: List[:class:`~disnake.SelectOption`]
-            A list of options that can be selected in this menu.
+        options: Union[List[:class:`disnake.SelectOption`], List[:class:`str`], Dict[:class:`str`, :class:`str`]]
+            A list of options that can be selected in this menu. Use explicit :class:`.SelectOption`\\s
+            for fine-grained control over the options. Alternatively, a list of strings will be treated
+            as a list of labels, and a dict will be treated as a mapping of labels to values.
         disabled: :class:`bool`
             Whether the select is disabled or not.
 

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -74,7 +74,6 @@ SelectOptionInput = Union[List[SelectOption], List[str], Dict[str, str]]
 
 
 def _parse_select_options(options: SelectOptionInput) -> List[SelectOption]:
-
     if isinstance(options, dict):
         return [SelectOption(label=key, value=val) for key, val in options.items()]
 

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -70,10 +70,10 @@ S_co = TypeVar("S_co", bound="Select", covariant=True)
 V_co = TypeVar("V_co", bound="Optional[View]", covariant=True)
 P = ParamSpec("P")
 
+SelectOptionInput = Union[List[SelectOption], List[str], Dict[str, str]]
 
-def _parse_select_options(
-    options: Union[List[SelectOption], List[str], Dict[str, str]]
-) -> List[SelectOption]:
+
+def _parse_select_options(options: SelectOptionInput) -> List[SelectOption]:
 
     if isinstance(options, dict):
         return [SelectOption(label=key, value=val) for key, val in options.items()]
@@ -140,7 +140,7 @@ class Select(Item[V_co]):
         placeholder: Optional[str] = None,
         min_values: int = 1,
         max_values: int = 1,
-        options: Union[List[SelectOption], List[str], Dict[str, str]] = ...,
+        options: SelectOptionInput = ...,
         disabled: bool = False,
         row: Optional[int] = None,
     ):
@@ -154,7 +154,7 @@ class Select(Item[V_co]):
         placeholder: Optional[str] = None,
         min_values: int = 1,
         max_values: int = 1,
-        options: Union[List[SelectOption], List[str], Dict[str, str]] = ...,
+        options: SelectOptionInput = ...,
         disabled: bool = False,
         row: Optional[int] = None,
     ):
@@ -167,7 +167,7 @@ class Select(Item[V_co]):
         placeholder: Optional[str] = None,
         min_values: int = 1,
         max_values: int = 1,
-        options: Union[List[SelectOption], List[str], Dict[str, str]] = MISSING,
+        options: SelectOptionInput = MISSING,
         disabled: bool = False,
         row: Optional[int] = None,
     ) -> None:
@@ -358,7 +358,7 @@ def select(
     custom_id: str = ...,
     min_values: int = 1,
     max_values: int = 1,
-    options: Union[List[SelectOption], List[str], Dict[str, str]] = ...,
+    options: SelectOptionInput = ...,
     disabled: bool = False,
     row: Optional[int] = None,
 ) -> Callable[[ItemCallbackType[Select[V_co]]], DecoratedItem[Select[V_co]]]:


### PR DESCRIPTION
## Summary

Previous annotations didn't allow calls like `row.add_select(options=["a", "b"])`, full `SelectOption` instances had to be provided even though the underlying code supports both.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
