### PR TITLE
docs: own forum threads can be deleted if there are no replies

### DIFF
--- a/changelog/745.doc.rst
+++ b/changelog/745.doc.rst
@@ -1,0 +1,1 @@
+Clarify :func:`Thread.delete` criteria for threads in forum channels.

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -854,6 +854,8 @@ class Thread(Messageable, Hashable):
         Deletes this thread.
 
         You must have :attr:`~Permissions.manage_threads` to delete threads.
+        Alternatively, you may delete a thread if it's in a :class:`ForumChannel`,
+        you are the thread creator, and there are no messages other than the initial message.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary

Unlike threads in text channels, it seems like forum threads can be deleted by the owner without `manage_threads` perms if there are no replies, i.e. only the initial message (or none) exists in the thread.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
