### PR TITLE
fix: only send `slowmode_delay` param with `ForumChannel.create_thread` if required

### DIFF
--- a/changelog/746.bugfix.rst
+++ b/changelog/746.bugfix.rst
@@ -1,0 +1,1 @@
+Fix creation of forum threads without :class:`Permissions.manage_threads`.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2999,7 +2999,6 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         channel_data = {
             "name": name,
             "auto_archive_duration": auto_archive_duration or self.default_auto_archive_duration,
-            "type": ChannelType.public_thread.value,
         }
 
         if slowmode_delay is not MISSING:

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2911,7 +2911,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
-            If not provided, slowmode is disabled.
+            If not provided, slowmode is inherited from the parent's :attr:`~ForumChannel.thread_slowmode_delay`.
         content: :class:`str`
             The content of the message to send.
         embed: :class:`.Embed`
@@ -2996,13 +2996,19 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         else:
             flags = 0
 
+        channel_data = {
+            "name": name,
+            "auto_archive_duration": auto_archive_duration or self.default_auto_archive_duration,
+            "type": ChannelType.public_thread.value,
+        }
+
+        if slowmode_delay is not MISSING:
+            channel_data["rate_limit_per_user"] = slowmode_delay
+
         try:
             data = await self._state.http.start_thread_in_forum_channel(
                 self.id,
-                name=name,
-                auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
-                rate_limit_per_user=slowmode_delay or 0,
-                type=ChannelType.public_thread.value,
+                **channel_data,
                 files=params.files,
                 flags=flags,
                 reason=reason,

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2911,7 +2911,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
-            If not provided, slowmode is inherited from the parent.
+            If not provided, slowmode is inherited from the parent's configured default thread slowmode.
         content: :class:`str`
             The content of the message to send.
         embed: :class:`.Embed`

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2911,7 +2911,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         slowmode_delay: :class:`int`
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
-            If not provided, slowmode is inherited from the parent's :attr:`~ForumChannel.thread_slowmode_delay`.
+            If not provided, slowmode is inherited from the parent.
         content: :class:`str`
             The content of the message to send.
         embed: :class:`.Embed`

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -55,7 +55,7 @@ from .context_managers import Typing
 from .enums import ChannelType, StagePrivacyLevel, VideoQualityMode, try_enum, try_enum_to_int
 from .errors import ClientException
 from .file import File
-from .flags import ChannelFlags, MessageFlags
+from .flags import ChannelFlags
 from .iterators import ArchivedThreadIterator
 from .mixins import Hashable
 from .permissions import PermissionOverwrite, Permissions
@@ -2975,6 +2975,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
             embeds=embeds,
             file=file,
             files=files,
+            suppress_embeds=suppress_embeds,
             view=view,
             components=components,
             allowed_mentions=allowed_mentions,
@@ -2991,11 +2992,6 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         elif params.files and not all(isinstance(file, File) for file in params.files):
             raise TypeError("files parameter must be a list of File")
 
-        if suppress_embeds:
-            flags = MessageFlags.suppress_embeds.flag
-        else:
-            flags = 0
-
         channel_data = {
             "name": name,
             "auto_archive_duration": auto_archive_duration or self.default_auto_archive_duration,
@@ -3009,7 +3005,6 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
                 self.id,
                 **channel_data,
                 files=params.files,
-                flags=flags,
                 reason=reason,
                 **params.payload,
             )


### PR DESCRIPTION
## Summary

Without `manage_messages` perms, trying to create a thread in a forum channel currently results in a permissions error, as the client always sends the `slowmode_delay`/`rate_limit_per_user` field in the request (defaulting to 0).

This PR fixes that by only sending the field if necessary, and additionally removes the `type` field which isn't documented (but works fine nonetheless, and was required in initial stages of the forums API iirc).

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
