### PR TITLE
fix: don't count initial message in forum threads towards `message_count`

### DIFF
--- a/changelog/747.bugfix.rst
+++ b/changelog/747.bugfix.rst
@@ -1,0 +1,1 @@
+Don't count initial message in forum threads towards :attr:`Thread.message_count` and :attr:`Thread.total_message_sent`.

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -782,8 +782,9 @@ class ConnectionState:
         self.dispatch("message", message)
         if self._messages is not None:
             self._messages.append(message)
-        # we ensure that the channel is a type that implements last_message_id
+
         if channel:
+            # we ensure that the channel is a type that implements last_message_id
             if channel.__class__ in (TextChannel, Thread, VoiceChannel):
                 channel.last_message_id = message.id  # type: ignore
             # Essentially, messages *don't* count towards message_count, if:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -784,18 +784,21 @@ class ConnectionState:
             self._messages.append(message)
         # we ensure that the channel is a type that implements last_message_id
         if channel:
-            if type(channel) in (TextChannel, Thread, VoiceChannel):
+            if channel.__class__ in (TextChannel, Thread, VoiceChannel):
                 channel.last_message_id = message.id  # type: ignore
             # Essentially, messages *don't* count towards message_count, if:
             # - they're the thread starter message
             # - or, they're the initial message of a forum channel thread (which uses MessageType.default)
             # This mirrors the current client and API behavior.
-            if type(channel) is Thread and not (
+            if channel.__class__ is Thread and not (
                 message.type is MessageType.thread_starter_message
-                or (type(channel.parent) is ForumChannel and channel.id == message.id)
+                or (
+                    type(channel.parent) is ForumChannel  # type: ignore
+                    and channel.id == message.id
+                )
             ):
-                channel.total_message_sent += 1
-                channel.message_count += 1
+                channel.total_message_sent += 1  # type: ignore
+                channel.message_count += 1  # type: ignore
 
     def parse_message_delete(self, data: gateway.MessageDeleteEvent) -> None:
         raw = RawMessageDeleteEvent(data)

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -793,7 +793,11 @@ class ConnectionState:
             # This mirrors the current client and API behavior.
             if type(channel) is Thread and not (
                 message.type is MessageType.thread_starter_message
-                or (isinstance(channel.parent, ForumChannel) and channel.id == message.id)
+                or (
+                    channel.parent
+                    and channel.parent.type is ChannelType.forum
+                    and channel.id == message.id
+                )
             ):
                 channel.total_message_sent += 1
                 channel.message_count += 1

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -786,7 +786,6 @@ class ConnectionState:
         if channel:
             if type(channel) in (TextChannel, Thread, VoiceChannel):
                 channel.last_message_id = message.id  # type: ignore
-            # woo fun logic
             # Essentially, messages *don't* count towards message_count, if:
             # - they're the thread starter message
             # - or, they're the initial message of a forum channel thread (which uses MessageType.default)

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -792,11 +792,7 @@ class ConnectionState:
             # This mirrors the current client and API behavior.
             if type(channel) is Thread and not (
                 message.type is MessageType.thread_starter_message
-                or (
-                    channel.parent
-                    and channel.parent.type is ChannelType.forum
-                    and channel.id == message.id
-                )
+                or (type(channel.parent) is ForumChannel and channel.id == message.id)
             ):
                 channel.total_message_sent += 1
                 channel.message_count += 1

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -784,14 +784,19 @@ class ConnectionState:
             self._messages.append(message)
         # we ensure that the channel is a type that implements last_message_id
         if channel:
-            if channel.__class__ in (TextChannel, Thread, VoiceChannel):
+            if type(channel) in (TextChannel, Thread, VoiceChannel):
                 channel.last_message_id = message.id  # type: ignore
-            if (
-                channel.__class__ is Thread
-                and message.type is not MessageType.thread_starter_message
+            # woo fun logic
+            # Essentially, messages *don't* count towards message_count, if:
+            # - they're the thread starter message
+            # - or, they're the initial message of a forum channel thread (which uses MessageType.default)
+            # This mirrors the current client and API behavior.
+            if type(channel) is Thread and not (
+                message.type is MessageType.thread_starter_message
+                or (isinstance(channel.parent, ForumChannel) and channel.id == message.id)
             ):
-                channel.total_message_sent += 1  # type: ignore
-                channel.message_count += 1  # type: ignore
+                channel.total_message_sent += 1
+                channel.message_count += 1
 
     def parse_message_delete(self, data: gateway.MessageDeleteEvent) -> None:
         raw = RawMessageDeleteEvent(data)


### PR DESCRIPTION
## Summary

Followup to #730.
It appears that the message type of the initial forum thread message isn't `thread_starter_message (21)`, but just `default (0)`.
We relied on the message type to accurately update the message count fields, which means it's now off by one for newly created forum threads.

This PR instead mirrors the internal client behavior by also checking the message ID, see the comments in the code.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
