### PR TITLE
docs: clarify behavior of flag initializer kwargs with aliases

### DIFF
--- a/changelog/749.doc.rst
+++ b/changelog/749.doc.rst
@@ -1,1 +1,1 @@
-Clarify behavior of flag type initializers when both a flag and an alias are given.
+Clarify behavior of kwargs in flag methods when both a flag and an alias are given.

--- a/changelog/749.doc.rst
+++ b/changelog/749.doc.rst
@@ -1,0 +1,1 @@
+Clarify behavior of flag type initializers when both a flag and an alias are given.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -829,6 +829,7 @@ class Intents(BaseFlags):
 
     To construct an object you can pass keyword arguments denoting the flags
     to enable or disable.
+    Arguments are applied in order, similar to :class:`Permissions`.
 
     This is used to disable certain gateway features that are unnecessary to
     run your bot. To make use of this, it is passed to the ``intents`` keyword

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -348,6 +348,7 @@ class SystemChannelFlags(BaseFlags, inverted=True):
 
     To construct an object you can pass keyword arguments denoting the flags
     to enable or disable.
+    Arguments are applied in order, similar to :class:`Permissions`.
 
     .. container:: operations
 
@@ -1468,6 +1469,7 @@ class MemberCacheFlags(BaseFlags):
 
     To construct an object you can pass keyword arguments denoting the flags
     to enable or disable.
+    Arguments are applied in order, similar to :class:`Permissions`.
 
     The default value is all flags enabled.
 

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -87,6 +87,14 @@ class Permissions(BaseFlags):
     bits using the properties as if they were regular bools. This allows
     you to edit permissions.
 
+    To construct an object you can pass keyword arguments denoting the permissions
+    to enable or disable.
+    Arguments are applied in order, which notably also means that supplying a flag
+    and its alias will make whatever comes last overwrite the first one; as an example,
+    ``Permissions(external_emojis=True, use_external_emojis=False)`` and
+    ``Permissions(use_external_emojis=True, external_emojis=False)``
+    both result in the same permissions value (``0``).
+
     .. versionchanged:: 1.3
         You can now use keyword arguments to initialize :class:`Permissions`
         similar to :meth:`update`.

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -589,6 +589,8 @@ class Permissions(BaseFlags):
         arguments. The names must be equivalent to the properties
         listed. Extraneous key/value pairs will be silently ignored.
 
+        Arguments are applied in order, similar to the constructor.
+
         Parameters
         ----------
         **kwargs

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -432,6 +432,12 @@ class TestBaseFlags:
         assert ins.two is False
         assert ins.one is True
 
+        ins = TestFlags(two=False, three=True)
+        assert ins.value == 0b11
+
+        ins = TestFlags(two=True, three=False)
+        assert ins.value == 0
+
 
 class _ListFlags(flags.ListBaseFlags):
     @flags.flag_value

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -418,25 +418,18 @@ class TestBaseFlags:
     def test_alias_priority(self) -> None:
         ins = TestFlags(three=False, two=True, one=False)
         assert ins.value == 0b10
-        assert ins.three is False
-        assert ins.two is True
-        assert ins.one is False
 
         ins = TestFlags(three=True, two=False, one=False)
-        assert ins.three is False
-        assert ins.two is False
-        assert ins.one is False
+        assert ins.value == 0b00
 
         ins = TestFlags(three=True, two=False)
-        assert ins.three is False
-        assert ins.two is False
-        assert ins.one is True
+        assert ins.value == 0b01
 
         ins = TestFlags(two=False, three=True)
         assert ins.value == 0b11
 
         ins = TestFlags(two=True, three=False)
-        assert ins.value == 0
+        assert ins.value == 0b00
 
 
 class _ListFlags(flags.ListBaseFlags):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -116,6 +116,20 @@ class TestPermissions:
         assert perms.value == expected_perms.value
 
     @pytest.mark.parametrize(
+        ("update", "expected"),
+        [
+            ({"read_messages": True, "view_channel": False}, 8),
+            ({"view_channel": True, "read_messages": False}, 8),
+            ({"read_messages": False, "view_channel": True}, 8 + 1024),
+            ({"view_channel": False, "read_messages": True}, 8 + 1024),
+        ],
+    )
+    def test_update_aliases(self, update: Dict[str, bool], expected: int) -> None:
+        perms = Permissions(administrator=True)
+        perms.update(**update)
+        assert perms.value == expected
+
+    @pytest.mark.parametrize(
         ("parameters", "expected"),
         [
             ({"view_channel": True, "move_members": True}, None),

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -16,8 +16,10 @@ class TestPermissions:
 
     def test_init_permissions_keyword_arguments_with_aliases(self) -> None:
         assert Permissions(read_messages=True, view_channel=False).value == 0
+        assert Permissions(view_channel=True, read_messages=False).value == 0
 
-        assert Permissions(read_messages=False, view_channel=True).view_channel is True
+        assert Permissions(read_messages=False, view_channel=True).value == 1024
+        assert Permissions(view_channel=False, read_messages=True).value == 1024
 
     def test_init_invalid_value(self) -> None:
         with pytest.raises(TypeError, match="Expected int parameter, received str instead."):


### PR DESCRIPTION
## Summary

Resolves #607.

The description in that issue isn't fully correct, essentially it boils down to "later kwargs take precedence over earlier kwargs".

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
