### PR TITLE
deps: bump pyright to 1.1.271

### DIFF
--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -394,7 +394,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self.require_var_positional: bool = kwargs.get("require_var_positional", False)
         self.ignore_extra: bool = kwargs.get("ignore_extra", True)
         self.cooldown_after_parsing: bool = kwargs.get("cooldown_after_parsing", False)
-        self.cog: CogT = None
+        self.cog: CogT = None  # type: ignore
 
         # bandaid for the fact that sometimes parent can be the bot instance
         parent = kwargs.get("parent")

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -31,7 +31,7 @@ import inspect
 import sys
 import traceback
 from collections.abc import Sequence
-from typing import Any, Awaitable, Callable, Generic, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Coroutine, Generic, List, Optional, Type, TypeVar, Union
 
 import aiohttp
 
@@ -42,10 +42,10 @@ from disnake.utils import MISSING, utcnow
 __all__ = ("loop",)
 
 T = TypeVar("T")
-_func = Callable[..., Awaitable[Any]]
+_func = Callable[..., Coroutine[Any, Any, Any]]
 LF = TypeVar("LF", bound=_func)
 FT = TypeVar("FT", bound=_func)
-ET = TypeVar("ET", bound=Callable[[Any, BaseException], Awaitable[Any]])
+ET = TypeVar("ET", bound=Callable[[Any, BaseException], Coroutine[Any, Any, Any]])
 
 
 class SleepHandle:
@@ -550,7 +550,7 @@ class Loop(Generic[LF]):
         if not asyncio.iscoroutinefunction(coro):
             raise TypeError(f"Expected coroutine function, received {coro.__class__.__name__!r}.")
 
-        self._error = coro  # type: ignore
+        self._error = coro
         return coro
 
     def _get_next_sleep_time(self) -> datetime.datetime:

--- a/disnake/i18n.py
+++ b/disnake/i18n.py
@@ -143,7 +143,7 @@ class Localized(Generic[StringT]):
         key: str = MISSING,
         data: Union[Optional[LocalizationsDict], LocalizationValue] = MISSING,
     ):
-        self.string: StringT = string
+        self.string: StringT = string  # type: ignore  # default values for generic parameters don't quite work
 
         if not (key is MISSING) ^ (data is MISSING):
             raise TypeError("Exactly one of `key` or `data` must be provided")
@@ -181,7 +181,7 @@ class Localized(Generic[StringT]):
         ...
 
     def _upgrade(
-        self, string: Optional[str] = None, *, key: Optional[str] = None
+        self: Localized[Any], string: Optional[str] = None, *, key: Optional[str] = None
     ) -> Localized[Any]:
         # update key if provided and not already set
         self.localizations._upgrade(key)

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -120,7 +120,7 @@ class Item(WrappedComponent, Generic[V_co]):
         ...
 
     def __init__(self):
-        self._view: V_co = None
+        self._view: V_co = None  # type: ignore
         self._row: Optional[int] = None
         self._rendered_row: Optional[int] = None
         # This works mostly well but there is a gotcha with

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -3,7 +3,7 @@
 ## type checking
 typing_extensions~=4.2.0
 # this is not pyright itself, but the python wrapper
-pyright==1.1.264
+pyright==1.1.271
 
 ## test bot
 python-dotenv~=0.20.0


### PR DESCRIPTION
## Summary

The `# type: ignore` in `Localized.__init__` is due to `strictParameterNoneValue` still being disabled, all the other changes take care of valid typing errors that were previously false negatives.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
