### PR TITLE
feat: rename with_edits to with_changes

### DIFF
--- a/changelog/757.feature.rst
+++ b/changelog/757.feature.rst
@@ -1,0 +1,8 @@
+Implement auto moderation.
+- New types: :class:`AutoModAction`, :class:`AutoModTriggerMetadata`, :class:`AutoModRule`, :class:`AutoModActionExecution`
+- New enums: :class:`AutoModTriggerType`, :class:`AutoModEventType`, :class:`AutoModActionType`
+- New flags: :class:`AutoModKeywordPresets`
+- New methods: :func:`Guild.create_automod_rule`, :func:`Guild.fetch_automod_rule`, :func:`Guild.fetch_automod_rules`
+- New intents: :attr:`Intents.automod_configuration`, :attr:`Intents.automod_execution` (+ :attr:`Intents.automod` shortcut for both)
+- New events: :func:`on_automod_rule_create`, :func:`on_automod_rule_update`, :func:`on_automod_rule_delete`, :func:`on_automod_action_execution`
+- \+ all the relevant :class:`AuditLogEntry` and :class:`AuditLogChanges` fields.

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -292,7 +292,7 @@ class AutoModTriggerMetadata:
         self.allow_list: Optional[Sequence[str]] = allow_list
         self.mention_total_limit: Optional[int] = mention_total_limit
 
-    def with_edits(
+    def with_changes(
         self,
         *,
         keyword_filter: Optional[Sequence[str]] = MISSING,
@@ -301,7 +301,7 @@ class AutoModTriggerMetadata:
         mention_total_limit: Optional[int] = MISSING,
     ) -> Self:
         """
-        Returns a new instance with the given edits applied.
+        Returns a new instance with the given changes applied.
         All other fields will be kept intact.
 
         Returns


### PR DESCRIPTION
## Summary
renames ``with_edits`` to ``with_changes`` for less confusion.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
