### PR TITLE
docs: fix outdated inherited `original_message` aliases

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4914,6 +4914,18 @@ Interaction
     :inherited-members:
     :exclude-members: original_message, edit_original_message, delete_original_message
 
+    .. method:: original_message
+
+        An alias of :func:`original_response`.
+
+    .. method:: edit_original_message
+
+        An alias of :func:`edit_original_response`.
+
+    .. method:: delete_original_message
+
+        An alias of :func:`delete_original_response`.
+
 ApplicationCommandInteraction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -4922,6 +4934,19 @@ ApplicationCommandInteraction
 .. autoclass:: ApplicationCommandInteraction()
     :members:
     :inherited-members:
+    :exclude-members: original_message, edit_original_message, delete_original_message
+
+    .. method:: original_message
+
+        An alias of :func:`original_response`.
+
+    .. method:: edit_original_message
+
+        An alias of :func:`edit_original_response`.
+
+    .. method:: delete_original_message
+
+        An alias of :func:`delete_original_response`.
 
 GuildCommandInteraction
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -4946,6 +4971,19 @@ MessageInteraction
 .. autoclass:: MessageInteraction()
     :members:
     :inherited-members:
+    :exclude-members: original_message, edit_original_message, delete_original_message
+
+    .. method:: original_message
+
+        An alias of :func:`original_response`.
+
+    .. method:: edit_original_message
+
+        An alias of :func:`edit_original_response`.
+
+    .. method:: delete_original_message
+
+        An alias of :func:`delete_original_response`.
 
 ModalInteraction
 ~~~~~~~~~~~~~~~~
@@ -4955,6 +4993,19 @@ ModalInteraction
 .. autoclass:: ModalInteraction()
     :members:
     :inherited-members:
+    :exclude-members: original_message, edit_original_message, delete_original_message
+
+    .. method:: original_message
+
+        An alias of :func:`original_response`.
+
+    .. method:: edit_original_message
+
+        An alias of :func:`edit_original_response`.
+
+    .. method:: delete_original_message
+
+        An alias of :func:`delete_original_response`.
 
 InteractionResponse
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

The documentation of `Interaction` subclasses still shows documentation for `original_message`, which is particularly confusing as it also contains the `.. versionchanged` that only makes sense in the context of `original_response`.
This pr properly documents them as aliases, which could then be deprecated in the near future.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
