### PR TITLE
typing: add `io.TextIOBase` as supported fp for `disnake.File`

### DIFF
--- a/disnake/file.py
+++ b/disnake/file.py
@@ -47,14 +47,14 @@ class File:
     __slots__ = ("fp", "filename", "spoiler", "description", "_original_pos", "_owner", "_closer")
 
     if TYPE_CHECKING:
-        fp: io.BufferedIOBase
+        fp: Union[io.TextIOBase, io.BufferedIOBase]
         filename: Optional[str]
         spoiler: bool
         description: Optional[str]
 
     def __init__(
         self,
-        fp: Union[str, bytes, os.PathLike, io.BufferedIOBase],
+        fp: Union[str, bytes, os.PathLike, io.TextIOBase, io.BufferedIOBase],
         filename: Optional[str] = None,
         *,
         spoiler: bool = False,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Allows the use of `io.StringIO` and other TextIO-based files (which `disnake.File` has no reason not to support) without linter complaining.
Closes #765 
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
