### PR TITLE
feat: add backwards-compatible `EmptyEmbed` alias

### DIFF
--- a/changelog/435.breaking.rst
+++ b/changelog/435.breaking.rst
@@ -1,4 +1,4 @@
 Rework :class:`.Embed` internals.
-- This comes with the removal of ``Embed.Empty``. Use ``None`` instead.
-- :meth:`Embed.set_footer()` now requires the ``text`` parameter.
+- :meth:`Embed.set_footer` now requires the ``text`` parameter.
 - :attr:`Embed.type` is now optional, although this could previously be ``Embed.Empty``.
+- ``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``, and will result in type-checking errors.

--- a/changelog/435.breaking.rst
+++ b/changelog/435.breaking.rst
@@ -1,4 +1,4 @@
 Rework :class:`.Embed` internals.
 - :meth:`Embed.set_footer` now requires the ``text`` parameter.
 - :attr:`Embed.type` is now optional, although this could previously be ``Embed.Empty``.
-- ``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``, and will result in type-checking errors.
+- ``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``, have been removed from the documentation, and will result in type-checking errors.

--- a/changelog/435.deprecate.rst
+++ b/changelog/435.deprecate.rst
@@ -1,0 +1,1 @@
+``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``.

--- a/changelog/435.deprecate.rst
+++ b/changelog/435.deprecate.rst
@@ -1,1 +1,1 @@
-``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``.
+``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None`` and have been removed from the documentation.

--- a/changelog/435.deprecate.rst
+++ b/changelog/435.deprecate.rst
@@ -1,1 +1,1 @@
-``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None`` and have been removed from the documentation.
+``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``, have been removed from the documentation, and will result in type-checking errors.

--- a/changelog/768.deprecate.rst
+++ b/changelog/768.deprecate.rst
@@ -1,0 +1,1 @@
+``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``.

--- a/changelog/768.deprecate.rst
+++ b/changelog/768.deprecate.rst
@@ -1,1 +1,1 @@
-``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``.
+``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None`` and have been removed from the documentation.

--- a/changelog/768.deprecate.rst
+++ b/changelog/768.deprecate.rst
@@ -1,1 +1,1 @@
-``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None`` and have been removed from the documentation.
+``EmptyEmbed`` and ``Embed.Empty`` are deprecated in favor of ``None``, have been removed from the documentation, and will result in type-checking errors.

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -22,9 +22,22 @@ from typing import (
 from . import utils
 from .colour import Colour
 from .file import File
-from .utils import MISSING
+from .utils import MISSING, classproperty, warn_deprecated
 
 __all__ = ("Embed",)
+
+
+# backwards compatibility, hidden from type-checkers to have them show errors when accessed
+if not TYPE_CHECKING:
+
+    def __getattr__(name: str) -> None:
+        if name == "EmptyEmbed":
+            warn_deprecated(
+                "`EmptyEmbed` is deprecated and will be removed in a future version. Use `None` instead.",
+                stacklevel=2,
+            )
+            return None
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
 class EmbedProxy:
@@ -209,6 +222,17 @@ class Embed:
         self._fields: Optional[List[EmbedFieldPayload]] = None
 
         self._files: Dict[_FileKey, File] = {}
+
+    # see `EmptyEmbed` above
+    if not TYPE_CHECKING:
+
+        @classproperty
+        def Empty(self) -> None:
+            warn_deprecated(
+                "`Embed.Empty` is deprecated and will be removed in a future version. Use `None` instead.",
+                stacklevel=3,
+            )
+            return None
 
     @classmethod
     def from_dict(cls, data: EmbedData) -> Self:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -436,3 +436,8 @@ def setup(app: Sphinx) -> None:
         app.config.intersphinx_mapping["py"] = ("https://docs.python.org/ja/3", None)
         app.config.html_context["discord_invite"] = "https://discord.gg/disnake"
         app.config.resource_links["disnake"] = "https://discord.gg/disnake"
+
+    # HACK: avoid deprecation warnings caused by sphinx always iterating over all class attributes
+    import disnake
+
+    del disnake.Embed.Empty  # type: ignore

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from disnake import Color, Embed, File
+from disnake import Color, Embed, File, embeds
 from disnake.utils import MISSING, utcnow
 
 _BASE = {"type": "rich"}
@@ -423,3 +423,17 @@ def test_copy_empty() -> None:
     e = Embed.from_dict({})
     copy = e.copy()
     assert e.to_dict() == copy.to_dict() == {}
+
+
+# backwards compatibility
+def test_emptyembed() -> None:
+    with pytest.warns(DeprecationWarning):
+        assert embeds.EmptyEmbed is None  # type: ignore
+    with pytest.warns(DeprecationWarning):
+        assert Embed.Empty is None  # type: ignore
+    with pytest.warns(DeprecationWarning):
+        assert Embed().Empty is None  # type: ignore
+
+    # make sure unknown module attrs continue to raise
+    with pytest.raises(AttributeError):
+        embeds.this_does_not_exist  # type: ignore


### PR DESCRIPTION
## Summary

Followup to #435, makes it a less breaking change.
`EmptyEmbed` and `Embed.Empty` emit deprecation warnings at runtime, and are gated behind `if not TYPE_CHECKING:` to generate type-checking errors already while keeping runtime behavior for now.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
