### PR TITLE
fix(gateway): default to current url for resuming instead of initial url

### DIFF
--- a/changelog/769.feature.rst
+++ b/changelog/769.feature.rst
@@ -1,0 +1,1 @@
+Add ``resume_gateway_url`` handling to gateway/websocket resume flow.

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -359,6 +359,7 @@ class DiscordWebSocket:
         # ws related stuff
         self.session_id: Optional[str] = None
         self.sequence: Optional[int] = None
+        # this may or may not include url parameters, we only need the host part of the url anyway
         self.resume_gateway: Optional[str] = None
         self._zlib: zlib._Decompress = zlib.decompressobj()
         self._buffer: bytearray = bytearray()
@@ -424,6 +425,7 @@ class DiscordWebSocket:
         ws._discord_parsers = client._connection.parsers
         ws._dispatch = client.dispatch
         ws.gateway = gateway
+        ws.resume_gateway = gateway
         ws.call_hooks = client._connection.call_hooks
         ws._initial_identify = initial
         ws.shard_id = shard_id


### PR DESCRIPTION
## Summary

Since we only get the `resume_gateway_url` in the `IDENTIFY`, and don't receive it again when resuming, the value was lost after the first resume, resulting in all subsequent resumes connecting to the initial gateway again:

1. initial connect to `gateway.~`, receive and store resume url (e.g. `gateway-us-east1-c.~`)
1. resume to `gateway-us-east1-c.~`, no resume url received and stored value is lost since the ws is recreated every time
1. resume to `gateway.~`, since we don't have a resume url
1. resume to `gateway.~`
1. ...

This PR fixes this behavior by storing the current url (e.g. `gateway-us-east1-c.~` in 2.) as the resume url, changing the flow to this:

1. initial connect to `gateway.~`, receive and store resume url (e.g. `gateway-us-east1-c.~`)
1. resume to `gateway-us-east1-c.~`, no resume url received but `gateway-us-east1-c.~` is stored as the resume url
1. resume to `gateway-us-east1-c.~`, same thing as 2.
1. ...

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
