### PR TITLE
fix: handle edge case with `Optional[Literal[...]]` parameter annotations

### DIFF
--- a/changelog/770.bugfix.rst
+++ b/changelog/770.bugfix.rst
@@ -1,0 +1,1 @@
+Fix edge case with parsing command annotations that contain a union of non-type objects, like ``Optional[Literal[1, 2, 3]]``.

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -113,7 +113,7 @@ def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[Type
         # Assume we have a type hint
         if get_origin(obj) in (Union, UnionType, Optional):
             obj = get_args(obj)
-            return any(issubclass(o, tp) for o in obj)
+            return any(isinstance(o, type) and issubclass(o, tp) for o in obj)
         else:
             # Other type hint specializations are not supported
             return False


### PR DESCRIPTION
## Summary

Fixes edge case in annotation parser.
Previously it would call `issubclass` with a non-type parameter for particular command annotations, e.g.
```py
from typing import Literal, Optional
import disnake
from disnake.ext import commands

bot = commands.Bot()
@bot.slash_command()
async def f(inter: disnake.CommandInteraction, stuff: Optional[Literal[1, 2, 3]] = None):
    ...
```

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
