### PR TITLE
fix(ci): typo in codemod error message on GHA

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -160,7 +160,7 @@ jobs:
       run: |
         nox -s codemod -- run-all
         if [ -n "$(git status --porcelain disnake/)" ]; then
-          echo "::error::Please run 'nox -s codemod - run-all' locally and commit the changes." >&2;
+          echo "::error::Please run 'nox -s codemod -- run-all' locally and commit the changes." >&2;
           exit 1;
         else
           exit 0;


### PR DESCRIPTION
## Summary

was an invalid command before.

## Checklist

- [x] This PR is **not** a code change (e.g. documentation, README, ...)
