### PR TITLE
feat: hide the extra disnake.AutoShardedClient overload in typechecking

### DIFF
--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -10,7 +10,7 @@ from typing import (
     Callable,
     Dict,
     List,
-    NoReturn,
+    NoReturn as Never,
     Optional,
     Tuple,
     Type,
@@ -354,7 +354,7 @@ class AutoShardedClient(Client):
         ...
 
     @overload
-    def __init__(self: NoReturn):
+    def __init__(self: Never):
         ...
 
     def __init__(self, *args: Any, shard_ids: Optional[List[int]] = None, **kwargs: Any) -> None:

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -10,7 +10,7 @@ from typing import (
     Callable,
     Dict,
     List,
-    NoReturn as Never,
+    NoReturn,
     Optional,
     Tuple,
     Type,
@@ -354,7 +354,7 @@ class AutoShardedClient(Client):
         ...
 
     @overload
-    def __init__(self: Never):
+    def __init__(self: NoReturn):
         ...
 
     def __init__(self, *args: Any, shard_ids: Optional[List[int]] = None, **kwargs: Any) -> None:

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -4,7 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    NoReturn,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 
 import aiohttp
 
@@ -342,7 +354,7 @@ class AutoShardedClient(Client):
         ...
 
     @overload
-    def __init__(self):
+    def __init__(self: NoReturn):
         ...
 
     def __init__(self, *args: Any, shard_ids: Optional[List[int]] = None, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary

hides the second overload using NoReturn; typecheckers won't use it because of that.
Not sure if this is a feature or a bug with type checkers, tho :)
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
