### PR TITLE
fix: ensure embed fields are copied properly

### DIFF
--- a/changelog/792.bugfix.rst
+++ b/changelog/792.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure that embed fields are copied properly by :func:`Embed.copy` and that the copied embed is completely separate from the original one.

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -279,10 +279,15 @@ class Embed:
     def copy(self) -> Self:
         """Returns a shallow copy of the embed."""
         embed = type(self).from_dict(self.to_dict())
+
         # assign manually to keep behavior of default colors
         embed._colour = self._colour
-        # shallow copy of files
+
+        # copy files and fields collections
         embed._files = self._files.copy()
+        if self._fields is not None:
+            embed._fields = self._fields.copy()
+
         return embed
 
     def __len__(self) -> int:
@@ -717,13 +722,16 @@ class Embed:
         if not self._fields:
             raise IndexError("field index out of range")
         try:
-            field = self._fields[index]
+            self._fields[index]
         except IndexError:
             raise IndexError("field index out of range")
 
-        field["name"] = str(name)
-        field["value"] = str(value)
-        field["inline"] = inline
+        field: EmbedFieldPayload = {
+            "inline": inline,
+            "name": str(name),
+            "value": str(value),
+        }
+        self._fields[index] = field
         return self
 
     def to_dict(self) -> EmbedData:

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -310,8 +310,7 @@ class Embed:
                 self.title,
                 self.url,
                 self.description,
-                # not checking for falsy value as `0` is a valid color
-                self._colour not in (MISSING, None),
+                self._colour,
                 self._fields,
                 self._timestamp,
                 self._author,

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -83,30 +83,40 @@ def test_len(embed: Embed) -> None:
 
 
 def test_eq() -> None:
+    # basic test
     embed_1, embed_2 = Embed(), Embed()
     assert embed_1 == embed_2
 
-    # color=MISSING should not affect __eq__
+    embed_1.title, embed_2.title = None, ""
+    assert embed_1 == embed_2
+
+    # color tests
+    embed_1, embed_2 = Embed(), Embed()
     embed_1.color = Color(123456)
     assert not embed_1 == embed_2
 
     embed_1.color = MISSING
     assert embed_1 == embed_2
 
+    embed_1, embed_2 = Embed(color=None), Embed()
+    assert embed_1 == embed_2
+
+    try:
+        Embed.set_default_color(123456)
+        assert not embed_1 == embed_2
+    finally:
+        Embed.set_default_color(None)
+
+    # test fields
+    embed_1, embed_2 = Embed(), Embed()
     embed_1.add_field(name="This is a test field", value="69 test 69")
     embed_2.add_field(name="This is a test field", value="69 test 69", inline=False)
     assert not embed_1 == embed_2
 
     embed_1, embed_2 = Embed(), Embed()
-
-    embed_1.title, embed_2.title = None, ""
+    embed_1._fields = []
+    embed_2._fields = None
     assert embed_1 == embed_2
-
-    embed_1, embed_2 = Embed(color=None), Embed()
-    assert embed_1 == embed_2
-
-    embed_1.set_default_color(123456)
-    assert not embed_1 == embed_2
 
 
 def test_embed_proxy_eq() -> None:

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -134,10 +134,11 @@ def test_color_zero() -> None:
     e = Embed()
     assert not e
 
-    # color=0 should be applied to bool and dict
+    # color=0 should be applied to to_dict, __bool__, and __eq__
     e.color = 0
     assert e
     assert e.to_dict() == {"color": 0, **_BASE}
+    assert e != Embed(color=None)
 
 
 def test_default_color() -> None:

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -414,15 +414,47 @@ def test_copy(embed: Embed, file: File) -> None:
     copy = embed.copy()
     assert embed.to_dict() == copy.to_dict()
 
-    # shallow copy, but `_files` should be copied
+    # shallow copy, but `_files` and `_fields` should be copied
     assert embed._files == copy._files
     assert embed._files is not copy._files
+    assert embed._fields == copy._fields
+    assert embed._fields is not copy._fields
 
 
 def test_copy_empty() -> None:
     e = Embed.from_dict({})
     copy = e.copy()
     assert e.to_dict() == copy.to_dict() == {}
+
+    # shallow copy, but `_files` and `_fields` should be copied
+    assert e._files == copy._files
+    assert e._files is not copy._files
+    assert e._fields is None
+    assert copy._fields is None
+
+
+def test_copy_fields(embed: Embed) -> None:
+    embed.add_field("things", "stuff")
+    copy = embed.copy()
+    embed.clear_fields()
+    assert copy._fields
+
+    embed.insert_field_at(0, "w", "x")
+    copy = embed.copy()
+    embed.remove_field(0)
+    assert embed._fields == []
+    assert copy._fields == [{"name": "w", "value": "x", "inline": True}]
+
+    embed.insert_field_at(0, "w", "x")
+    copy = embed.copy()
+    embed.insert_field_at(1, "y", "z")
+    embed.set_field_at(0, "abc", "def", inline=False)
+
+    assert embed._fields == [
+        {"name": "abc", "value": "def", "inline": False},
+        {"name": "y", "value": "z", "inline": True},
+    ]
+    assert copy._fields == [{"name": "w", "value": "x", "inline": True}]
 
 
 # backwards compatibility


### PR DESCRIPTION
## Summary

Copies the `_fields` list in `Embed.copy()` and prevents updating fields of the original embed through a copied one.
Previously, this would have passed:
```py
e = Embed()
assert e._fields is e.copy()._fields
```

Note that this PR uses a shallow copy of the `_fields` list, not a deep copy.
As such, `e._fields[0] is copy._fields[0]` still holds, which shouldn't be an issue as the field elements are not mutable through `e.fields` (which returns `list[EmbedProxy]` instead of the underlying `list[dict]`).

This also does not handle `Embed.from_dict(e.to_dict())`, which still retains those references as before, as it's not meant for copying and can result in a variety of problems if used for that purpose - `Embed.copy` takes care of those, it exists for a reason :^)

see https://canary.discord.com/channels/808030843078836254/1026220842130079775

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
