### PR TITLE
docs: add Discord docs extlinks entry, update broken links

### DIFF
--- a/changelog/793.doc.rst
+++ b/changelog/793.doc.rst
@@ -1,1 +1,1 @@
-Update broken Discord API Docs links, add ``:discord-docs:`` role for easily creating links to the documentation.
+Update broken Discord API Docs links, add ``:ddocs:`` role for easily creating links to the API documentation.

--- a/changelog/793.doc.rst
+++ b/changelog/793.doc.rst
@@ -1,0 +1,1 @@
+Update broken Discord API Docs links, add ``:discord-docs:`` role for easily creating links to the documentation.

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -93,7 +93,7 @@ class AppInfo:
         A list of RPC origin URLs, if RPC is enabled.
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
-        GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.
+        GameSDK's :discord-docs:`GetTicket <game-sdk/applications#getticket>`.
 
         .. versionadded:: 1.3
 
@@ -277,7 +277,7 @@ class PartialAppInfo:
         A list of RPC origin URLs, if RPC is enabled.
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
-        GameSDK's `GetTicket <https://discord.com/developers/docs/game-sdk/applications#getticket>`_.
+        GameSDK's :discord-docs:`GetTicket <game-sdk/applications#getticket>`.
     terms_of_service_url: Optional[:class:`str`]
         The application's terms of service URL, if set.
     privacy_policy_url: Optional[:class:`str`]

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -93,7 +93,7 @@ class AppInfo:
         A list of RPC origin URLs, if RPC is enabled.
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
-        GameSDK's :discord-docs:`GetTicket <game-sdk/applications#getticket>`.
+        GameSDK's :ddocs:`GetTicket <game-sdk/applications#getticket>`.
 
         .. versionadded:: 1.3
 
@@ -277,7 +277,7 @@ class PartialAppInfo:
         A list of RPC origin URLs, if RPC is enabled.
     verify_key: :class:`str`
         The hex encoded key for verification in interactions and the
-        GameSDK's :discord-docs:`GetTicket <game-sdk/applications#getticket>`.
+        GameSDK's :ddocs:`GetTicket <game-sdk/applications#getticket>`.
     terms_of_service_url: Optional[:class:`str`]
         The application's terms of service URL, if set.
     privacy_policy_url: Optional[:class:`str`]

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -220,7 +220,7 @@ class AutoModTriggerMetadata:
     keyword_filter: Optional[Sequence[:class:`str`]]
         The list of keywords to check for. Used with :attr:`AutoModTriggerType.keyword`.
 
-        See :discord-docs:`api docs <resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies>`
+        See :ddocs:`api docs <resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies>`
         for details about how keyword matching works.
 
     presets: Optional[:class:`AutoModKeywordPresets`]

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -220,7 +220,7 @@ class AutoModTriggerMetadata:
     keyword_filter: Optional[Sequence[:class:`str`]]
         The list of keywords to check for. Used with :attr:`AutoModTriggerType.keyword`.
 
-        See `api docs <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies>`__
+        See :discord-docs:`api docs <resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies>`
         for details about how keyword matching works.
 
     presets: Optional[:class:`AutoModKeywordPresets`]

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -152,7 +152,7 @@ class Embed:
     type: Optional[:class:`str`]
         The type of embed. Usually "rich".
         Possible strings for embed types can be found on Discord's
-        `api docs <https://discord.com/developers/docs/resources/channel#embed-object-embed-types>`__.
+        :discord-docs:`api-docs <resources/channel#embed-object-embed-types>`.
     description: Optional[:class:`str`]
         The description of the embed.
     url: Optional[:class:`str`]
@@ -240,7 +240,7 @@ class Embed:
         format that Discord expects it to be in.
 
         You can find out about this format in the
-        `official Discord documentation <https://discord.com/developers/docs/resources/channel#embed-object>`__.
+        :discord-docs:`official Discord documentation <resources/channel#embed-object>`.
 
         Parameters
         ----------

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -152,7 +152,7 @@ class Embed:
     type: Optional[:class:`str`]
         The type of embed. Usually "rich".
         Possible strings for embed types can be found on Discord's
-        :discord-docs:`api-docs <resources/channel#embed-object-embed-types>`.
+        :ddocs:`api-docs <resources/channel#embed-object-embed-types>`.
     description: Optional[:class:`str`]
         The description of the embed.
     url: Optional[:class:`str`]
@@ -240,7 +240,7 @@ class Embed:
         format that Discord expects it to be in.
 
         You can find out about this format in the
-        :discord-docs:`official Discord documentation <resources/channel#embed-object>`.
+        :ddocs:`official Discord documentation <resources/channel#embed-object>`.
 
         Parameters
         ----------

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4480,7 +4480,7 @@ class Guild(Hashable):
         You must have :attr:`.Permissions.manage_guild` permission to do this.
 
         The maximum number of rules for each trigger type is limited, see the
-        `api docs <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-limits-per-trigger-type>`__
+        :discord-docs:`api docs <resources/auto-moderation#auto-moderation-limits-per-trigger-type>`
         for more details.
 
         .. versionadded:: 2.6

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4480,7 +4480,7 @@ class Guild(Hashable):
         You must have :attr:`.Permissions.manage_guild` permission to do this.
 
         The maximum number of rules for each trigger type is limited, see the
-        :discord-docs:`api docs <resources/auto-moderation#auto-moderation-rule-object-trigger-types>`
+        :ddocs:`api docs <resources/auto-moderation#auto-moderation-rule-object-trigger-types>`
         for more details.
 
         .. versionadded:: 2.6

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4480,7 +4480,7 @@ class Guild(Hashable):
         You must have :attr:`.Permissions.manage_guild` permission to do this.
 
         The maximum number of rules for each trigger type is limited, see the
-        :discord-docs:`api docs <resources/auto-moderation#auto-moderation-limits-per-trigger-type>`
+        :discord-docs:`api docs <resources/auto-moderation#auto-moderation-rule-object-trigger-types>`
         for more details.
 
         .. versionadded:: 2.6

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -126,7 +126,7 @@ class RawMessageUpdateEvent(_RawReprMixin):
         .. versionadded:: 1.7
 
     data: :class:`dict`
-        The raw data given by the :discord-docs:`gateway <topics/gateway#message-update>`.
+        The raw data given by the :discord-docs:`gateway <topics/gateway-events#message-update>`.
     cached_message: Optional[:class:`Message`]
         The cached message, if found in the internal message cache. Represents the message before
         it is modified by the data in :attr:`RawMessageUpdateEvent.data`.

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -126,7 +126,7 @@ class RawMessageUpdateEvent(_RawReprMixin):
         .. versionadded:: 1.7
 
     data: :class:`dict`
-        The raw data given by the :discord-docs:`gateway <topics/gateway-events#message-update>`.
+        The raw data given by the :ddocs:`gateway <topics/gateway-events#message-update>`.
     cached_message: Optional[:class:`Message`]
         The cached message, if found in the internal message cache. Represents the message before
         it is modified by the data in :attr:`RawMessageUpdateEvent.data`.

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -126,7 +126,7 @@ class RawMessageUpdateEvent(_RawReprMixin):
         .. versionadded:: 1.7
 
     data: :class:`dict`
-        The raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_
+        The raw data given by the :discord-docs:`gateway <topics/gateway#message-update>`.
     cached_message: Optional[:class:`Message`]
         The cached message, if found in the internal message cache. Represents the message before
         it is modified by the data in :attr:`RawMessageUpdateEvent.data`.

--- a/disnake/types/activity.py
+++ b/disnake/types/activity.py
@@ -39,7 +39,7 @@ class ActivityParty(TypedDict, total=False):
 
 class ActivityAssets(TypedDict, total=False):
     # large_image/small_image may be a snowflake or prefixed media proxy ID, see:
-    # https://discord.com/developers/docs/topics/gateway#activity-object-activity-asset-image
+    # https://discord.com/developers/docs/topics/gateway-events#activity-object-activity-asset-image
     large_image: str
     large_text: str
     small_image: str

--- a/disnake/types/gateway.py
+++ b/disnake/types/gateway.py
@@ -249,7 +249,7 @@ class VoiceResumeCommand(TypedDict):
 # Gateway events
 #####
 
-# https://discord.com/developers/docs/topics/gateway#ready
+# https://discord.com/developers/docs/topics/gateway-events#ready
 class ReadyEvent(TypedDict):
     v: int
     user: User
@@ -260,32 +260,32 @@ class ReadyEvent(TypedDict):
     application: PartialGatewayAppInfo
 
 
-# https://discord.com/developers/docs/topics/gateway#resumed
+# https://discord.com/developers/docs/topics/gateway-events#resumed
 class ResumedEvent(TypedDict):
     ...
 
 
-# https://discord.com/developers/docs/topics/gateway#application-command-permissions-update
+# https://discord.com/developers/docs/topics/gateway-events#application-command-permissions-update
 ApplicationCommandPermissionsUpdateEvent = GuildApplicationCommandPermissions
 
 
-# https://discord.com/developers/docs/topics/gateway#message-create
+# https://discord.com/developers/docs/topics/gateway-events#message-create
 MessageCreateEvent = Message
 
 
-# https://discord.com/developers/docs/topics/gateway#message-update
+# https://discord.com/developers/docs/topics/gateway-events#message-update
 # This does not necessarily contain all message fields, but `id` and `channel_id` always exist
 MessageUpdateEvent = Message
 
 
-# https://discord.com/developers/docs/topics/gateway#message-delete
+# https://discord.com/developers/docs/topics/gateway-events#message-delete
 class MessageDeleteEvent(TypedDict):
     id: Snowflake
     channel_id: Snowflake
     guild_id: NotRequired[Snowflake]
 
 
-# https://discord.com/developers/docs/topics/gateway#message-delete-bulk
+# https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk
 class MessageDeleteBulkEvent(TypedDict):
     ids: List[Snowflake]
     channel_id: Snowflake
@@ -300,24 +300,24 @@ class _BaseReactionEvent(TypedDict):
     emoji: PartialEmoji
 
 
-# https://discord.com/developers/docs/topics/gateway#message-reaction-add
+# https://discord.com/developers/docs/topics/gateway-events#message-reaction-add
 class MessageReactionAddEvent(_BaseReactionEvent):
     member: NotRequired[MemberWithUser]
 
 
-# https://discord.com/developers/docs/topics/gateway#message-reaction-remove
+# https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove
 class MessageReactionRemoveEvent(_BaseReactionEvent):
     ...
 
 
-# https://discord.com/developers/docs/topics/gateway#message-reaction-remove-all
+# https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all
 class MessageReactionRemoveAllEvent(TypedDict):
     channel_id: Snowflake
     message_id: Snowflake
     guild_id: NotRequired[Snowflake]
 
 
-# https://discord.com/developers/docs/topics/gateway#message-reaction-remove-emoji
+# https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-emoji
 class MessageReactionRemoveEmojiEvent(TypedDict):
     channel_id: Snowflake
     guild_id: NotRequired[Snowflake]
@@ -325,19 +325,19 @@ class MessageReactionRemoveEmojiEvent(TypedDict):
     emoji: PartialEmoji
 
 
-# https://discord.com/developers/docs/topics/gateway#interaction-create
+# https://discord.com/developers/docs/topics/gateway-events#interaction-create
 InteractionCreateEvent = BaseInteraction
 
 
-# https://discord.com/developers/docs/topics/gateway#presence-update
+# https://discord.com/developers/docs/topics/gateway-events#presence-update
 PresenceUpdateEvent = PartialPresenceUpdate
 
 
-# https://discord.com/developers/docs/topics/gateway#user-update
+# https://discord.com/developers/docs/topics/gateway-events#user-update
 UserUpdateEvent = User
 
 
-# https://discord.com/developers/docs/topics/gateway#invite-create
+# https://discord.com/developers/docs/topics/gateway-events#invite-create
 class InviteCreateEvent(TypedDict):
     channel_id: Snowflake
     code: str
@@ -353,42 +353,42 @@ class InviteCreateEvent(TypedDict):
     uses: int  # always 0
 
 
-# https://discord.com/developers/docs/topics/gateway#invite-delete
+# https://discord.com/developers/docs/topics/gateway-events#invite-delete
 class InviteDeleteEvent(TypedDict):
     channel_id: Snowflake
     guild_id: NotRequired[Snowflake]
     code: str
 
 
-# https://discord.com/developers/docs/topics/gateway#channel-create
+# https://discord.com/developers/docs/topics/gateway-events#channel-create
 ChannelCreateEvent = GuildChannel
 
 
-# https://discord.com/developers/docs/topics/gateway#channel-update
+# https://discord.com/developers/docs/topics/gateway-events#channel-update
 ChannelUpdateEvent = Channel
 
 
-# https://discord.com/developers/docs/topics/gateway#channel-delete
+# https://discord.com/developers/docs/topics/gateway-events#channel-delete
 ChannelDeleteEvent = Channel
 
 
-# https://discord.com/developers/docs/topics/gateway#channel-pins-update
+# https://discord.com/developers/docs/topics/gateway-events#channel-pins-update
 class ChannelPinsUpdateEvent(TypedDict):
     guild_id: NotRequired[Snowflake]
     channel_id: Snowflake
     last_pin_timestamp: NotRequired[Optional[str]]
 
 
-# https://discord.com/developers/docs/topics/gateway#thread-create
+# https://discord.com/developers/docs/topics/gateway-events#thread-create
 class ThreadCreateEvent(Thread):
     newly_created: NotRequired[bool]
 
 
-# https://discord.com/developers/docs/topics/gateway#thread-update
+# https://discord.com/developers/docs/topics/gateway-events#thread-update
 ThreadUpdateEvent = Thread
 
 
-# https://discord.com/developers/docs/topics/gateway#thread-delete
+# https://discord.com/developers/docs/topics/gateway-events#thread-delete
 class ThreadDeleteEvent(TypedDict):
     id: Snowflake
     guild_id: Snowflake
@@ -396,7 +396,7 @@ class ThreadDeleteEvent(TypedDict):
     type: ThreadType
 
 
-# https://discord.com/developers/docs/topics/gateway#thread-list-sync
+# https://discord.com/developers/docs/topics/gateway-events#thread-list-sync
 class ThreadListSyncEvent(TypedDict):
     guild_id: Snowflake
     channel_ids: NotRequired[List[Snowflake]]
@@ -404,12 +404,12 @@ class ThreadListSyncEvent(TypedDict):
     members: List[ThreadMember]
 
 
-# https://discord.com/developers/docs/topics/gateway#thread-member-update
+# https://discord.com/developers/docs/topics/gateway-events#thread-member-update
 class ThreadMemberUpdateEvent(ThreadMember):
     guild_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#thread-members-update
+# https://discord.com/developers/docs/topics/gateway-events#thread-members-update
 class ThreadMembersUpdateEvent(TypedDict):
     id: Snowflake
     guild_id: Snowflake
@@ -418,18 +418,18 @@ class ThreadMembersUpdateEvent(TypedDict):
     removed_member_ids: NotRequired[List[Snowflake]]
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-member-add
+# https://discord.com/developers/docs/topics/gateway-events#guild-member-add
 class GuildMemberAddEvent(MemberWithUser):
     guild_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-member-remove
+# https://discord.com/developers/docs/topics/gateway-events#guild-member-remove
 class GuildMemberRemoveEvent(TypedDict):
     guild_id: Snowflake
     user: User
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-member-update
+# https://discord.com/developers/docs/topics/gateway-events#guild-member-update
 class GuildMemberUpdateEvent(TypedDict):
     guild_id: Snowflake
     roles: List[Snowflake]
@@ -444,27 +444,27 @@ class GuildMemberUpdateEvent(TypedDict):
     communication_disabled_until: NotRequired[Optional[str]]
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-emojis-update
+# https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update
 class GuildEmojisUpdateEvent(TypedDict):
     guild_id: Snowflake
     emojis: List[Emoji]
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-stickers-update
+# https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update
 class GuildStickersUpdateEvent(TypedDict):
     guild_id: Snowflake
     stickers: List[GuildSticker]
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-create
+# https://discord.com/developers/docs/topics/gateway-events#guild-create
 GuildCreateEvent = Union[Guild, UnavailableGuild]
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-update
+# https://discord.com/developers/docs/topics/gateway-events#guild-update
 GuildUpdateEvent = Guild
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-delete
+# https://discord.com/developers/docs/topics/gateway-events#guild-delete
 GuildDeleteEvent = UnavailableGuild
 
 
@@ -473,41 +473,41 @@ class _GuildBanEvent(TypedDict):
     user: User
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-ban-add
+# https://discord.com/developers/docs/topics/gateway-events#guild-ban-add
 GuildBanAddEvent = _GuildBanEvent
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-ban-remove
+# https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove
 GuildBanRemoveEvent = _GuildBanEvent
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-role-create
+# https://discord.com/developers/docs/topics/gateway-events#guild-role-create
 class GuildRoleCreateEvent(TypedDict):
     guild_id: Snowflake
     role: Role
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-role-delete
+# https://discord.com/developers/docs/topics/gateway-events#guild-role-delete
 class GuildRoleDeleteEvent(TypedDict):
     guild_id: Snowflake
     role_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-role-update
+# https://discord.com/developers/docs/topics/gateway-events#guild-role-update
 class GuildRoleUpdateEvent(TypedDict):
     guild_id: Snowflake
     role: Role
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-create
+# https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-create
 GuildScheduledEventCreateEvent = GuildScheduledEvent
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-update
+# https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-update
 GuildScheduledEventUpdateEvent = GuildScheduledEvent
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-delete
+# https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-delete
 GuildScheduledEventDeleteEvent = GuildScheduledEvent
 
 
@@ -517,15 +517,15 @@ class _GuildScheduledEventUserEvent(TypedDict):
     guild_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-add
+# https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add
 GuildScheduledEventUserAddEvent = _GuildScheduledEventUserEvent
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-scheduled-event-user-remove
+# https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove
 GuildScheduledEventUserRemoveEvent = _GuildScheduledEventUserEvent
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-members-chunk
+# https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
 class GuildMembersChunkEvent(TypedDict):
     guild_id: Snowflake
     members: List[MemberWithUser]
@@ -536,59 +536,59 @@ class GuildMembersChunkEvent(TypedDict):
     nonce: NotRequired[str]
 
 
-# https://discord.com/developers/docs/topics/gateway#guild-integrations-update
+# https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update
 class GuildIntegrationsUpdateEvent(TypedDict):
     guild_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#integration-create
+# https://discord.com/developers/docs/topics/gateway-events#integration-create
 class IntegrationCreateEvent(BaseIntegration):
     guild_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#integration-update
+# https://discord.com/developers/docs/topics/gateway-events#integration-update
 class IntegrationUpdateEvent(BaseIntegration):
     guild_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#integration-delete
+# https://discord.com/developers/docs/topics/gateway-events#integration-delete
 class IntegrationDeleteEvent(TypedDict):
     id: Snowflake
     guild_id: Snowflake
     application_id: NotRequired[Snowflake]
 
 
-# https://discord.com/developers/docs/topics/gateway#webhooks-update
+# https://discord.com/developers/docs/topics/gateway-events#webhooks-update
 class WebhooksUpdateEvent(TypedDict):
     guild_id: Snowflake
     channel_id: Snowflake
 
 
-# https://discord.com/developers/docs/topics/gateway#stage-instance-create
+# https://discord.com/developers/docs/topics/gateway-events#stage-instance-create
 StageInstanceCreateEvent = StageInstance
 
 
-# https://discord.com/developers/docs/topics/gateway#stage-instance-update
+# https://discord.com/developers/docs/topics/gateway-events#stage-instance-update
 StageInstanceUpdateEvent = StageInstance
 
 
-# https://discord.com/developers/docs/topics/gateway#stage-instance-delete
+# https://discord.com/developers/docs/topics/gateway-events#stage-instance-delete
 StageInstanceDeleteEvent = StageInstance
 
 
-# https://discord.com/developers/docs/topics/gateway#voice-state-update
+# https://discord.com/developers/docs/topics/gateway-events#voice-state-update
 # We assume that we'll only receive voice states for guilds
 VoiceStateUpdateEvent = GuildVoiceState
 
 
-# https://discord.com/developers/docs/topics/gateway#voice-server-update
+# https://discord.com/developers/docs/topics/gateway-events#voice-server-update
 class VoiceServerUpdateEvent(TypedDict):
     token: str
     guild_id: Snowflake
     endpoint: Optional[str]
 
 
-# https://discord.com/developers/docs/topics/gateway#typing-start
+# https://discord.com/developers/docs/topics/gateway-events#typing-start
 class TypingStartEvent(TypedDict):
     channel_id: Snowflake
     guild_id: NotRequired[Snowflake]
@@ -597,19 +597,19 @@ class TypingStartEvent(TypedDict):
     member: NotRequired[MemberWithUser]
 
 
-# https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-create
+# https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-create
 AutoModerationRuleCreateEvent = AutoModRule
 
 
-# https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-update
+# https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-update
 AutoModerationRuleUpdateEvent = AutoModRule
 
 
-# https://discord.com/developers/docs/topics/gateway#auto-moderation-rule-delete
+# https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-delete
 AutoModerationRuleDeleteEvent = AutoModRule
 
 
-# https://discord.com/developers/docs/topics/gateway#auto-moderation-action-execution
+# https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution
 class AutoModerationActionExecutionEvent(TypedDict):
     guild_id: Snowflake
     action: AutoModAction

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -95,7 +95,7 @@ class VoiceProtocol:
         Parameters
         ----------
         data: :class:`dict`
-            The raw :discord-docs:`voice state payload <resources/voice#voice-state-object>`.
+            The raw :ddocs:`voice state payload <resources/voice#voice-state-object>`.
         """
         raise NotImplementedError
 
@@ -108,7 +108,7 @@ class VoiceProtocol:
         Parameters
         ----------
         data: :class:`dict`
-            The raw :discord-docs:`voice server update payload <topics/gateway-events#voice-server-update>`.
+            The raw :ddocs:`voice server update payload <topics/gateway-events#voice-server-update>`.
         """
         raise NotImplementedError
 

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -95,11 +95,7 @@ class VoiceProtocol:
         Parameters
         ----------
         data: :class:`dict`
-            The raw `voice state payload`__.
-
-            .. _voice_state_update_payload: https://discord.com/developers/docs/resources/voice#voice-state-object
-
-            __ voice_state_update_payload_
+            The raw :discord-docs:`voice state payload <resources/voice#voice-state-object>`.
         """
         raise NotImplementedError
 
@@ -112,11 +108,7 @@ class VoiceProtocol:
         Parameters
         ----------
         data: :class:`dict`
-            The raw `voice server update payload`__.
-
-            .. _voice_server_update_payload: https://discord.com/developers/docs/topics/gateway#voice-server-update-voice-server-update-event-fields
-
-            __ voice_server_update_payload_
+            The raw :discord-docs:`voice server update payload <topics/gateway#voice-server-update-voice-server-update-event-fields>`.
         """
         raise NotImplementedError
 

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -108,7 +108,7 @@ class VoiceProtocol:
         Parameters
         ----------
         data: :class:`dict`
-            The raw :discord-docs:`voice server update payload <topics/gateway#voice-server-update-voice-server-update-event-fields>`.
+            The raw :discord-docs:`voice server update payload <topics/gateway-events#voice-server-update>`.
         """
         raise NotImplementedError
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1345,7 +1345,7 @@ This section documents events related to Discord chat messages.
     will return a :class:`Message` object that represents the message before the content was modified.
 
     Due to the inherently raw nature of this event, the data parameter coincides with
-    the raw data given by the :discord-docs:`gateway <topics/gateway-events#message-update>`.
+    the raw data given by the :ddocs:`gateway <topics/gateway-events#message-update>`.
 
     Since the data payload can be partial, care must be taken when accessing stuff in the dictionary.
     One example of a common case of partial data is when the ``'content'`` key is inaccessible. This

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1345,7 +1345,7 @@ This section documents events related to Discord chat messages.
     will return a :class:`Message` object that represents the message before the content was modified.
 
     Due to the inherently raw nature of this event, the data parameter coincides with
-    the raw data given by the `gateway <https://discord.com/developers/docs/topics/gateway#message-update>`_.
+    the raw data given by the :discord-docs:`gateway <topics/gateway#message-update>`.
 
     Since the data payload can be partial, care must be taken when accessing stuff in the dictionary.
     One example of a common case of partial data is when the ``'content'`` key is inaccessible. This

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1345,7 +1345,7 @@ This section documents events related to Discord chat messages.
     will return a :class:`Message` object that represents the message before the content was modified.
 
     Due to the inherently raw nature of this event, the data parameter coincides with
-    the raw data given by the :discord-docs:`gateway <topics/gateway#message-update>`.
+    the raw data given by the :discord-docs:`gateway <topics/gateway-events#message-update>`.
 
     Since the data payload can be partial, care must be taken when accessing stuff in the dictionary.
     One example of a common case of partial data is when the ``'content'`` key is inaccessible. This

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ dpy_github_repo = "https://github.com/Rapptz/discord.py"
 extlinks = {
     "issue": (f"{github_repo}/issues/%s", "#%s"),
     "issue-dpy": (f"{dpy_github_repo}/issues/%s", "#%s"),
+    "discord-docs": ("https://discord.com/developers/docs/%s", None),
 }
 
 extlinks_detect_hardcoded_links = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,6 +236,12 @@ if os.environ.get("READTHEDOCS"):
     hoverxref_api_host = "/_"
 
 
+linkcheck_ignore = [
+    r"https?://github.com/.+?/.+?/(issues|pull)/\d+",
+    r"https?://support.discord.com/",
+]
+
+
 # -- Options for HTML output ----------------------------------------------
 
 html_experimental_html5_writer = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ dpy_github_repo = "https://github.com/Rapptz/discord.py"
 extlinks = {
     "issue": (f"{github_repo}/issues/%s", "#%s"),
     "issue-dpy": (f"{dpy_github_repo}/issues/%s", "#%s"),
-    "discord-docs": ("https://discord.com/developers/docs/%s", None),
+    "ddocs": ("https://discord.com/developers/docs/%s", None),
 }
 
 extlinks_detect_hardcoded_links = True


### PR DESCRIPTION
## Summary

Adds a `:ddocs:` role for easily linking to `https://discord.com/developers/docs/*`, and fixes a couple invalid links that are a result of api docs changes.

Also adds a `linkcheck_ignore` config for running the linkcheck builder without making unnecessary requests. This is meant to be run manually and hence I didn't integrate linkcheck into the ci workflow, mainly because (1) there really isn't a point in doing this every time, and (2) checking fragments/anchors for api docs isn't possible since the entire page is generated dynamically.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
