### PR TITLE
feat: support regex automod

### DIFF
--- a/changelog/794.feature.rst
+++ b/changelog/794.feature.rst
@@ -1,0 +1,1 @@
+Support regex within automod. Adds :attr:`AutoModTriggerMetadata.regex_patterns`

--- a/changelog/794.feature.rst
+++ b/changelog/794.feature.rst
@@ -1,1 +1,1 @@
-Support regex within automod. Adds :attr:`AutoModTriggerMetadata.regex_patterns`
+Support regex within automod using :attr:`AutoModTriggerMetadata.regex_patterns`.

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -643,6 +643,11 @@ class AutoModActionExecution:
 
     matched_keyword: Optional[:class:`str`]
         The keyword that matched.
+
+        .. note::
+
+            If this rule matched because of a regex, this will contain the matching regex.
+
     matched_content: Optional[:class:`str`]
         The substring of :attr:`.content` that matched the rule/keyword.
 

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -224,7 +224,7 @@ class AutoModTriggerMetadata:
         for details about how keyword matching works.
 
     regex_patterns: Optional[Sequence[:class:`str`]]
-        The list of keywords to check for. Used with :attr:`AutoModTriggerType.keyword`.
+        The list of regular expressions to check for. Used with :attr:`AutoModTriggerType.keyword`.
 
         A maximum of 10 regexes can be added.
 
@@ -253,15 +253,15 @@ class AutoModTriggerMetadata:
     )
 
     @overload
-    def __init__(self, *, keyword_filter: Sequence[str]) -> None:
+    def __init__(
+        self, *, keyword_filter: Sequence[str], regex_patterns: Sequence[str] = ...
+    ) -> None:
         ...
 
     @overload
-    def __init__(self, *, regex_patterns: Sequence[str]):
-        ...
-
-    @overload
-    def __init__(self, *, keyword_filter: Sequence[str], regex_patterns: Sequence[str]):
+    def __init__(
+        self, *, keyword_filter: Sequence[str] = ..., regex_patterns: Sequence[str]
+    ) -> None:
         ...
 
     @overload
@@ -287,7 +287,7 @@ class AutoModTriggerMetadata:
         mention_total_limit: Optional[int] = None,
     ) -> None:
         self.keyword_filter: Optional[Sequence[str]] = keyword_filter
-        self.regex_patterns: Optional[Sequence[str]] = keyword_filter
+        self.regex_patterns: Optional[Sequence[str]] = regex_patterns
         self.presets: Optional[AutoModKeywordPresets] = presets
         self.allow_list: Optional[Sequence[str]] = allow_list
         self.mention_total_limit: Optional[int] = mention_total_limit

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -223,6 +223,17 @@ class AutoModTriggerMetadata:
         See :ddocs:`api docs <resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies>`
         for details about how keyword matching works.
 
+    regex_patterns: Optional[Sequence[:class:`str`]]
+        The list of keywords to check for. Used with :attr:`AutoModTriggerType.keyword`.
+
+        A maximum of 10 regexes can be added.
+
+        .. note::
+
+            Only Rust flavored regex is currently supported, which can be tested in online editors such as `Rustexp <https://rustexp.lpil.uk/>`__.
+
+        .. versionadded:: 2.7
+
     presets: Optional[:class:`AutoModKeywordPresets`]
         The keyword presets. Used with :attr:`AutoModTriggerType.keyword_preset`.
 
@@ -235,6 +246,7 @@ class AutoModTriggerMetadata:
 
     __slots__ = (
         "keyword_filter",
+        "regex_patterns",
         "presets",
         "allow_list",
         "mention_total_limit",
@@ -242,6 +254,14 @@ class AutoModTriggerMetadata:
 
     @overload
     def __init__(self, *, keyword_filter: Sequence[str]) -> None:
+        ...
+
+    @overload
+    def __init__(self, *, regex_patterns: Sequence[str]):
+        ...
+
+    @overload
+    def __init__(self, *, keyword_filter: Sequence[str], regex_patterns: Sequence[str]):
         ...
 
     @overload
@@ -261,11 +281,13 @@ class AutoModTriggerMetadata:
         self,
         *,
         keyword_filter: Optional[Sequence[str]] = None,
+        regex_patterns: Optional[Sequence[str]] = None,
         presets: Optional[AutoModKeywordPresets] = None,
         allow_list: Optional[Sequence[str]] = None,
         mention_total_limit: Optional[int] = None,
     ) -> None:
         self.keyword_filter: Optional[Sequence[str]] = keyword_filter
+        self.regex_patterns: Optional[Sequence[str]] = keyword_filter
         self.presets: Optional[AutoModKeywordPresets] = presets
         self.allow_list: Optional[Sequence[str]] = allow_list
         self.mention_total_limit: Optional[int] = mention_total_limit
@@ -274,6 +296,7 @@ class AutoModTriggerMetadata:
         self,
         *,
         keyword_filter: Optional[Sequence[str]] = MISSING,
+        regex_patterns: Optional[Sequence[str]] = MISSING,
         presets: Optional[AutoModKeywordPresets] = MISSING,
         allow_list: Optional[Sequence[str]] = MISSING,
         mention_total_limit: Optional[int] = MISSING,
@@ -289,6 +312,7 @@ class AutoModTriggerMetadata:
         """
         return self.__class__(  # type: ignore  # call doesn't match any overloads
             keyword_filter=self.keyword_filter if keyword_filter is MISSING else keyword_filter,
+            regex_patterns=self.regex_patterns if regex_patterns is MISSING else regex_patterns,
             presets=self.presets if presets is MISSING else presets,
             allow_list=self.allow_list if allow_list is MISSING else allow_list,
             mention_total_limit=(
@@ -305,6 +329,7 @@ class AutoModTriggerMetadata:
 
         return cls(  # type: ignore  # call doesn't match any overloads
             keyword_filter=data.get("keyword_filter"),
+            regex_patterns=data.get("regex_patterns"),
             presets=presets,
             allow_list=data.get("allow_list"),
             mention_total_limit=data.get("mention_total_limit"),
@@ -314,6 +339,8 @@ class AutoModTriggerMetadata:
         data: AutoModTriggerMetadataPayload = {}
         if self.keyword_filter is not None:
             data["keyword_filter"] = list(self.keyword_filter)
+        if self.regex_patterns is not None:
+            data["regex_patterns"] = list(self.regex_patterns)
         if self.presets is not None:
             data["presets"] = self.presets.values  # type: ignore  # `values` contains ints instead of preset literal values
         if self.allow_list is not None:
@@ -326,6 +353,8 @@ class AutoModTriggerMetadata:
         s = f"<{type(self).__name__}"
         if self.keyword_filter is not None:
             s += f" keyword_filter={self.keyword_filter!r}"
+        if self.regex_patterns is not None:
+            s += f" regex_patterns={self.regex_patterns!r}"
         if self.presets is not None:
             s += f" presets={self.presets!r}"
         if self.allow_list is not None:

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -222,11 +222,12 @@ class AutoModTriggerMetadata:
 
         See :ddocs:`api docs <resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies>`
         for details about how keyword matching works.
+        Each keyword must be 30 characters or less.
 
     regex_patterns: Optional[Sequence[:class:`str`]]
         The list of regular expressions to check for. Used with :attr:`AutoModTriggerType.keyword`.
 
-        A maximum of 10 regexes can be added.
+        A maximum of 10 regexes can be added, each with up to 75 characters.
 
         .. note::
 

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -642,11 +642,7 @@ class AutoModActionExecution:
         otherwise this field will be empty.
 
     matched_keyword: Optional[:class:`str`]
-        The keyword that matched.
-
-        .. note::
-
-            If this rule matched because of a regex, this will contain the matching regex.
+        The keyword or regex that matched.
 
     matched_content: Optional[:class:`str`]
         The substring of :attr:`.content` that matched the rule/keyword.

--- a/disnake/types/automod.py
+++ b/disnake/types/automod.py
@@ -40,6 +40,7 @@ class AutoModAction(TypedDict):
 
 class AutoModTriggerMetadata(TypedDict, total=False):
     keyword_filter: List[str]
+    regex_patterns: List[str]
     presets: List[AutoModPresetType]
     allow_list: List[str]
     mention_total_limit: int


### PR DESCRIPTION
## Summary

implements https://github.com/discord/discord-api-docs/pull/5504

This has been tested in a private server.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
