### PR TITLE
docs: custom 404 page

### DIFF
--- a/changelog/797.doc.rst
+++ b/changelog/797.doc.rst
@@ -1,0 +1,1 @@
+Added a custom 404 page for when the navigated page does not exist.

--- a/changelog/797.doc.rst
+++ b/changelog/797.doc.rst
@@ -1,1 +1,1 @@
-Added a custom 404 page for when the navigated page does not exist.
+Add a custom 404 page for when the navigated page does not exist.

--- a/docs/404.rst
+++ b/docs/404.rst
@@ -1,0 +1,30 @@
+.. SPDX-License-Identifier: MIT
+
+:orphan:
+
+Page Not Found
+--------------
+
+
+We could not find what you were looking for.
+
+
+You might find what you're looking for in one of the below pages:
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    Index <index>
+    API Reference <api>
+    Search <search>
+    Changelog <whats_new>
+
+Extensions:
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    ext/commands/index.rst
+    ext/tasks/index.rst

--- a/docs/404.rst
+++ b/docs/404.rst
@@ -5,26 +5,6 @@
 Page Not Found
 --------------
 
+Sorry, we couldn't find that page.
 
-We could not find what you were looking for.
-
-
-You might find what you're looking for in one of the below pages:
-
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-
-    Index <index>
-    API Reference <api>
-    Search <search>
-    Changelog <whats_new>
-
-Extensions:
-
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-
-    ext/commands/index.rst
-    ext/tasks/index.rst
+Try using the search box or go to the homepage.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,11 +46,11 @@ extensions = [
     "sphinxcontrib_trio",
     "sphinxcontrib.towncrier.ext",
     "hoverxref.extension",
+    "notfound.extension",
     "exception_hierarchy",
     "attributetable",
     "resourcelinks",
     "nitpick_file_ignorer",
-    "notfound.extension",
 ]
 
 autodoc_member_order = "bysource"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,6 +236,8 @@ hoverxref_tooltip_theme = ["tooltipster-custom"]
 # use proxied API endpoint on rtd to avoid CORS issues
 if os.environ.get("READTHEDOCS"):
     hoverxref_api_host = "/_"
+else:
+    notfound_urls_prefix = ""
 
 
 linkcheck_ignore = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "attributetable",
     "resourcelinks",
     "nitpick_file_ignorer",
+    "notfound.extension",
 ]
 
 autodoc_member_order = "bysource"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,9 +236,11 @@ hoverxref_tooltip_theme = ["tooltipster-custom"]
 # use proxied API endpoint on rtd to avoid CORS issues
 if os.environ.get("READTHEDOCS"):
     hoverxref_api_host = "/_"
-else:
-    notfound_urls_prefix = ""
 
+# when not on read the docs, assume no prefix for the 404 page.
+# this means that /404.html should properly render on local builds
+if not os.environ.get("READTHEDOCS"):
+    notfound_urls_prefix = "/"
 
 linkcheck_ignore = [
     r"https?://github.com/.+?/.+?/(issues|pull)/\d+",

--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -5,3 +5,4 @@ sphinx-hoverxref==1.1.3
 sphinx-autobuild~=2021.3
 sphinxcontrib-towncrier==0.3.0a0
 towncrier==22.8.0
+sphinx-notfound-page==0.8.3


### PR DESCRIPTION
## Summary

adds a custom 404 page to the documentation

## Checklist
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
