### PR TITLE
typing: misc internal component typing changes

### DIFF
--- a/disnake/components.py
+++ b/disnake/components.py
@@ -146,7 +146,7 @@ class Button(Component):
 
     .. note::
 
-        The user constructible and usable type to create a button is :class:`disnake.ui.Button`
+        The user constructible and usable type to create a button is :class:`disnake.ui.Button`,
         not this one.
 
     .. versionadded:: 2.0

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -19,7 +19,7 @@ from typing import (
 
 from .enums import ButtonStyle, ComponentType, TextInputStyle, try_enum
 from .partial_emoji import PartialEmoji, _EmojiTag
-from .utils import MISSING, get_slots
+from .utils import MISSING, assert_never, get_slots
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
         SelectOption as SelectOptionPayload,
         TextInput as TextInputPayload,
     )
-    from .utils import assert_never
 
 __all__ = (
     "Component",
@@ -520,7 +519,6 @@ def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> 
     elif component_type == 4:
         return TextInput(data)  # type: ignore
     else:
-        if TYPE_CHECKING:
-            assert_never(component_type)
+        assert_never(component_type)
         as_enum = try_enum(ComponentType, component_type)
         return Component._raw_construct(type=as_enum)  # type: ignore

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         SelectOption as SelectOptionPayload,
         TextInput as TextInputPayload,
     )
+    from .utils import assert_never
 
 __all__ = (
     "Component",
@@ -519,5 +520,7 @@ def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> 
     elif component_type == 4:
         return TextInput(data)  # type: ignore
     else:
+        if TYPE_CHECKING:
+            assert_never(component_type)
         as_enum = try_enum(ComponentType, component_type)
         return Component._raw_construct(type=as_enum)  # type: ignore

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -26,7 +26,7 @@ from ..components import (
     SelectMenu as SelectComponent,
 )
 from ..enums import ButtonStyle, ComponentType, TextInputStyle
-from ..utils import MISSING, SequenceProxy
+from ..utils import MISSING, SequenceProxy, assert_never
 from .button import Button
 from .item import WrappedComponent
 from .select import Select
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from ..message import Message
     from ..partial_emoji import PartialEmoji
     from ..types.components import ActionRow as ActionRowPayload
-    from ..utils import assert_never
 
 __all__ = (
     "ActionRow",
@@ -551,8 +550,7 @@ class ActionRow(Generic[UIComponentT]):
                 elif isinstance(component, SelectComponent):
                     current_row.append_item(Select.from_component(component))
                 else:
-                    if TYPE_CHECKING:
-                        assert_never(component)
+                    assert_never(component)
                     if strict:
                         raise TypeError(f"Encountered unknown component type: {component.type!r}.")
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from ..message import Message
     from ..partial_emoji import PartialEmoji
     from ..types.components import ActionRow as ActionRowPayload
+    from ..utils import assert_never
 
 __all__ = (
     "ActionRow",
@@ -549,8 +550,11 @@ class ActionRow(Generic[UIComponentT]):
                     current_row.append_item(Button.from_component(component))
                 elif isinstance(component, SelectComponent):
                     current_row.append_item(Select.from_component(component))
-                elif strict:
-                    raise TypeError(f"Encountered unknown component type: {component.type!r}.")
+                else:
+                    if TYPE_CHECKING:
+                        assert_never(component)
+                    if strict:
+                        raise TypeError(f"Encountered unknown component type: {component.type!r}.")
 
         return rows
 

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -280,8 +280,8 @@ def button(
     """A decorator that attaches a button to a component.
 
     The function being decorated should have three parameters, ``self`` representing
-    the :class:`disnake.ui.View`, the :class:`disnake.ui.Button` being pressed and
-    the :class:`disnake.MessageInteraction` you receive.
+    the :class:`disnake.ui.View`, the :class:`disnake.ui.Button` that was
+    interacted with, and the :class:`disnake.MessageInteraction`.
 
     .. note::
 

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -267,8 +267,8 @@ def select(
     """A decorator that attaches a string select menu to a component.
 
     The function being decorated should have three parameters, ``self`` representing
-    the :class:`disnake.ui.View`, the :class:`disnake.ui.Select` being pressed and
-    the :class:`disnake.MessageInteraction` you receive.
+    the :class:`disnake.ui.View`, the :class:`disnake.ui.Select` that was
+    interacted with, and the :class:`disnake.MessageInteraction`.
 
     In order to get the selected items that the user has chosen within the callback
     use :attr:`Select.values`.

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -25,7 +25,6 @@ from ..components import (
     ActionRow as ActionRowComponent,
     Button as ButtonComponent,
     MessageComponent,
-    NestedComponent,
     SelectMenu as SelectComponent,
     _component_factory,
 )
@@ -47,12 +46,12 @@ if TYPE_CHECKING:
 
 def _walk_all_components(
     components: List[ActionRowComponent[MessageComponent]],
-) -> Iterator[NestedComponent]:
+) -> Iterator[MessageComponent]:
     for item in components:
         yield from item.children
 
 
-def _component_to_item(component: NestedComponent) -> Item:
+def _component_to_item(component: MessageComponent) -> Item:
     if isinstance(component, ButtonComponent):
         from .button import Button
 

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -29,6 +29,7 @@ from ..components import (
     _component_factory,
 )
 from ..enums import ComponentType, try_enum_to_int
+from ..utils import assert_never
 from .item import Item
 
 __all__ = ("View",)
@@ -41,7 +42,6 @@ if TYPE_CHECKING:
     from ..message import Message
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
-    from ..utils import assert_never
     from .item import ItemCallbackType
 
 
@@ -61,8 +61,8 @@ def _component_to_item(component: MessageComponent) -> Item:
         from .select import Select
 
         return Select.from_component(component)
-    if TYPE_CHECKING:
-        assert_never(component)
+
+    assert_never(component)
     return Item.from_component(component)
 
 

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from ..message import Message
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
+    from ..utils import assert_never
     from .item import ItemCallbackType
 
 
@@ -60,6 +61,8 @@ def _component_to_item(component: MessageComponent) -> Item:
         from .select import Select
 
         return Select.from_component(component)
+    if TYPE_CHECKING:
+        assert_never(component)
     return Item.from_component(component)
 
 

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -108,7 +108,7 @@ class _cached_property:
 if TYPE_CHECKING:
     from functools import cached_property as cached_property
 
-    from typing_extensions import ParamSpec, Self
+    from typing_extensions import Never, ParamSpec, Self
 
     from .abc import Snowflake
     from .asset import AssetBytes
@@ -1369,3 +1369,9 @@ def _overload_with_permissions(func: T) -> T:
 # this is used as a marker for functions or classes that were created by codemodding
 def _generated(func: T) -> T:
     return func
+
+
+# Similar to typing.assert_never, but returns instead of raising.
+# This is only to avoid "unreachable code", which pyright doesn't type-check.
+def assert_never(arg: Never, /) -> None:
+    pass

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1371,7 +1371,7 @@ def _generated(func: T) -> T:
     return func
 
 
-# Similar to typing.assert_never, but returns instead of raising.
+# Similar to typing.assert_never, but returns instead of raising (i.e. has no runtime effect).
 # This is only to avoid "unreachable code", which pyright doesn't type-check.
 def assert_never(arg: Never, /) -> None:
     pass

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1359,6 +1359,12 @@ def humanize_list(values: List[str], combine: str) -> str:
         return f" {combine} ".join(values)
 
 
+# Similar to typing.assert_never, but returns instead of raising (i.e. has no runtime effect).
+# This is only to avoid "unreachable code", which pyright doesn't type-check.
+def assert_never(arg: Never, /) -> None:
+    pass
+
+
 # n.b. This must be imported and used as @ _overload_with_permissions (without the space)
 # this is used by the libcst parser and has no runtime purpose
 # it is merely a marker not unlike pytest.mark
@@ -1369,9 +1375,3 @@ def _overload_with_permissions(func: T) -> T:
 # this is used as a marker for functions or classes that were created by codemodding
 def _generated(func: T) -> T:
     return func
-
-
-# Similar to typing.assert_never, but returns instead of raising (i.e. has no runtime effect).
-# This is only to avoid "unreachable code", which pyright doesn't type-check.
-def assert_never(arg: Never, /) -> None:
-    pass


### PR DESCRIPTION
## Summary

Some minor internal typing and documentation changes, like adding a couple `assert_never`s in component factory methods.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
