### PR TITLE
feat: implement new select menu components

### DIFF
--- a/changelog/800.feature.rst
+++ b/changelog/800.feature.rst
@@ -1,1 +1,1 @@
-Separate select menu types (:class:`SelectMenu`, :class:`ui.Select`) into base types (:class:`BaseSelectMenu`, :class:`ui.BaseSelect`).
+TODO: replace with contents of main changelog entry

--- a/changelog/800.feature.rst
+++ b/changelog/800.feature.rst
@@ -1,1 +1,12 @@
-TODO: replace with contents of main changelog entry
+Add new select menu components.
+- Add new :class:`ComponentType` values.
+- Add :class:`UserSelectMenu`, :class:`RoleSelectMenu`, :class:`MentionableSelectMenu`, :class:`ChannelSelectMenu` components.
+- Add :class:`ui.UserSelect`, :class:`ui.RoleSelect`, :class:`ui.MentionableSelect`, :class:`ui.ChannelSelect` UI types.
+- Add :func:`ui.user_select`, :func:`ui.role_select`, :func:`ui.mentionable_select`, :func:`ui.channel_select` decorators.
+- Add :func:`ui.ActionRow.add_user_select`, :func:`add_role_select() <ui.ActionRow.add_role_select>`, :func:`add_mentionable_select() <ui.ActionRow.add_mentionable_select>`, :func:`add_channel_select() <ui.ActionRow.add_channel_select>`
+- Renamed string select types for clarity (previous names will continue to work):
+    - :class:`SelectMenu` -> :class:`StringSelectMenu`
+    - :class:`ui.Select` -> :class:`ui.StringSelect`
+    - :func:`ui.select` -> :func:`ui.string_select`
+    - :func:`ui.ActionRow.add_select` -> :func:`ui.ActionRow.add_string_select`
+- Add :attr:`MessageInteraction.resolved_values` and :attr:`MessageInteractionData.resolved`.

--- a/changelog/803.feature.rst
+++ b/changelog/803.feature.rst
@@ -1,0 +1,3 @@
+Add new select menu components.
+
+TODO: more text c:

--- a/changelog/803.feature.rst
+++ b/changelog/803.feature.rst
@@ -1,3 +1,12 @@
 Add new select menu components.
-
-TODO: more text c:
+- Add new :class:`ComponentType` values.
+- Add :class:`UserSelectMenu`, :class:`RoleSelectMenu`, :class:`MentionableSelectMenu`, :class:`ChannelSelectMenu` components.
+- Add :class:`ui.UserSelect`, :class:`ui.RoleSelect`, :class:`ui.MentionableSelect`, :class:`ui.ChannelSelect` UI types.
+- Add :func:`ui.user_select`, :func:`ui.role_select`, :func:`ui.mentionable_select`, :func:`ui.channel_select` decorators.
+- Add :func:`ui.ActionRow.add_user_select`, :func:`add_role_select() <ui.ActionRow.add_role_select>`, :func:`add_mentionable_select() <ui.ActionRow.add_mentionable_select>`, :func:`add_channel_select() <ui.ActionRow.add_channel_select>`
+- Renamed string select types for clarity (previous names will continue to work):
+    - :class:`SelectMenu` -> :class:`StringSelectMenu`
+    - :class:`ui.Select` -> :class:`ui.StringSelect`
+    - :func:`ui.select` -> :func:`ui.string_select`
+    - :func:`ui.ActionRow.add_select` -> :func:`ui.ActionRow.add_string_select`
+- Add :attr:`MessageInteraction.resolved_values` and :attr:`MessageInteractionData.resolved`.

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -45,6 +45,7 @@ __all__ = (
     "Button",
     "BaseSelectMenu",
     "StringSelectMenu",
+    "SelectMenu",
     "UserSelectMenu",
     "RoleSelectMenu",
     "MentionableSelectMenu",
@@ -295,7 +296,6 @@ class BaseSelectMenu(Component):
         return payload
 
 
-# TODO: make all string-select-menu-related changes backwards-compatible
 class StringSelectMenu(BaseSelectMenu):
     """Represents a string select menu from the Discord Bot UI Kit.
 
@@ -340,6 +340,9 @@ class StringSelectMenu(BaseSelectMenu):
         payload = cast("StringSelectMenuPayload", super().to_dict())
         payload["options"] = [op.to_dict() for op in self.options]
         return payload
+
+
+SelectMenu = StringSelectMenu  # backwards compatibility
 
 
 class UserSelectMenu(BaseSelectMenu):

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -458,15 +458,15 @@ class ChannelSelectMenu(BaseSelectMenu):
 
     def __init__(self, data: ChannelSelectMenuPayload):
         super().__init__(data)
-        # TODO: check api typing (missing/none/empty list)
+        # on the API side, an empty list is (currently) equivalent to no value
         channel_types = data.get("channel_types")
         self.channel_types: Optional[List[ChannelType]] = (
-            [try_enum(ChannelType, t) for t in channel_types] if channel_types is not None else None
+            [try_enum(ChannelType, t) for t in channel_types] if channel_types else None
         )
 
     def to_dict(self) -> ChannelSelectMenuPayload:
         payload = cast("ChannelSelectMenuPayload", super().to_dict())
-        if self.channel_types is not None:
+        if self.channel_types:
             payload["channel_types"] = [t.value for t in self.channel_types]
         return payload
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -295,6 +295,7 @@ class BaseSelectMenu(Component):
         return payload
 
 
+# TODO: make all string-select-menu-related changes backwards-compatible
 class StringSelectMenu(BaseSelectMenu):
     """Represents a string select menu from the Discord Bot UI Kit.
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -281,7 +281,7 @@ class StringSelectMenu(BaseSelectMenu):
 
     .. note::
         The user constructible and usable type to create a
-        string select menu is :class:`disnake.ui.Select`.
+        string select menu is :class:`disnake.ui.StringSelect`.
 
     .. versionadded:: 2.0
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
         BaseSelectMenu as BaseSelectMenuPayload,
         ButtonComponent as ButtonComponentPayload,
         Component as ComponentPayload,
-        SelectMenu as SelectMenuPayload,
         SelectOption as SelectOptionPayload,
+        StringSelectMenu as StringSelectMenuPayload,
         TextInput as TextInputPayload,
     )
 
@@ -307,14 +307,14 @@ class SelectMenu(BaseSelectMenu):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = BaseSelectMenu.__repr_info__ + __slots__
 
-    def __init__(self, data: SelectMenuPayload):
+    def __init__(self, data: StringSelectMenuPayload):
         super().__init__(data)
         self.options: List[SelectOption] = [
             SelectOption.from_dict(option) for option in data.get("options", [])
         ]
 
-    def to_dict(self) -> SelectMenuPayload:
-        payload = cast("SelectMenuPayload", super().to_dict())
+    def to_dict(self) -> StringSelectMenuPayload:
+        payload = cast("StringSelectMenuPayload", super().to_dict())
         payload["options"] = [op.to_dict() for op in self.options]
         return payload
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -17,7 +17,7 @@ from typing import (
     cast,
 )
 
-from .enums import ButtonStyle, ComponentType, TextInputStyle, try_enum
+from .enums import ButtonStyle, ChannelType, ComponentType, TextInputStyle, try_enum
 from .partial_emoji import PartialEmoji, _EmojiTag
 from .utils import MISSING, assert_never, get_slots
 
@@ -29,10 +29,14 @@ if TYPE_CHECKING:
         ActionRow as ActionRowPayload,
         BaseSelectMenu as BaseSelectMenuPayload,
         ButtonComponent as ButtonComponentPayload,
+        ChannelSelectMenu as ChannelSelectMenuPayload,
         Component as ComponentPayload,
+        MentionableSelectMenu as MentionableSelectMenuPayload,
+        RoleSelectMenu as RoleSelectMenuPayload,
         SelectOption as SelectOptionPayload,
         StringSelectMenu as StringSelectMenuPayload,
         TextInput as TextInputPayload,
+        UserSelectMenu as UserSelectMenuPayload,
     )
 
 __all__ = (
@@ -41,20 +45,31 @@ __all__ = (
     "Button",
     "BaseSelectMenu",
     "StringSelectMenu",
+    "UserSelectMenu",
+    "RoleSelectMenu",
+    "MentionableSelectMenu",
+    "ChannelSelectMenu",
     "SelectOption",
     "TextInput",
 )
 
 C = TypeVar("C", bound="Component")
 
+AnySelectMenu = Union[
+    "StringSelectMenu",
+    "UserSelectMenu",
+    "RoleSelectMenu",
+    "MentionableSelectMenu",
+    "ChannelSelectMenu",
+]
+MessageComponent = Union["Button", "AnySelectMenu"]
+
 if TYPE_CHECKING:  # TODO: remove when we add modal select support
     from typing_extensions import TypeAlias
 
-AnySelectMenu: TypeAlias = "StringSelectMenu"
-MessageComponent = Union["Button", "AnySelectMenu"]
-
 # ModalComponent = Union["TextInput", "AnySelectMenu"]
 ModalComponent: TypeAlias = "TextInput"
+
 NestedComponent = Union[MessageComponent, ModalComponent]
 ComponentT = TypeVar("ComponentT", bound=NestedComponent)
 
@@ -66,7 +81,7 @@ class Component:
 
     - :class:`ActionRow`
     - :class:`Button`
-    - subtypes of :class:`BaseSelectMenu` (:class:`StringSelectMenu`, ...)
+    - subtypes of :class:`BaseSelectMenu` (:class:`StringSelectMenu`, :class:`UserSelectMenu`, :class:`RoleSelectMenu`, :class:`MentionableSelectMenu`, :class:`ChannelSelectMenu`)
     - :class:`TextInput`
 
     This class is abstract and cannot be instantiated.
@@ -222,6 +237,10 @@ class BaseSelectMenu(Component):
     The currently supported select menus are:
 
     - :class:`~disnake.StringSelectMenu`
+    - :class:`~disnake.UserSelectMenu`
+    - :class:`~disnake.RoleSelectMenu`
+    - :class:`~disnake.MentionableSelectMenu`
+    - :class:`~disnake.ChannelSelectMenu`
 
     .. versionadded:: 2.7
 
@@ -319,6 +338,136 @@ class StringSelectMenu(BaseSelectMenu):
     def to_dict(self) -> StringSelectMenuPayload:
         payload = cast("StringSelectMenuPayload", super().to_dict())
         payload["options"] = [op.to_dict() for op in self.options]
+        return payload
+
+
+class UserSelectMenu(BaseSelectMenu):
+    """Represents a user select menu from the Discord Bot UI Kit.
+
+    .. versionadded:: 2.7
+
+    Attributes
+    ----------
+    custom_id: Optional[:class:`str`]
+        The ID of the select menu that gets received during an interaction.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select menu is disabled or not.
+    """
+
+    __slots__: Tuple[str, ...] = ()
+
+    if TYPE_CHECKING:
+
+        def to_dict(self) -> UserSelectMenuPayload:
+            return cast("UserSelectMenuPayload", super().to_dict())
+
+
+class RoleSelectMenu(BaseSelectMenu):
+    """Represents a role select menu from the Discord Bot UI Kit.
+
+    .. versionadded:: 2.7
+
+    Attributes
+    ----------
+    custom_id: Optional[:class:`str`]
+        The ID of the select menu that gets received during an interaction.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select menu is disabled or not.
+    """
+
+    __slots__: Tuple[str, ...] = ()
+
+    if TYPE_CHECKING:
+
+        def to_dict(self) -> RoleSelectMenuPayload:
+            return cast("RoleSelectMenuPayload", super().to_dict())
+
+
+class MentionableSelectMenu(BaseSelectMenu):
+    """Represents a mentionable (user/role) select menu from the Discord Bot UI Kit.
+
+    .. versionadded:: 2.7
+
+    Attributes
+    ----------
+    custom_id: Optional[:class:`str`]
+        The ID of the select menu that gets received during an interaction.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select menu is disabled or not.
+    """
+
+    __slots__: Tuple[str, ...] = ()
+
+    if TYPE_CHECKING:
+
+        def to_dict(self) -> MentionableSelectMenuPayload:
+            return cast("MentionableSelectMenuPayload", super().to_dict())
+
+
+class ChannelSelectMenu(BaseSelectMenu):
+    """Represents a channel select menu from the Discord Bot UI Kit.
+
+    .. versionadded:: 2.7
+
+    Attributes
+    ----------
+    custom_id: Optional[:class:`str`]
+        The ID of the select menu that gets received during an interaction.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select menu is disabled or not.
+    channel_types: Optional[List[:class:`ChannelType`]]
+        A list of channel types that can be selected in this select menu.
+        If ``None``, channels of all types may be selected.
+    """
+
+    __slots__: Tuple[str, ...] = ("channel_types",)
+
+    __repr_info__: ClassVar[Tuple[str, ...]] = BaseSelectMenu.__repr_info__ + __slots__
+
+    def __init__(self, data: ChannelSelectMenuPayload):
+        super().__init__(data)
+        # TODO: check api typing (missing/none/empty list)
+        channel_types = data.get("channel_types")
+        self.channel_types: Optional[List[ChannelType]] = (
+            [try_enum(ChannelType, t) for t in channel_types] if channel_types is not None else None
+        )
+
+    def to_dict(self) -> ChannelSelectMenuPayload:
+        payload = cast("ChannelSelectMenuPayload", super().to_dict())
+        if self.channel_types is not None:
+            payload["channel_types"] = [t.value for t in self.channel_types]
         return payload
 
 
@@ -521,6 +670,14 @@ def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> 
         return StringSelectMenu(data)  # type: ignore
     elif component_type == 4:
         return TextInput(data)  # type: ignore
+    elif component_type == 5:
+        return UserSelectMenu(data)  # type: ignore
+    elif component_type == 6:
+        return RoleSelectMenu(data)  # type: ignore
+    elif component_type == 7:
+        return MentionableSelectMenu(data)  # type: ignore
+    elif component_type == 8:
+        return ChannelSelectMenu(data)  # type: ignore
     else:
         assert_never(component_type)
         as_enum = try_enum(ComponentType, component_type)

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -400,7 +400,7 @@ class RoleSelectMenu(BaseSelectMenu):
 
 
 class MentionableSelectMenu(BaseSelectMenu):
-    """Represents a mentionable (user/role) select menu from the Discord Bot UI Kit.
+    """Represents a mentionable (user/member/role) select menu from the Discord Bot UI Kit.
 
     .. versionadded:: 2.7
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -40,7 +40,7 @@ __all__ = (
     "ActionRow",
     "Button",
     "BaseSelectMenu",
-    "SelectMenu",
+    "StringSelectMenu",
     "SelectOption",
     "TextInput",
 )
@@ -50,7 +50,7 @@ C = TypeVar("C", bound="Component")
 if TYPE_CHECKING:  # TODO: remove when we add modal select support
     from typing_extensions import TypeAlias
 
-AnySelectMenu: TypeAlias = "SelectMenu"
+AnySelectMenu: TypeAlias = "StringSelectMenu"
 MessageComponent = Union["Button", "AnySelectMenu"]
 
 # ModalComponent = Union["TextInput", "AnySelectMenu"]
@@ -66,7 +66,7 @@ class Component:
 
     - :class:`ActionRow`
     - :class:`Button`
-    - subtypes of :class:`BaseSelectMenu` (:class:`SelectMenu`)
+    - subtypes of :class:`BaseSelectMenu` (:class:`StringSelectMenu`, ...)
     - :class:`TextInput`
 
     This class is abstract and cannot be instantiated.
@@ -221,7 +221,7 @@ class BaseSelectMenu(Component):
 
     The currently supported select menus are:
 
-    - :class:`~disnake.SelectMenu`
+    - :class:`~disnake.StringSelectMenu`
 
     .. versionadded:: 2.7
 
@@ -276,7 +276,7 @@ class BaseSelectMenu(Component):
         return payload
 
 
-class SelectMenu(BaseSelectMenu):
+class StringSelectMenu(BaseSelectMenu):
     """Represents a string select menu from the Discord Bot UI Kit.
 
     .. note::
@@ -284,6 +284,9 @@ class SelectMenu(BaseSelectMenu):
         string select menu is :class:`disnake.ui.Select`.
 
     .. versionadded:: 2.0
+
+    .. versionchanged:: 2.7
+        Renamed from ``SelectMenu`` to ``StringSelectMenu``.
 
     Attributes
     ----------
@@ -515,7 +518,7 @@ def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> 
     elif component_type == 2:
         return Button(data)  # type: ignore
     elif component_type == 3:
-        return SelectMenu(data)  # type: ignore
+        return StringSelectMenu(data)  # type: ignore
     elif component_type == 4:
         return TextInput(data)  # type: ignore
     else:

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -82,7 +82,7 @@ class Component:
 
     - :class:`ActionRow`
     - :class:`Button`
-    - subtypes of :class:`BaseSelectMenu` (:class:`StringSelectMenu`, :class:`UserSelectMenu`, :class:`RoleSelectMenu`, :class:`MentionableSelectMenu`, :class:`ChannelSelectMenu`)
+    - subtypes of :class:`BaseSelectMenu` (:class:`ChannelSelectMenu`, :class:`MentionableSelectMenu`, :class:`RoleSelectMenu`, :class:`StringSelectMenu`, :class:`UserSelectMenu`)
     - :class:`TextInput`
 
     This class is abstract and cannot be instantiated.

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -348,6 +348,10 @@ SelectMenu = StringSelectMenu  # backwards compatibility
 class UserSelectMenu(BaseSelectMenu):
     """Represents a user select menu from the Discord Bot UI Kit.
 
+    .. note::
+        The user constructible and usable type to create a
+        user select menu is :class:`disnake.ui.UserSelect`.
+
     .. versionadded:: 2.7
 
     Attributes
@@ -376,6 +380,10 @@ class UserSelectMenu(BaseSelectMenu):
 
 class RoleSelectMenu(BaseSelectMenu):
     """Represents a role select menu from the Discord Bot UI Kit.
+
+    .. note::
+        The user constructible and usable type to create a
+        role select menu is :class:`disnake.ui.RoleSelect`.
 
     .. versionadded:: 2.7
 
@@ -406,6 +414,10 @@ class RoleSelectMenu(BaseSelectMenu):
 class MentionableSelectMenu(BaseSelectMenu):
     """Represents a mentionable (user/member/role) select menu from the Discord Bot UI Kit.
 
+    .. note::
+        The user constructible and usable type to create a
+        mentionable select menu is :class:`disnake.ui.MentionableSelect`.
+
     .. versionadded:: 2.7
 
     Attributes
@@ -434,6 +446,10 @@ class MentionableSelectMenu(BaseSelectMenu):
 
 class ChannelSelectMenu(BaseSelectMenu):
     """Represents a channel select menu from the Discord Bot UI Kit.
+
+    .. note::
+        The user constructible and usable type to create a
+        channel select menu is :class:`disnake.ui.ChannelSelect`.
 
     .. versionadded:: 2.7
 

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -588,6 +588,10 @@ class ComponentType(Enum):
     button = 2
     string_select = 3
     text_input = 4
+    user_select = 5
+    role_select = 6
+    mentionable_select = 7
+    channel_select = 8
 
     def __int__(self):
         return self.value

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -587,6 +587,7 @@ class ComponentType(Enum):
     action_row = 1
     button = 2
     string_select = 3
+    select = string_select  # backwards compatibility
     text_input = 4
     user_select = 5
     role_select = 6

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -586,7 +586,7 @@ class VideoQualityMode(Enum):
 class ComponentType(Enum):
     action_row = 1
     button = 2
-    select = 3
+    string_select = 3
     text_input = 4
 
     def __int__(self):

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -23,6 +23,7 @@ from ..app_commands import OptionChoice
 from ..channel import PartialMessageable, _threaded_guild_channel_factory
 from ..enums import (
     ChannelType,
+    ComponentType,
     InteractionResponseType,
     InteractionType,
     Locale,
@@ -1762,9 +1763,9 @@ class InteractionDataResolved(Dict[str, Any]):
         )
 
     def get_with_type(
-        self, key: Snowflake, data_type: OptionType, default: T = None
+        self, key: Snowflake, data_type: Union[OptionType, ComponentType], default: T = None
     ) -> Union[Member, User, Role, InteractionChannel, Message, Attachment, T]:
-        if data_type is OptionType.mentionable:
+        if data_type is OptionType.mentionable or data_type is ComponentType.mentionable_select:
             key = int(key)
             if (result := self.members.get(key)) is not None:
                 return result
@@ -1772,16 +1773,16 @@ class InteractionDataResolved(Dict[str, Any]):
                 return result
             return self.roles.get(key, default)
 
-        if data_type is OptionType.user:
+        if data_type is OptionType.user or data_type is ComponentType.user_select:
             key = int(key)
             if (member := self.members.get(key)) is not None:
                 return member
             return self.users.get(key, default)
 
-        if data_type is OptionType.channel:
+        if data_type is OptionType.channel or data_type is ComponentType.channel_select:
             return self.channels.get(int(key), default)
 
-        if data_type is OptionType.role:
+        if data_type is OptionType.role or data_type is ComponentType.role_select:
             return self.roles.get(int(key), default)
 
         if data_type is OptionType.attachment:

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -84,6 +84,7 @@ class MessageInteraction(Interaction):
         )
         self.message = Message(state=self._state, channel=self.channel, data=data["message"])
 
+    # TODO: perhaps keep `values` like before and add a `resolved_values` instead?
     @property
     def values(self) -> Optional[Sequence[Union[str, Member, User, Role, InteractionChannel]]]:
         """Optional[Sequence[:class:`str`]]: The values the user selected.

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -114,7 +114,9 @@ class MessageInteractionData(Dict[str, Any]):
         super().__init__(data)
         self.custom_id: str = data["custom_id"]
         self.component_type: ComponentType = try_enum(ComponentType, data["component_type"])
-        self.values: Optional[List[str]] = data.get("values")
+        self.values: Optional[List[str]] = (
+            list(map(str, values)) if (values := data.get("values")) else None
+        )
 
     def __repr__(self):
         return (

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -164,6 +164,17 @@ async def logging_coroutine(coroutine: Coroutine[Any, Any, T], *, info: str) -> 
         _log.exception("Exception occurred during %s", info)
 
 
+_SELECT_COMPONENT_TYPES = frozenset(
+    (
+        ComponentType.string_select,
+        ComponentType.user_select,
+        ComponentType.role_select,
+        ComponentType.mentionable_select,
+        ComponentType.channel_select,
+    )
+)
+
+
 class ConnectionState:
     if TYPE_CHECKING:
         _get_websocket: Callable[..., DiscordWebSocket]
@@ -952,14 +963,7 @@ class ConnectionState:
             self.dispatch("message_interaction", interaction)
             if interaction.data.component_type is ComponentType.button:
                 self.dispatch("button_click", interaction)
-            # TODO: move out of method
-            elif interaction.data.component_type in (
-                ComponentType.string_select,
-                ComponentType.user_select,
-                ComponentType.role_select,
-                ComponentType.mentionable_select,
-                ComponentType.channel_select,
-            ):
+            elif interaction.data.component_type in _SELECT_COMPONENT_TYPES:
                 self.dispatch("dropdown", interaction)
 
         elif data["type"] == 4:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -952,7 +952,7 @@ class ConnectionState:
             self.dispatch("message_interaction", interaction)
             if interaction.data.component_type is ComponentType.button:
                 self.dispatch("button_click", interaction)
-            elif interaction.data.component_type is ComponentType.select:
+            elif interaction.data.component_type in (ComponentType.string_select,):
                 self.dispatch("dropdown", interaction)
 
         elif data["type"] == 4:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -952,7 +952,14 @@ class ConnectionState:
             self.dispatch("message_interaction", interaction)
             if interaction.data.component_type is ComponentType.button:
                 self.dispatch("button_click", interaction)
-            elif interaction.data.component_type in (ComponentType.string_select,):
+            # TODO: move out of method
+            elif interaction.data.component_type in (
+                ComponentType.string_select,
+                ComponentType.user_select,
+                ComponentType.role_select,
+                ComponentType.mentionable_select,
+                ComponentType.channel_select,
+            ):
                 self.dispatch("dropdown", interaction)
 
         elif data["type"] == 4:

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -48,15 +48,15 @@ class _SelectMenu(TypedDict):
 
 
 class BaseSelectMenu(_SelectMenu):
-    type: Literal[3]
+    type: Literal[3, 5, 6, 7, 8]
 
 
-class SelectMenu(_SelectMenu):
+class StringSelectMenu(_SelectMenu):
     type: Literal[3]
     options: List[SelectOption]
 
 
-AnySelectMenu = SelectMenu
+AnySelectMenu = StringSelectMenu  # TODO
 
 
 class Modal(TypedDict):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -6,6 +6,7 @@ from typing import List, Literal, TypedDict, Union
 
 from typing_extensions import NotRequired
 
+from .channel import ChannelType
 from .emoji import PartialEmoji
 
 ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8]
@@ -56,7 +57,30 @@ class StringSelectMenu(_SelectMenu):
     options: List[SelectOption]
 
 
-AnySelectMenu = StringSelectMenu  # TODO
+class UserSelectMenu(_SelectMenu):
+    type: Literal[5]
+
+
+class RoleSelectMenu(_SelectMenu):
+    type: Literal[6]
+
+
+class MentionableSelectMenu(_SelectMenu):
+    type: Literal[7]
+
+
+class ChannelSelectMenu(_SelectMenu):
+    type: Literal[8]
+    channel_types: NotRequired[List[ChannelType]]
+
+
+AnySelectMenu = Union[
+    StringSelectMenu,
+    UserSelectMenu,
+    RoleSelectMenu,
+    MentionableSelectMenu,
+    ChannelSelectMenu,
+]
 
 
 class Modal(TypedDict):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -8,7 +8,7 @@ from typing_extensions import NotRequired
 
 from .emoji import PartialEmoji
 
-ComponentType = Literal[1, 2, 3, 4]
+ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8]
 ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextInputStyle = Literal[1, 2]
 

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -172,6 +172,11 @@ class _BaseComponentInteractionData(TypedDict):
     custom_id: str
 
 
+class _BaseSnowflakeComponentInteractionData(_BaseComponentInteractionData):
+    values: List[Snowflake]
+    resolved: NotRequired[InteractionDataResolved]
+
+
 ### Message interaction components
 
 
@@ -179,21 +184,41 @@ class MessageComponentInteractionButtonData(_BaseComponentInteractionData):
     component_type: Literal[2]
 
 
-class MessageComponentInteractionSelectData(_BaseComponentInteractionData):
+class MessageComponentInteractionStringSelectData(_BaseComponentInteractionData):
     component_type: Literal[3]
     values: List[str]
 
 
+class MessageComponentInteractionUserSelectData(_BaseSnowflakeComponentInteractionData):
+    component_type: Literal[5]
+
+
+class MessageComponentInteractionRoleSelectData(_BaseSnowflakeComponentInteractionData):
+    component_type: Literal[6]
+
+
+class MessageComponentInteractionMentionableSelectData(_BaseSnowflakeComponentInteractionData):
+    component_type: Literal[7]
+
+
+class MessageComponentInteractionChannelSelectData(_BaseSnowflakeComponentInteractionData):
+    component_type: Literal[8]
+
+
 MessageComponentInteractionData = Union[
     MessageComponentInteractionButtonData,
-    MessageComponentInteractionSelectData,
+    MessageComponentInteractionStringSelectData,
+    MessageComponentInteractionUserSelectData,
+    MessageComponentInteractionRoleSelectData,
+    MessageComponentInteractionMentionableSelectData,
+    MessageComponentInteractionChannelSelectData,
 ]
 
 
 ### Modal interaction components
 
-
-class ModalInteractionSelectData(_BaseComponentInteractionData):
+# TODO: add other select types
+class ModalInteractionStringSelectData(_BaseComponentInteractionData):
     type: Literal[3]
     values: List[str]
 
@@ -204,7 +229,7 @@ class ModalInteractionTextInputData(_BaseComponentInteractionData):
 
 
 ModalInteractionComponentData = Union[
-    ModalInteractionSelectData,
+    ModalInteractionStringSelectData,
     ModalInteractionTextInputData,
 ]
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -23,7 +23,7 @@ from ..components import (
     ActionRow as ActionRowComponent,
     Button as ButtonComponent,
     NestedComponent,
-    SelectMenu as SelectComponent,
+    StringSelectMenu as StringSelectComponent,
 )
 from ..enums import ButtonStyle, ComponentType, TextInputStyle
 from ..utils import MISSING, SequenceProxy, assert_never
@@ -547,7 +547,7 @@ class ActionRow(Generic[UIComponentT]):
             for component in row.children:
                 if isinstance(component, ButtonComponent):
                     current_row.append_item(Button.from_component(component))
-                elif isinstance(component, SelectComponent):
+                elif isinstance(component, StringSelectComponent):
                     current_row.append_item(Select.from_component(component))
                 else:
                     assert_never(component)

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -350,6 +350,8 @@ class ActionRow(Generic[UIComponentT]):
         )
         return self
 
+    add_select = add_string_select  # backwards compatibility
+
     def add_user_select(
         self: SelectCompatibleActionRowT,
         *,

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -29,7 +29,7 @@ from ..components import (
     StringSelectMenu as StringSelectComponent,
     UserSelectMenu as UserSelectComponent,
 )
-from ..enums import ButtonStyle, ComponentType, TextInputStyle
+from ..enums import ButtonStyle, ChannelType, ComponentType, TextInputStyle
 from ..utils import MISSING, SequenceProxy, assert_never
 from .button import Button
 from .item import WrappedComponent
@@ -295,7 +295,6 @@ class ActionRow(Generic[UIComponentT]):
         )
         return self
 
-    # TODO: other select types
     def add_string_select(
         self: SelectCompatibleActionRowT,
         *,
@@ -347,6 +346,215 @@ class ActionRow(Generic[UIComponentT]):
                 max_values=max_values,
                 options=options,
                 disabled=disabled,
+            ),
+        )
+        return self
+
+    def add_user_select(
+        self: SelectCompatibleActionRowT,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+    ) -> SelectCompatibleActionRowT:
+        """Add a user select menu to the action row. Can only be used if the action
+        row holds message components.
+
+        To append a pre-existing :class:`~disnake.ui.UserSelect` use the
+        :meth:`append_item` method instead.
+
+        This function returns the class instance to allow for fluent-style chaining.
+
+        .. versionadded:: 2.7
+
+        Parameters
+        ----------
+        custom_id: :class:`str`
+            The ID of the select menu that gets received during an interaction.
+            If not given then one is generated for you.
+        placeholder: Optional[:class:`str`]
+            The placeholder text that is shown if nothing is selected, if any.
+        min_values: :class:`int`
+            The minimum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        max_values: :class:`int`
+            The maximum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        disabled: :class:`bool`
+            Whether the select is disabled or not.
+
+        Raises
+        ------
+        ValueError
+            The width of the action row exceeds 5.
+        """
+        self.append_item(
+            UserSelect(
+                custom_id=custom_id,
+                placeholder=placeholder,
+                min_values=min_values,
+                max_values=max_values,
+                disabled=disabled,
+            ),
+        )
+        return self
+
+    def add_role_select(
+        self: SelectCompatibleActionRowT,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+    ) -> SelectCompatibleActionRowT:
+        """Add a role select menu to the action row. Can only be used if the action
+        row holds message components.
+
+        To append a pre-existing :class:`~disnake.ui.RoleSelect` use the
+        :meth:`append_item` method instead.
+
+        This function returns the class instance to allow for fluent-style chaining.
+
+        .. versionadded:: 2.7
+
+        Parameters
+        ----------
+        custom_id: :class:`str`
+            The ID of the select menu that gets received during an interaction.
+            If not given then one is generated for you.
+        placeholder: Optional[:class:`str`]
+            The placeholder text that is shown if nothing is selected, if any.
+        min_values: :class:`int`
+            The minimum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        max_values: :class:`int`
+            The maximum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        disabled: :class:`bool`
+            Whether the select is disabled or not.
+
+        Raises
+        ------
+        ValueError
+            The width of the action row exceeds 5.
+        """
+        self.append_item(
+            RoleSelect(
+                custom_id=custom_id,
+                placeholder=placeholder,
+                min_values=min_values,
+                max_values=max_values,
+                disabled=disabled,
+            ),
+        )
+        return self
+
+    def add_mentionable_select(
+        self: SelectCompatibleActionRowT,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+    ) -> SelectCompatibleActionRowT:
+        """Add a mentionable (user/role) select menu to the action row. Can only be used if the action
+        row holds message components.
+
+        To append a pre-existing :class:`~disnake.ui.MentionableSelect` use the
+        :meth:`append_item` method instead.
+
+        This function returns the class instance to allow for fluent-style chaining.
+
+        .. versionadded:: 2.7
+
+        Parameters
+        ----------
+        custom_id: :class:`str`
+            The ID of the select menu that gets received during an interaction.
+            If not given then one is generated for you.
+        placeholder: Optional[:class:`str`]
+            The placeholder text that is shown if nothing is selected, if any.
+        min_values: :class:`int`
+            The minimum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        max_values: :class:`int`
+            The maximum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        disabled: :class:`bool`
+            Whether the select is disabled or not.
+
+        Raises
+        ------
+        ValueError
+            The width of the action row exceeds 5.
+        """
+        self.append_item(
+            MentionableSelect(
+                custom_id=custom_id,
+                placeholder=placeholder,
+                min_values=min_values,
+                max_values=max_values,
+                disabled=disabled,
+            ),
+        )
+        return self
+
+    def add_channel_select(
+        self: SelectCompatibleActionRowT,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        channel_types: Optional[List[ChannelType]] = None,
+    ) -> SelectCompatibleActionRowT:
+        """Add a channel select menu to the action row. Can only be used if the action
+        row holds message components.
+
+        To append a pre-existing :class:`~disnake.ui.ChannelSelect` use the
+        :meth:`append_item` method instead.
+
+        This function returns the class instance to allow for fluent-style chaining.
+
+        .. versionadded:: 2.7
+
+        Parameters
+        ----------
+        custom_id: :class:`str`
+            The ID of the select menu that gets received during an interaction.
+            If not given then one is generated for you.
+        placeholder: Optional[:class:`str`]
+            The placeholder text that is shown if nothing is selected, if any.
+        min_values: :class:`int`
+            The minimum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        max_values: :class:`int`
+            The maximum number of items that must be chosen for this select menu.
+            Defaults to 1 and must be between 1 and 25.
+        disabled: :class:`bool`
+            Whether the select is disabled or not.
+        channel_types: Optional[List[:class:`.ChannelType`]]
+            The list of channel types that can be selected in this select menu.
+            Defaults to all types (i.e. ``None``).
+
+        Raises
+        ------
+        ValueError
+            The width of the action row exceeds 5.
+        """
+        self.append_item(
+            ChannelSelect(
+                custom_id=custom_id,
+                placeholder=placeholder,
+                min_values=min_values,
+                max_values=max_values,
+                disabled=disabled,
+                channel_types=channel_types,
             ),
         )
         return self

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -29,7 +29,7 @@ from ..enums import ButtonStyle, ComponentType, TextInputStyle
 from ..utils import MISSING, SequenceProxy, assert_never
 from .button import Button
 from .item import WrappedComponent
-from .select import Select
+from .select import StringSelect
 from .select.string import SelectOptionInput, V_co
 from .text_input import TextInput
 
@@ -53,7 +53,7 @@ __all__ = (
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-AnySelect: TypeAlias = "Select[V_co]"
+AnySelect: TypeAlias = "StringSelect[V_co]"
 
 MessageUIComponent = Union[Button[Any], "AnySelect[Any]"]
 ModalUIComponent = TextInput  # Union[TextInput, "AnySelect[Any]"]
@@ -134,8 +134,8 @@ class ActionRow(Generic[UIComponentT]):
         ...
 
     # Explicit definitions are needed to make
-    # "ActionRow(Select(), TextInput())" and
-    # "ActionRow(Select(), Button())"
+    # "ActionRow(StringSelect(), TextInput())" and
+    # "ActionRow(StringSelect(), Button())"
     # differentiate themselves properly.
 
     @overload
@@ -288,7 +288,7 @@ class ActionRow(Generic[UIComponentT]):
         )
         return self
 
-    def add_select(
+    def add_string_select(
         self: SelectCompatibleActionRowT,
         *,
         custom_id: str = MISSING,
@@ -301,7 +301,7 @@ class ActionRow(Generic[UIComponentT]):
         """Add a string select menu to the action row. Can only be used if the action
         row holds message components.
 
-        To append a pre-existing :class:`~disnake.ui.Select` use the
+        To append a pre-existing :class:`~disnake.ui.StringSelect` use the
         :meth:`append_item` method instead.
 
         This function returns the class instance to allow for fluent-style chaining.
@@ -332,7 +332,7 @@ class ActionRow(Generic[UIComponentT]):
             The width of the action row exceeds 5.
         """
         self.append_item(
-            Select(
+            StringSelect(
                 custom_id=custom_id,
                 placeholder=placeholder,
                 min_values=min_values,
@@ -548,7 +548,7 @@ class ActionRow(Generic[UIComponentT]):
                 if isinstance(component, ButtonComponent):
                     current_row.append_item(Button.from_component(component))
                 elif isinstance(component, StringSelectComponent):
-                    current_row.append_item(Select.from_component(component))
+                    current_row.append_item(StringSelect.from_component(component))
                 else:
                     assert_never(component)
                     if strict:

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -313,6 +313,9 @@ class ActionRow(Generic[UIComponentT]):
 
         This function returns the class instance to allow for fluent-style chaining.
 
+        .. versionchanged:: 2.7
+            Renamed from ``add_select`` to ``add_string_select``.
+
         Parameters
         ----------
         custom_id: :class:`str`

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -22,14 +22,18 @@ from typing import (
 from ..components import (
     ActionRow as ActionRowComponent,
     Button as ButtonComponent,
+    ChannelSelectMenu as ChannelSelectComponent,
+    MentionableSelectMenu as MentionableSelectComponent,
     NestedComponent,
+    RoleSelectMenu as RoleSelectComponent,
     StringSelectMenu as StringSelectComponent,
+    UserSelectMenu as UserSelectComponent,
 )
 from ..enums import ButtonStyle, ComponentType, TextInputStyle
 from ..utils import MISSING, SequenceProxy, assert_never
 from .button import Button
 from .item import WrappedComponent
-from .select import StringSelect
+from .select import ChannelSelect, MentionableSelect, RoleSelect, StringSelect, UserSelect
 from .select.string import SelectOptionInput, V_co
 from .text_input import TextInput
 
@@ -50,10 +54,13 @@ __all__ = (
     "ModalActionRow",
 )
 
-if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
-AnySelect: TypeAlias = "StringSelect[V_co]"
+AnySelect = Union[
+    "StringSelect[V_co]",
+    "UserSelect[V_co]",
+    "RoleSelect[V_co]",
+    "MentionableSelect[V_co]",
+    "ChannelSelect[V_co]",
+]
 
 MessageUIComponent = Union[Button[Any], "AnySelect[Any]"]
 ModalUIComponent = TextInput  # Union[TextInput, "AnySelect[Any]"]
@@ -288,6 +295,7 @@ class ActionRow(Generic[UIComponentT]):
         )
         return self
 
+    # TODO: other select types
     def add_string_select(
         self: SelectCompatibleActionRowT,
         *,
@@ -549,6 +557,14 @@ class ActionRow(Generic[UIComponentT]):
                     current_row.append_item(Button.from_component(component))
                 elif isinstance(component, StringSelectComponent):
                     current_row.append_item(StringSelect.from_component(component))
+                elif isinstance(component, UserSelectComponent):
+                    current_row.append_item(UserSelect.from_component(component))
+                elif isinstance(component, RoleSelectComponent):
+                    current_row.append_item(RoleSelect.from_component(component))
+                elif isinstance(component, MentionableSelectComponent):
+                    current_row.append_item(MentionableSelect.from_component(component))
+                elif isinstance(component, ChannelSelectComponent):
+                    current_row.append_item(ChannelSelect.from_component(component))
                 else:
                     assert_never(component)
                     if strict:

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -461,7 +461,7 @@ class ActionRow(Generic[UIComponentT]):
         max_values: int = 1,
         disabled: bool = False,
     ) -> SelectCompatibleActionRowT:
-        """Add a mentionable (user/role) select menu to the action row. Can only be used if the action
+        """Add a mentionable (user/member/role) select menu to the action row. Can only be used if the action
         row holds message components.
 
         To append a pre-existing :class:`~disnake.ui.MentionableSelect` use the

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -55,11 +55,11 @@ __all__ = (
 )
 
 AnySelect = Union[
+    "ChannelSelect[V_co]",
+    "MentionableSelect[V_co]",
+    "RoleSelect[V_co]",
     "StringSelect[V_co]",
     "UserSelect[V_co]",
-    "RoleSelect[V_co]",
-    "MentionableSelect[V_co]",
-    "ChannelSelect[V_co]",
 ]
 
 MessageUIComponent = Union[Button[Any], "AnySelect[Any]"]

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -42,7 +42,7 @@ class WrappedComponent(ABC):
     The following classes implement this ABC:
 
     - :class:`disnake.ui.Button`
-    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.Select`)
+    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, ...)
     - :class:`disnake.ui.TextInput`
 
     .. versionadded:: 2.4
@@ -81,7 +81,7 @@ class Item(WrappedComponent, Generic[V_co]):
     The current UI items supported are:
 
     - :class:`disnake.ui.Button`
-    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.Select`)
+    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, ...)
 
     .. versionadded:: 2.0
     """

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -42,7 +42,7 @@ class WrappedComponent(ABC):
     The following classes implement this ABC:
 
     - :class:`disnake.ui.Button`
-    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, ...)
+    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, :class:`disnake.ui.UserSelect`, :class:`disnake.ui.RoleSelect`, :class:`disnake.ui.MentionableSelect`, :class:`disnake.ui.ChannelSelect`)
     - :class:`disnake.ui.TextInput`
 
     .. versionadded:: 2.4
@@ -81,7 +81,7 @@ class Item(WrappedComponent, Generic[V_co]):
     The current UI items supported are:
 
     - :class:`disnake.ui.Button`
-    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, ...)
+    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, :class:`disnake.ui.UserSelect`, :class:`disnake.ui.RoleSelect`, :class:`disnake.ui.MentionableSelect`, :class:`disnake.ui.ChannelSelect`)
 
     .. versionadded:: 2.0
     """

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -42,7 +42,7 @@ class WrappedComponent(ABC):
     The following classes implement this ABC:
 
     - :class:`disnake.ui.Button`
-    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, :class:`disnake.ui.UserSelect`, :class:`disnake.ui.RoleSelect`, :class:`disnake.ui.MentionableSelect`, :class:`disnake.ui.ChannelSelect`)
+    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.ChannelSelect`, :class:`disnake.ui.MentionableSelect`, :class:`disnake.ui.RoleSelect`, :class:`disnake.ui.StringSelect`, :class:`disnake.ui.UserSelect`)
     - :class:`disnake.ui.TextInput`
 
     .. versionadded:: 2.4
@@ -81,7 +81,7 @@ class Item(WrappedComponent, Generic[V_co]):
     The current UI items supported are:
 
     - :class:`disnake.ui.Button`
-    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.StringSelect`, :class:`disnake.ui.UserSelect`, :class:`disnake.ui.RoleSelect`, :class:`disnake.ui.MentionableSelect`, :class:`disnake.ui.ChannelSelect`)
+    - subtypes of :class:`disnake.ui.BaseSelect` (:class:`disnake.ui.ChannelSelect`, :class:`disnake.ui.MentionableSelect`, :class:`disnake.ui.RoleSelect`, :class:`disnake.ui.StringSelect`, :class:`disnake.ui.UserSelect`)
 
     .. versionadded:: 2.0
     """

--- a/disnake/ui/select/__init__.py
+++ b/disnake/ui/select/__init__.py
@@ -10,10 +10,18 @@ Select Menu UI Kit Types
 :license: MIT, see LICENSE for more details.
 
 """
-from . import base, string
+from . import base, channel, mentionable, role, string, user
 from .base import *
+from .channel import *
+from .mentionable import *
+from .role import *
 from .string import *
+from .user import *
 
 __all__ = []
 __all__.extend(base.__all__)
+__all__.extend(channel.__all__)
+__all__.extend(mentionable.__all__)
+__all__.extend(role.__all__)
 __all__.extend(string.__all__)
+__all__.extend(user.__all__)

--- a/disnake/ui/select/base.py
+++ b/disnake/ui/select/base.py
@@ -157,7 +157,6 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         self._underlying = component
 
     def refresh_state(self, interaction: MessageInteraction) -> None:
-        # TODO: change typing of `interaction.values`
         self._selected_values = interaction.values  # type: ignore
 
     @classmethod

--- a/disnake/ui/select/base.py
+++ b/disnake/ui/select/base.py
@@ -51,6 +51,10 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
     This isn't meant to be used directly, instead use one of the concrete select menu types:
 
     - :class:`disnake.ui.StringSelect`
+    - :class:`disnake.ui.UserSelect`
+    - :class:`disnake.ui.RoleSelect`
+    - :class:`disnake.ui.MentionableSelect`
+    - :class:`disnake.ui.ChannelSelect`
 
     .. versionadded:: 2.7
     """

--- a/disnake/ui/select/base.py
+++ b/disnake/ui/select/base.py
@@ -50,7 +50,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
 
     This isn't meant to be used directly, instead use one of the concrete select menu types:
 
-    - :class:`disnake.ui.Select`
+    - :class:`disnake.ui.StringSelect`
 
     .. versionadded:: 2.7
     """

--- a/disnake/ui/select/base.py
+++ b/disnake/ui/select/base.py
@@ -157,7 +157,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         self._underlying = component
 
     def refresh_state(self, interaction: MessageInteraction) -> None:
-        self._selected_values = interaction.values  # type: ignore
+        self._selected_values = interaction.resolved_values  # type: ignore
 
     @classmethod
     @abstractmethod

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -12,7 +12,7 @@ from .base import BaseSelect, P, V_co, _create_decorator
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-    from ...guild import GuildChannel
+    from ...interactions.base import InteractionChannel
     from ..item import DecoratedItem, ItemCallbackType, Object
 
 
@@ -22,8 +22,7 @@ __all__ = (
 )
 
 
-# TODO: threads, dms?
-class ChannelSelect(BaseSelect[ChannelSelectMenu, "GuildChannel", V_co]):
+class ChannelSelect(BaseSelect[ChannelSelectMenu, "InteractionChannel", V_co]):
     """Represents a UI channel select menu.
 
     This is usually represented as a drop down menu.
@@ -59,8 +58,8 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "GuildChannel", V_co]):
 
     Attributes
     ----------
-    values: List[:class:`.abc.GuildChannel`]
-        A list of roles that have been selected by the user.
+    values: List[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.PartialMessageable`]]
+        A list of channels that have been selected by the user.
     """
 
     __repr_attributes__: Tuple[str, ...] = BaseSelect.__repr_attributes__ + ("channel_types",)

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -114,7 +114,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "GuildChannel", V_co]):
             disabled=disabled,
             row=row,
         )
-        self._underlying.channel_types = channel_types
+        self._underlying.channel_types = channel_types or None
 
     @classmethod
     def from_component(cls, component: ChannelSelectMenu) -> Self:

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Type, TypeVar, overload
+
+from ...components import ChannelSelectMenu
+from ...enums import ChannelType, ComponentType
+from ...utils import MISSING
+from .base import BaseSelect, P, V_co, _create_decorator
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from ...guild import GuildChannel
+    from ..item import DecoratedItem, ItemCallbackType, Object
+
+
+__all__ = (
+    "ChannelSelect",
+    "channel_select",
+)
+
+
+# TODO: threads, dms?
+class ChannelSelect(BaseSelect[ChannelSelectMenu, "GuildChannel", V_co]):
+    """Represents a UI channel select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, use :attr:`.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    channel_types: Optional[List[:class:`.ChannelType`]]
+        The list of channel types that can be selected in this select menu.
+        Defaults to all types (i.e. ``None``).
+
+    Attributes
+    ----------
+    values: List[:class:`.abc.GuildChannel`]
+        A list of roles that have been selected by the user.
+    """
+
+    __repr_attributes__: Tuple[str, ...] = BaseSelect.__repr_attributes__ + ("channel_types",)
+
+    @overload
+    def __init__(
+        self: ChannelSelect[None],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        channel_types: Optional[List[ChannelType]] = None,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self: ChannelSelect[V_co],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        channel_types: Optional[List[ChannelType]] = None,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        channel_types: Optional[List[ChannelType]] = None,
+        row: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            ChannelSelectMenu,
+            ComponentType.channel_select,
+            custom_id=custom_id,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+            row=row,
+        )
+        self._underlying.channel_types = channel_types
+
+    @classmethod
+    def from_component(cls, component: ChannelSelectMenu) -> Self:
+        return cls(
+            custom_id=component.custom_id,
+            placeholder=component.placeholder,
+            min_values=component.min_values,
+            max_values=component.max_values,
+            disabled=component.disabled,
+            channel_types=component.channel_types,
+            row=None,
+        )
+
+
+S_co = TypeVar("S_co", bound="ChannelSelect", covariant=True)
+
+
+@overload
+def channel_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = ...,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    channel_types: Optional[List[ChannelType]] = None,
+    row: Optional[int] = None,
+) -> Callable[[ItemCallbackType[ChannelSelect[V_co]]], DecoratedItem[ChannelSelect[V_co]]]:
+    ...
+
+
+@overload
+def channel_select(
+    cls: Type[Object[S_co, P]], *_: P.args, **kwargs: P.kwargs
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    ...
+
+
+def channel_select(
+    cls: Type[Object[S_co, P]] = ChannelSelect[Any],
+    /,
+    **kwargs: Any,
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    """A decorator that attaches a channel select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`disnake.ui.View`, the :class:`disnake.ui.ChannelSelect` that was
+    interacted with, and the :class:`disnake.MessageInteraction`.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`ChannelSelect.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    cls: Type[:class:`ChannelSelect`]
+        The select subclass to create an instance of. If provided, the following parameters
+        described below do no apply. Instead, this decorator will accept the same keywords
+        as the passed cls does.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled. Defaults to ``False``.
+    channel_types: Optional[List[:class:`.ChannelType`]]
+        The list of channel types that can be selected in this select menu.
+        Defaults to all types (i.e. ``None``).
+    """
+    return _create_decorator(cls, ChannelSelect, **kwargs)

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -128,6 +128,21 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "GuildChannel", V_co]):
             row=None,
         )
 
+    @property
+    def channel_types(self) -> Optional[List[ChannelType]]:
+        """Optional[List[:class:`disnake.ChannelType`]]: A list of channel types that can be selected in this select menu."""
+        return self._underlying.channel_types
+
+    @channel_types.setter
+    def channel_types(self, value: Optional[List[ChannelType]]):
+        if value is not None:
+            if not isinstance(value, list):
+                raise TypeError("channel_types must be a list of ChannelType")
+            if not all(isinstance(obj, ChannelType) for obj in value):
+                raise TypeError("all list items must be ChannelType")
+
+        self._underlying.channel_types = value
+
 
 S_co = TypeVar("S_co", bound="ChannelSelect", covariant=True)
 

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
     from ...member import Member
     from ...role import Role
+    from ...user import User
     from ..item import DecoratedItem, ItemCallbackType, Object
 
 
@@ -23,8 +24,8 @@ __all__ = (
 )
 
 
-class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[Member, Role]", V_co]):
-    """Represents a UI mentionable (user/role) select menu.
+class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, Role]", V_co]):
+    """Represents a UI mentionable (user/member/role) select menu.
 
     This is usually represented as a drop down menu.
 
@@ -56,8 +57,8 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[Member, Role]",
 
     Attributes
     ----------
-    values: List[Union[:class:`.Member`, :class:`.Role`]]
-        A list of members and/or roles that have been selected by the user.
+    values: List[Union[:class:`~disnake.User`, :class:`.Member`, :class:`.Role`]]
+        A list of users, members and/or roles that have been selected by the user.
     """
 
     @overload
@@ -147,7 +148,7 @@ def mentionable_select(
     /,
     **kwargs: Any,
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
-    """A decorator that attaches a mentionable (user/role) select menu to a component.
+    """A decorator that attaches a mentionable (user/member/role) select menu to a component.
 
     The function being decorated should have three parameters, ``self`` representing
     the :class:`disnake.ui.View`, the :class:`disnake.ui.MentionableSelect` that was

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -57,7 +57,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[Member, Role]",
     Attributes
     ----------
     values: List[Union[:class:`.Member`, :class:`.Role`]]
-        A list of users and/or roles that have been selected by the user.
+        A list of members and/or roles that have been selected by the user.
     """
 
     @overload

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, Union, overload
+
+from ...components import MentionableSelectMenu
+from ...enums import ComponentType
+from ...utils import MISSING
+from .base import BaseSelect, P, V_co, _create_decorator
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from ...member import Member
+    from ...role import Role
+    from ..item import DecoratedItem, ItemCallbackType, Object
+
+
+__all__ = (
+    "MentionableSelect",
+    "mentionable_select",
+)
+
+
+class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[Member, Role]", V_co]):
+    """Represents a UI mentionable (user/role) select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, use :attr:`.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+
+    Attributes
+    ----------
+    values: List[Union[:class:`.Member`, :class:`.Role`]]
+        A list of users and/or roles that have been selected by the user.
+    """
+
+    @overload
+    def __init__(
+        self: MentionableSelect[None],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self: MentionableSelect[V_co],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            MentionableSelectMenu,
+            ComponentType.mentionable_select,
+            custom_id=custom_id,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+            row=row,
+        )
+
+    @classmethod
+    def from_component(cls, component: MentionableSelectMenu) -> Self:
+        return cls(
+            custom_id=component.custom_id,
+            placeholder=component.placeholder,
+            min_values=component.min_values,
+            max_values=component.max_values,
+            disabled=component.disabled,
+            row=None,
+        )
+
+
+S_co = TypeVar("S_co", bound="MentionableSelect", covariant=True)
+
+
+@overload
+def mentionable_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = ...,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    row: Optional[int] = None,
+) -> Callable[[ItemCallbackType[MentionableSelect[V_co]]], DecoratedItem[MentionableSelect[V_co]]]:
+    ...
+
+
+@overload
+def mentionable_select(
+    cls: Type[Object[S_co, P]], *_: P.args, **kwargs: P.kwargs
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    ...
+
+
+def mentionable_select(
+    cls: Type[Object[S_co, P]] = MentionableSelect[Any],
+    /,
+    **kwargs: Any,
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    """A decorator that attaches a mentionable (user/role) select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`disnake.ui.View`, the :class:`disnake.ui.MentionableSelect` that was
+    interacted with, and the :class:`disnake.MessageInteraction`.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`MentionableSelect.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    cls: Type[:class:`MentionableSelect`]
+        The select subclass to create an instance of. If provided, the following parameters
+        described below do no apply. Instead, this decorator will accept the same keywords
+        as the passed cls does.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled. Defaults to ``False``.
+    """
+    return _create_decorator(cls, MentionableSelect, **kwargs)

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, overload
+
+from ...components import RoleSelectMenu
+from ...enums import ComponentType
+from ...utils import MISSING
+from .base import BaseSelect, P, V_co, _create_decorator
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from ...role import Role
+    from ..item import DecoratedItem, ItemCallbackType, Object
+
+
+__all__ = (
+    "RoleSelect",
+    "role_select",
+)
+
+
+class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
+    """Represents a UI user select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, use :attr:`.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+
+    Attributes
+    ----------
+    values: List[:class:`.Role`]
+        A list of roles that have been selected by the user.
+    """
+
+    @overload
+    def __init__(
+        self: RoleSelect[None],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self: RoleSelect[V_co],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            RoleSelectMenu,
+            ComponentType.role_select,
+            custom_id=custom_id,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+            row=row,
+        )
+
+    @classmethod
+    def from_component(cls, component: RoleSelectMenu) -> Self:
+        return cls(
+            custom_id=component.custom_id,
+            placeholder=component.placeholder,
+            min_values=component.min_values,
+            max_values=component.max_values,
+            disabled=component.disabled,
+            row=None,
+        )
+
+
+S_co = TypeVar("S_co", bound="RoleSelect", covariant=True)
+
+
+@overload
+def role_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = ...,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    row: Optional[int] = None,
+) -> Callable[[ItemCallbackType[RoleSelect[V_co]]], DecoratedItem[RoleSelect[V_co]]]:
+    ...
+
+
+@overload
+def role_select(
+    cls: Type[Object[S_co, P]], *_: P.args, **kwargs: P.kwargs
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    ...
+
+
+def role_select(
+    cls: Type[Object[S_co, P]] = RoleSelect[Any],
+    /,
+    **kwargs: Any,
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    """A decorator that attaches a role select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`disnake.ui.View`, the :class:`disnake.ui.RoleSelect` that was
+    interacted with, and the :class:`disnake.MessageInteraction`.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`RoleSelect.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    cls: Type[:class:`RoleSelect`]
+        The select subclass to create an instance of. If provided, the following parameters
+        described below do no apply. Instead, this decorator will accept the same keywords
+        as the passed cls does.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled. Defaults to ``False``.
+    """
+    return _create_decorator(cls, RoleSelect, **kwargs)

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -16,7 +16,7 @@ from typing import (
     overload,
 )
 
-from ...components import SelectMenu, SelectOption
+from ...components import SelectOption, StringSelectMenu
 from ...enums import ComponentType
 from ...utils import MISSING
 from .base import BaseSelect, P, V_co, _create_decorator
@@ -45,7 +45,7 @@ def _parse_select_options(options: SelectOptionInput) -> List[SelectOption]:
     return [opt if isinstance(opt, SelectOption) else SelectOption(label=opt) for opt in options]
 
 
-class Select(BaseSelect[SelectMenu, str, V_co]):
+class Select(BaseSelect[StringSelectMenu, str, V_co]):
     """Represents a UI string select menu.
 
     This is usually represented as a drop down menu.
@@ -133,7 +133,7 @@ class Select(BaseSelect[SelectMenu, str, V_co]):
         row: Optional[int] = None,
     ) -> None:
         super().__init__(
-            SelectMenu,
+            StringSelectMenu,
             ComponentType.string_select,
             custom_id=custom_id,
             placeholder=placeholder,
@@ -145,7 +145,7 @@ class Select(BaseSelect[SelectMenu, str, V_co]):
         self._underlying.options = [] if options is MISSING else _parse_select_options(options)
 
     @classmethod
-    def from_component(cls, component: SelectMenu) -> Self:
+    def from_component(cls, component: StringSelectMenu) -> Self:
         return cls(
             custom_id=component.custom_id,
             placeholder=component.placeholder,

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
 
 
 __all__ = (
-    "Select",
-    "select",
+    "StringSelect",
+    "string_select",
 )
 
 
@@ -45,7 +45,7 @@ def _parse_select_options(options: SelectOptionInput) -> List[SelectOption]:
     return [opt if isinstance(opt, SelectOption) else SelectOption(label=opt) for opt in options]
 
 
-class Select(BaseSelect[StringSelectMenu, str, V_co]):
+class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
     """Represents a UI string select menu.
 
     This is usually represented as a drop down menu.
@@ -53,6 +53,9 @@ class Select(BaseSelect[StringSelectMenu, str, V_co]):
     In order to get the selected items that the user has chosen, use :attr:`.values`.
 
     .. versionadded:: 2.0
+
+    .. versionchanged:: 2.7
+        Renamed from ``Select`` to ``StringSelect``.
 
     Parameters
     ----------
@@ -95,7 +98,7 @@ class Select(BaseSelect[StringSelectMenu, str, V_co]):
 
     @overload
     def __init__(
-        self: Select[None],
+        self: StringSelect[None],
         *,
         custom_id: str = ...,
         placeholder: Optional[str] = None,
@@ -109,7 +112,7 @@ class Select(BaseSelect[StringSelectMenu, str, V_co]):
 
     @overload
     def __init__(
-        self: Select[V_co],
+        self: StringSelect[V_co],
         *,
         custom_id: str = ...,
         placeholder: Optional[str] = None,
@@ -235,11 +238,11 @@ class Select(BaseSelect[StringSelectMenu, str, V_co]):
         self._underlying.options.append(option)
 
 
-S_co = TypeVar("S_co", bound="Select", covariant=True)
+S_co = TypeVar("S_co", bound="StringSelect", covariant=True)
 
 
 @overload
-def select(
+def string_select(
     *,
     placeholder: Optional[str] = None,
     custom_id: str = ...,
@@ -248,34 +251,37 @@ def select(
     options: SelectOptionInput = ...,
     disabled: bool = False,
     row: Optional[int] = None,
-) -> Callable[[ItemCallbackType[Select[V_co]]], DecoratedItem[Select[V_co]]]:
+) -> Callable[[ItemCallbackType[StringSelect[V_co]]], DecoratedItem[StringSelect[V_co]]]:
     ...
 
 
 @overload
-def select(
+def string_select(
     cls: Type[Object[S_co, P]], *_: P.args, **kwargs: P.kwargs
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
     ...
 
 
-def select(
-    cls: Type[Object[S_co, P]] = Select[Any],
+def string_select(
+    cls: Type[Object[S_co, P]] = StringSelect[Any],
     /,
     **kwargs: Any,
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
     """A decorator that attaches a string select menu to a component.
 
     The function being decorated should have three parameters, ``self`` representing
-    the :class:`disnake.ui.View`, the :class:`disnake.ui.Select` that was
+    the :class:`disnake.ui.View`, the :class:`disnake.ui.StringSelect` that was
     interacted with, and the :class:`disnake.MessageInteraction`.
 
     In order to get the selected items that the user has chosen within the callback
-    use :attr:`Select.values`.
+    use :attr:`StringSelect.values`.
+
+    .. versionchanged:: 2.7
+        Renamed from ``select`` to ``string_select``.
 
     Parameters
     ----------
-    cls: Type[:class:`Select`]
+    cls: Type[:class:`StringSelect`]
         The select subclass to create an instance of. If provided, the following parameters
         described below do no apply. Instead, this decorator will accept the same keywords
         as the passed cls does.
@@ -311,4 +317,4 @@ def select(
     disabled: :class:`bool`
         Whether the select is disabled. Defaults to ``False``.
     """
-    return _create_decorator(cls, Select, **kwargs)
+    return _create_decorator(cls, StringSelect, **kwargs)

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -134,7 +134,7 @@ class Select(BaseSelect[SelectMenu, str, V_co]):
     ) -> None:
         super().__init__(
             SelectMenu,
-            ComponentType.select,
+            ComponentType.string_select,
             custom_id=custom_id,
             placeholder=placeholder,
             min_values=min_values,

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -31,7 +31,9 @@ if TYPE_CHECKING:
 
 __all__ = (
     "StringSelect",
+    "Select",
     "string_select",
+    "select",
 )
 
 
@@ -238,6 +240,9 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         self._underlying.options.append(option)
 
 
+Select = StringSelect  # backwards compatibility
+
+
 S_co = TypeVar("S_co", bound="StringSelect", covariant=True)
 
 
@@ -318,3 +323,6 @@ def string_select(
         Whether the select is disabled. Defaults to ``False``.
     """
     return _create_decorator(cls, StringSelect, **kwargs)
+
+
+select = string_select  # backwards compatibility

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, overload
+
+from ...components import UserSelectMenu
+from ...enums import ComponentType
+from ...utils import MISSING
+from .base import BaseSelect, P, V_co, _create_decorator
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from ...member import Member
+    from ..item import DecoratedItem, ItemCallbackType, Object
+
+
+__all__ = (
+    "UserSelect",
+    "user_select",
+)
+
+
+# TODO: check if users can be sent as well
+class UserSelect(BaseSelect[UserSelectMenu, "Member", V_co]):
+    """Represents a UI user select menu.
+
+    This is usually represented as a drop down menu.
+
+    In order to get the selected items that the user has chosen, use :attr:`.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        If not given then one is generated for you.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+
+    Attributes
+    ----------
+    values: List[:class:`.Member`]
+        A list of members that have been selected by the user.
+    """
+
+    @overload
+    def __init__(
+        self: UserSelect[None],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self: UserSelect[V_co],
+        *,
+        custom_id: str = ...,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ):
+        ...
+
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+        row: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            UserSelectMenu,
+            ComponentType.user_select,
+            custom_id=custom_id,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            disabled=disabled,
+            row=row,
+        )
+
+    @classmethod
+    def from_component(cls, component: UserSelectMenu) -> Self:
+        return cls(
+            custom_id=component.custom_id,
+            placeholder=component.placeholder,
+            min_values=component.min_values,
+            max_values=component.max_values,
+            disabled=component.disabled,
+            row=None,
+        )
+
+
+S_co = TypeVar("S_co", bound="UserSelect", covariant=True)
+
+
+@overload
+def user_select(
+    *,
+    placeholder: Optional[str] = None,
+    custom_id: str = ...,
+    min_values: int = 1,
+    max_values: int = 1,
+    disabled: bool = False,
+    row: Optional[int] = None,
+) -> Callable[[ItemCallbackType[UserSelect[V_co]]], DecoratedItem[UserSelect[V_co]]]:
+    ...
+
+
+@overload
+def user_select(
+    cls: Type[Object[S_co, P]], *_: P.args, **kwargs: P.kwargs
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    ...
+
+
+def user_select(
+    cls: Type[Object[S_co, P]] = UserSelect[Any],
+    /,
+    **kwargs: Any,
+) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
+    """A decorator that attaches a user select menu to a component.
+
+    The function being decorated should have three parameters, ``self`` representing
+    the :class:`disnake.ui.View`, the :class:`disnake.ui.UserSelect` that was
+    interacted with, and the :class:`disnake.MessageInteraction`.
+
+    In order to get the selected items that the user has chosen within the callback
+    use :attr:`UserSelect.values`.
+
+    .. versionadded:: 2.7
+
+    Parameters
+    ----------
+    cls: Type[:class:`UserSelect`]
+        The select subclass to create an instance of. If provided, the following parameters
+        described below do no apply. Instead, this decorator will accept the same keywords
+        as the passed cls does.
+    placeholder: Optional[:class:`str`]
+        The placeholder text that is shown if nothing is selected, if any.
+    custom_id: :class:`str`
+        The ID of the select menu that gets received during an interaction.
+        It is recommended not to set this parameter to prevent conflicts.
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
+    min_values: :class:`int`
+        The minimum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    max_values: :class:`int`
+        The maximum number of items that must be chosen for this select menu.
+        Defaults to 1 and must be between 1 and 25.
+    disabled: :class:`bool`
+        Whether the select is disabled. Defaults to ``False``.
+    """
+    return _create_decorator(cls, UserSelect, **kwargs)

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, TypeVar, Union, overload
 
 from ...components import UserSelectMenu
 from ...enums import ComponentType
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from ...member import Member
+    from ...user import User
     from ..item import DecoratedItem, ItemCallbackType, Object
 
 
@@ -22,8 +23,7 @@ __all__ = (
 )
 
 
-# TODO: check if users can be sent as well
-class UserSelect(BaseSelect[UserSelectMenu, "Member", V_co]):
+class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
     """Represents a UI user select menu.
 
     This is usually represented as a drop down menu.
@@ -56,8 +56,8 @@ class UserSelect(BaseSelect[UserSelectMenu, "Member", V_co]):
 
     Attributes
     ----------
-    values: List[:class:`.Member`]
-        A list of members that have been selected by the user.
+    values: List[:class:`~disnake.User`, :class:`.Member`]
+        A list of users/members that have been selected by the user.
     """
 
     @overload

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -25,7 +25,7 @@ from ..components import (
     ActionRow as ActionRowComponent,
     Button as ButtonComponent,
     MessageComponent,
-    SelectMenu as SelectComponent,
+    StringSelectMenu as StringSelectComponent,
     _component_factory,
 )
 from ..enums import ComponentType, try_enum_to_int
@@ -57,7 +57,7 @@ def _component_to_item(component: MessageComponent) -> Item:
         from .button import Button
 
         return Button.from_component(component)
-    if isinstance(component, SelectComponent):
+    if isinstance(component, StringSelectComponent):
         from .select import Select
 
         return Select.from_component(component)

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -58,9 +58,9 @@ def _component_to_item(component: MessageComponent) -> Item:
 
         return Button.from_component(component)
     if isinstance(component, StringSelectComponent):
-        from .select import Select
+        from .select import StringSelect
 
-        return Select.from_component(component)
+        return StringSelect.from_component(component)
 
     assert_never(component)
     return Item.from_component(component)

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -24,8 +24,12 @@ from typing import (
 from ..components import (
     ActionRow as ActionRowComponent,
     Button as ButtonComponent,
+    ChannelSelectMenu as ChannelSelectComponent,
+    MentionableSelectMenu as MentionableSelectComponent,
     MessageComponent,
+    RoleSelectMenu as RoleSelectComponent,
     StringSelectMenu as StringSelectComponent,
+    UserSelectMenu as UserSelectComponent,
     _component_factory,
 )
 from ..enums import ComponentType, try_enum_to_int
@@ -61,6 +65,22 @@ def _component_to_item(component: MessageComponent) -> Item:
         from .select import StringSelect
 
         return StringSelect.from_component(component)
+    if isinstance(component, UserSelectComponent):
+        from .select import UserSelect
+
+        return UserSelect.from_component(component)
+    if isinstance(component, RoleSelectComponent):
+        from .select import RoleSelect
+
+        return RoleSelect.from_component(component)
+    if isinstance(component, MentionableSelectComponent):
+        from .select import MentionableSelect
+
+        return MentionableSelect.from_component(component)
+    if isinstance(component, ChannelSelectComponent):
+        from .select import ChannelSelect
+
+        return ChannelSelect.from_component(component)
 
     assert_never(component)
     return Item.from_component(component)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2023,6 +2023,9 @@ of :class:`enum.Enum`.
     .. attribute:: string_select
 
         Represents a string select component.
+    .. attribute:: select
+
+        An alias of :attr:`string_select`.
     .. attribute:: text_input
 
         Represents a text input component.
@@ -6004,6 +6007,11 @@ ActionRow
 
 .. autoclass:: disnake.ui.ActionRow
     :members:
+    :exclude-members: add_select
+
+    .. method:: add_select
+
+        Alias of :func:`~disnake.ui.ActionRow.add_string_select`.
 
 Item
 ~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2026,6 +2026,18 @@ of :class:`enum.Enum`.
     .. attribute:: text_input
 
         Represents a text input component.
+    .. attribute:: user_select
+
+        Represents a user select component.
+    .. attribute:: role_select
+
+        Represents a role select component.
+    .. attribute:: mentionable_select
+
+        Represents a mentionable (user/role) select component.
+    .. attribute:: channel_select
+
+        Represents a channel select component.
 
 .. class:: OptionType
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4879,6 +4879,42 @@ StringSelectMenu
     :members:
     :inherited-members:
 
+UserSelectMenu
+~~~~~~~~~~~~~~
+
+.. attributetable:: UserSelectMenu
+
+.. autoclass:: UserSelectMenu()
+    :members:
+    :inherited-members:
+
+RoleSelectMenu
+~~~~~~~~~~~~~~
+
+.. attributetable:: RoleSelectMenu
+
+.. autoclass:: RoleSelectMenu()
+    :members:
+    :inherited-members:
+
+MentionableSelectMenu
+~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: MentionableSelectMenu
+
+.. autoclass:: MentionableSelectMenu()
+    :members:
+    :inherited-members:
+
+ChannelSelectMenu
+~~~~~~~~~~~~~~~~~
+
+.. attributetable:: ChannelSelectMenu
+
+.. autoclass:: ChannelSelectMenu()
+    :members:
+    :inherited-members:
+
 TextInput
 ~~~~~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6052,6 +6052,50 @@ StringSelect
 
 .. autofunction:: disnake.ui.string_select(cls=disnake.ui.StringSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, options=..., disabled=False, row=None)
 
+UserSelect
+~~~~~~~~~~~
+
+.. attributetable:: disnake.ui.UserSelect
+
+.. autoclass:: disnake.ui.UserSelect
+    :members:
+    :inherited-members:
+
+.. autofunction:: disnake.ui.user_select(cls=disnake.ui.UserSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
+
+RoleSelect
+~~~~~~~~~~~
+
+.. attributetable:: disnake.ui.RoleSelect
+
+.. autoclass:: disnake.ui.RoleSelect
+    :members:
+    :inherited-members:
+
+.. autofunction:: disnake.ui.role_select(cls=disnake.ui.RoleSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
+
+MentionableSelect
+~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: disnake.ui.MentionableSelect
+
+.. autoclass:: disnake.ui.MentionableSelect
+    :members:
+    :inherited-members:
+
+.. autofunction:: disnake.ui.mentionable_select(cls=disnake.ui.MentionableSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
+
+ChannelSelect
+~~~~~~~~~~~~~~
+
+.. attributetable:: disnake.ui.ChannelSelect
+
+.. autoclass:: disnake.ui.ChannelSelect
+    :members:
+    :inherited-members:
+
+.. autofunction:: disnake.ui.channel_select(cls=disnake.ui.ChannelSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, channel_types=None, row=None)
+
 Modal
 ~~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2023,6 +2023,8 @@ of :class:`enum.Enum`.
     .. attribute:: string_select
 
         Represents a string select component.
+
+        .. versionadded:: 2.7
     .. attribute:: select
 
         An alias of :attr:`string_select`.
@@ -2032,15 +2034,23 @@ of :class:`enum.Enum`.
     .. attribute:: user_select
 
         Represents a user select component.
+
+        .. versionadded:: 2.7
     .. attribute:: role_select
 
         Represents a role select component.
+
+        .. versionadded:: 2.7
     .. attribute:: mentionable_select
 
-        Represents a mentionable (user/role) select component.
+        Represents a mentionable (user/member/role) select component.
+
+        .. versionadded:: 2.7
     .. attribute:: channel_select
 
         Represents a channel select component.
+
+        .. versionadded:: 2.7
 
 .. class:: OptionType
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4858,12 +4858,12 @@ BaseSelectMenu
     :members:
     :inherited-members:
 
-SelectMenu
-~~~~~~~~~~~
+StringSelectMenu
+~~~~~~~~~~~~~~~~~
 
-.. attributetable:: SelectMenu
+.. attributetable:: StringSelectMenu
 
-.. autoclass:: SelectMenu()
+.. autoclass:: StringSelectMenu()
     :members:
     :inherited-members:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5993,16 +5993,16 @@ BaseSelect
     :members:
     :inherited-members:
 
-Select
-~~~~~~~
+StringSelect
+~~~~~~~~~~~~~
 
-.. attributetable:: disnake.ui.Select
+.. attributetable:: disnake.ui.StringSelect
 
-.. autoclass:: disnake.ui.Select
+.. autoclass:: disnake.ui.StringSelect
     :members:
     :inherited-members:
 
-.. autofunction:: disnake.ui.select(cls=disnake.ui.Select, *, custom_id=..., placeholder=None, min_values=1, max_values=1, options=..., disabled=False, row=None)
+.. autofunction:: disnake.ui.string_select(cls=disnake.ui.StringSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, options=..., disabled=False, row=None)
 
 Modal
 ~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2020,9 +2020,9 @@ of :class:`enum.Enum`.
     .. attribute:: button
 
         Represents a button component.
-    .. attribute:: select
+    .. attribute:: string_select
 
-        Represents a select component.
+        Represents a string select component.
     .. attribute:: text_input
 
         Represents a text input component.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4883,6 +4883,33 @@ BaseSelectMenu
     :members:
     :inherited-members:
 
+ChannelSelectMenu
+~~~~~~~~~~~~~~~~~
+
+.. attributetable:: ChannelSelectMenu
+
+.. autoclass:: ChannelSelectMenu()
+    :members:
+    :inherited-members:
+
+MentionableSelectMenu
+~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: MentionableSelectMenu
+
+.. autoclass:: MentionableSelectMenu()
+    :members:
+    :inherited-members:
+
+RoleSelectMenu
+~~~~~~~~~~~~~~
+
+.. attributetable:: RoleSelectMenu
+
+.. autoclass:: RoleSelectMenu()
+    :members:
+    :inherited-members:
+
 StringSelectMenu
 ~~~~~~~~~~~~~~~~~
 
@@ -4898,33 +4925,6 @@ UserSelectMenu
 .. attributetable:: UserSelectMenu
 
 .. autoclass:: UserSelectMenu()
-    :members:
-    :inherited-members:
-
-RoleSelectMenu
-~~~~~~~~~~~~~~
-
-.. attributetable:: RoleSelectMenu
-
-.. autoclass:: RoleSelectMenu()
-    :members:
-    :inherited-members:
-
-MentionableSelectMenu
-~~~~~~~~~~~~~~~~~~~~~
-
-.. attributetable:: MentionableSelectMenu
-
-.. autoclass:: MentionableSelectMenu()
-    :members:
-    :inherited-members:
-
-ChannelSelectMenu
-~~~~~~~~~~~~~~~~~
-
-.. attributetable:: ChannelSelectMenu
-
-.. autoclass:: ChannelSelectMenu()
     :members:
     :inherited-members:
 
@@ -6055,6 +6055,39 @@ BaseSelect
     :members:
     :inherited-members:
 
+ChannelSelect
+~~~~~~~~~~~~~~
+
+.. attributetable:: disnake.ui.ChannelSelect
+
+.. autoclass:: disnake.ui.ChannelSelect
+    :members:
+    :inherited-members:
+
+.. autofunction:: disnake.ui.channel_select(cls=disnake.ui.ChannelSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, channel_types=None, row=None)
+
+MentionableSelect
+~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: disnake.ui.MentionableSelect
+
+.. autoclass:: disnake.ui.MentionableSelect
+    :members:
+    :inherited-members:
+
+.. autofunction:: disnake.ui.mentionable_select(cls=disnake.ui.MentionableSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
+
+RoleSelect
+~~~~~~~~~~~
+
+.. attributetable:: disnake.ui.RoleSelect
+
+.. autoclass:: disnake.ui.RoleSelect
+    :members:
+    :inherited-members:
+
+.. autofunction:: disnake.ui.role_select(cls=disnake.ui.RoleSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
+
 StringSelect
 ~~~~~~~~~~~~~
 
@@ -6076,39 +6109,6 @@ UserSelect
     :inherited-members:
 
 .. autofunction:: disnake.ui.user_select(cls=disnake.ui.UserSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
-
-RoleSelect
-~~~~~~~~~~~
-
-.. attributetable:: disnake.ui.RoleSelect
-
-.. autoclass:: disnake.ui.RoleSelect
-    :members:
-    :inherited-members:
-
-.. autofunction:: disnake.ui.role_select(cls=disnake.ui.RoleSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
-
-MentionableSelect
-~~~~~~~~~~~~~~~~~~
-
-.. attributetable:: disnake.ui.MentionableSelect
-
-.. autoclass:: disnake.ui.MentionableSelect
-    :members:
-    :inherited-members:
-
-.. autofunction:: disnake.ui.mentionable_select(cls=disnake.ui.MentionableSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, row=None)
-
-ChannelSelect
-~~~~~~~~~~~~~~
-
-.. attributetable:: disnake.ui.ChannelSelect
-
-.. autoclass:: disnake.ui.ChannelSelect
-    :members:
-    :inherited-members:
-
-.. autofunction:: disnake.ui.channel_select(cls=disnake.ui.ChannelSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, channel_types=None, row=None)
 
 Modal
 ~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6019,10 +6019,6 @@ ActionRow
     :members:
     :exclude-members: add_select
 
-    .. method:: add_select
-
-        Alias of :func:`~disnake.ui.ActionRow.add_string_select`.
-
 Item
 ~~~~~~~
 

--- a/examples/interactions/low_level_components.py
+++ b/examples/interactions/low_level_components.py
@@ -33,7 +33,7 @@ async def send_button(ctx: commands.Context):
 async def send_select(ctx: commands.Context):
     await ctx.send(
         "Here's a select!",
-        components=disnake.ui.Select(options=["1", "2", "3"], custom_id="cool_select"),
+        components=disnake.ui.StringSelect(options=["1", "2", "3"], custom_id="cool_select"),
     )
 
 

--- a/examples/views/select/dropdown.py
+++ b/examples/views/select/dropdown.py
@@ -6,9 +6,9 @@ import disnake
 from disnake.ext import commands
 
 
-# Defines a custom Select containing colour options that the user can choose.
+# Defines a custom StringSelect containing colour options that the user can choose.
 # The callback function of this class is called when the user changes their choice.
-class Dropdown(disnake.ui.Select):
+class Dropdown(disnake.ui.StringSelect):
     def __init__(self):
         # Define the options that will be presented inside the dropdown
         options = [
@@ -36,7 +36,7 @@ class Dropdown(disnake.ui.Select):
     async def callback(self, inter: disnake.MessageInteraction):
         # Use the interaction object to send a response message containing
         # the user's favourite colour or choice. The `self` object refers to the
-        # Select object, and the `values` attribute gets a list of the user's
+        # StringSelect object, and the `values` attribute gets a list of the user's
         # selected options. We only want the first one.
         await inter.response.send_message(f"Your favourite colour is {self.values[0]}")
 

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 
 import disnake
-from disnake.ui import ActionRow, Button, Select, TextInput, WrappedComponent
+from disnake.ui import ActionRow, Button, StringSelect, TextInput, WrappedComponent
 from disnake.ui.action_row import components_to_dict, components_to_rows
 
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 button1 = Button()
 button2 = Button()
 button3 = Button()
-select = Select()
+select = StringSelect()
 text_input = TextInput(label="a", custom_id="b")
 
 
@@ -79,15 +79,15 @@ class TestActionRow:
 
     def test_add_select(self):
         r = ActionRow.with_message_components()
-        r.add_select(custom_id="asdf")
+        r.add_string_select(custom_id="asdf")
 
         (c,) = r.children
-        assert isinstance(c, Select)
+        assert isinstance(c, StringSelect)
         assert c.custom_id == "asdf"
 
         if TYPE_CHECKING:
-            ActionRow().add_select
-            ActionRow.with_message_components().add_select
+            ActionRow().add_string_select
+            ActionRow.with_message_components().add_string_select
             # should not work  # TODO: revert when modal select support is added.
             ActionRow.with_modal_components().add_select  # type: ignore
 

--- a/tests/ui/test_decorators.py
+++ b/tests/ui/test_decorators.py
@@ -37,15 +37,15 @@ class TestDecorator:
             assert func.__discord_ui_model_type__ is ui.Button
             assert func.__discord_ui_model_kwargs__ == {"custom_id": "123"}
 
-        with create_callback(ui.Select) as func:
-            res = ui.select(custom_id="123")(func)
-            assert_type(res, ui.item.DecoratedItem[ui.Select])
+        with create_callback(ui.StringSelect) as func:
+            res = ui.string_select(custom_id="123")(func)
+            assert_type(res, ui.item.DecoratedItem[ui.StringSelect])
 
-            assert func.__discord_ui_model_type__ is ui.Select
+            assert func.__discord_ui_model_type__ is ui.StringSelect
             assert func.__discord_ui_model_kwargs__ == {"custom_id": "123"}
 
     # from here on out we're only testing the button decorator,
-    # as @ui.select works identically
+    # as @ui.string_select etc. works identically
 
     @pytest.mark.parametrize("cls", [_CustomButton, _CustomButton[Any]])
     def test_cls(self, cls: Type[_CustomButton]) -> None:
@@ -64,7 +64,7 @@ class TestDecorator:
             this_should_not_work="h",  # type: ignore
         )
 
-    @pytest.mark.parametrize("cls", [123, int, ui.Select])
+    @pytest.mark.parametrize("cls", [123, int, ui.StringSelect])
     def test_cls_invalid(self, cls) -> None:
         with pytest.raises(TypeError, match=r"cls argument must be"):
             ui.button(cls=cls)  # type: ignore


### PR DESCRIPTION
## Summary

Adds new select menu components/items, with <sup><sub>almost</sub></sup> everything there is to it (component types, methods, decorators, ...).

This is a draft PR for several reasons:
- ~~It depends on #800, which is currently set as the base branch to get a clean diff.~~
- ~~It depends on #801, which is currently merged into this branch to avoid merge conflicts later on.~~
- ~~I haven't added backwards-compatible aliases yet, but that'll be easy enough once everything else is settled.~~
- ~~Depends on #814 for the `resolved` field, currently set as base branch.~~
- May want to consider fixing the `Select.values` issue with concurrent interactions.

Resolves #798.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
