### PR TITLE
fix: don't provide a default clean history duration as that makes the delete_message_days parameter unusable

### DIFF
--- a/changelog/810.bugfix.rst
+++ b/changelog/810.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue with :meth:`Member.ban` erroring when the ``delete_message_days`` parameter was provided.

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -720,7 +720,7 @@ class Member(disnake.abc.Messageable, _UserTag):
     async def ban(
         self,
         *,
-        clean_history_duration: Union[int, datetime.timedelta] = 86400,
+        clean_history_duration: Union[int, datetime.timedelta] = MISSING,
         delete_message_days: Literal[0, 1, 2, 3, 4, 5, 6, 7] = MISSING,
         reason: Optional[str] = None,
     ) -> None:


### PR DESCRIPTION
## Summary

The `Member.ban` method was providing a default to clean_duration
which causes an issue when anyone attempts to use
`delete_message_days`, essentially *not* including a deprecation
period for `delete_message_days`. This simply removes the default of
86400 seconds as that default is already provided in the `Guild.ban`
method, which is used internally by `Member.ban`.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
