### PR TITLE
feat: support `delete_after` for ephemeral messages

### DIFF
--- a/changelog/816.feature.rst
+++ b/changelog/816.feature.rst
@@ -1,0 +1,1 @@
+Support ``delete_after`` parameter when sending ephemeral interaction responses.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -619,8 +619,11 @@ class Interaction:
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
 
+            Can be up to 15 minutes, after which the interaction token expires
+            (see also :attr:`expires_at`/:attr:`is_expired`).
+
             .. versionchanged:: 2.7
-                Added support for ephemeral messages.
+                Added support for ephemeral responses.
 
         Raises
         ------
@@ -861,8 +864,11 @@ class InteractionResponse:
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
 
+            Can be up to 15 minutes, after which the interaction token expires
+            (see also :attr:`Interaction.expires_at`/:attr:`~Interaction.is_expired`).
+
             .. versionchanged:: 2.7
-                Added support for ephemeral messages.
+                Added support for ephemeral responses.
 
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This hides

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -619,7 +619,7 @@ class Interaction:
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
 
-            Can be up to 15 minutes, after which the interaction token expires
+            Can be up to 15 minutes after the interaction was created
             (see also :attr:`expires_at`/:attr:`is_expired`).
 
             .. versionchanged:: 2.7
@@ -864,7 +864,7 @@ class InteractionResponse:
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
 
-            Can be up to 15 minutes, after which the interaction token expires
+            Can be up to 15 minutes after the interaction was created
             (see also :attr:`Interaction.expires_at`/:attr:`~Interaction.is_expired`).
 
             .. versionchanged:: 2.7

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -882,9 +882,6 @@ class InteractionResponse:
             "tts": tts,
         }
 
-        if delete_after is not MISSING and ephemeral:
-            raise ValueError("ephemeral messages can not be deleted via endpoints")
-
         if embed is not MISSING and embeds is not MISSING:
             raise TypeError("cannot mix embed and embeds keyword arguments")
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -619,6 +619,9 @@ class Interaction:
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
 
+            .. versionchanged:: 2.7
+                Added support for ephemeral messages.
+
         Raises
         ------
         HTTPException
@@ -857,6 +860,9 @@ class InteractionResponse:
             If provided, the number of seconds to wait in the background
             before deleting the message we just sent. If the deletion fails,
             then it is silently ignored.
+
+            .. versionchanged:: 2.7
+                Added support for ephemeral messages.
 
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This hides

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1622,9 +1622,6 @@ class Webhook(BaseWebhook):
         if ephemeral and not application_webhook:
             raise TypeError("ephemeral messages can only be sent from application webhooks")
 
-        if delete_after is not MISSING and ephemeral:
-            raise TypeError("ephemeral messages can not be deleted via endpoints")
-
         if application_webhook or delete_after is not MISSING:
             wait = True
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1580,7 +1580,7 @@ class Webhook(BaseWebhook):
             .. versionadded:: 2.1
 
             .. versionchanged:: 2.7
-                Added support for ephemeral messages.
+                Added support for ephemeral interaction responses.
 
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This hides

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1579,6 +1579,9 @@ class Webhook(BaseWebhook):
 
             .. versionadded:: 2.1
 
+            .. versionchanged:: 2.7
+                Added support for ephemeral messages.
+
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This hides
             all embeds from the UI if set to ``True``.


### PR DESCRIPTION
## Summary

The API recently started supporting `DELETE /webhooks/.../@original`; `inter.delete_original_response()` already works fine, however `inter.response.send_message(delete_after=)` didn't.

Not sure if this should be considered a bugfix instead of a feature.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
