### PR TITLE
ci: update actions/packages to avoid deprecation warnings

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Update pip, wheel
       shell: bash
-      run: pip install -U pip wheel
+      run: pip install -U pip wheel setuptools
 
     - name: Install dependencies
       if: inputs.nox-setup || inputs.dependencies

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Set up python ${{ inputs.python-version }}
       id: setup-python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
         cache: "pip"

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -38,7 +38,7 @@ runs:
         cache: "pip"
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
-    - name: Update pip, wheel
+    - name: Update pip, wheel, setuptools
       shell: bash
       run: pip install -U pip wheel setuptools
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -37,6 +37,11 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: "pip"
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Update pip, wheel
+      shell: bash
+      run: pip install -U pip wheel
+
     - name: Install dependencies
       if: inputs.nox-setup || inputs.dependencies
       env:
@@ -52,6 +57,7 @@ runs:
         elif [ -n "$NOX_SETUP" ]; then
           nox -s setup -- $NOX_SETUP
         fi
+
     - name: Set python version
       id: python-version
       shell: bash

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -56,4 +56,4 @@ runs:
       id: python-version
       shell: bash
       run: |
-        echo "::set-output name=python-version::$(python -c 'import sys; print(".".join(map(str,sys.version_info[:2])))')"
+        echo "python-version=$(python -c 'import sys; print(".".join(map(str,sys.version_info[:2])))')" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -107,7 +107,7 @@ jobs:
         echo "PYRIGHT_VERSION=$PYRIGHT_VERSION" >> $GITHUB_ENV
 
     - name: Run pyright (Linux)
-      uses: jakebailey/pyright-action@v1.0.3
+      uses: jakebailey/pyright-action@v1.4.1
       with:
         version: ${{ env.PYRIGHT_VERSION }}
         python-version: ${{ steps.setup-env.outputs.python-version }}
@@ -116,7 +116,7 @@ jobs:
         warnings: true
 
     - name: Run pyright (Windows)
-      uses: jakebailey/pyright-action@v1.0.3
+      uses: jakebailey/pyright-action@v1.4.1
       if: ${{ success() || failure() }}  # run regardless of previous step's result
       with:
         version: ${{ env.PYRIGHT_VERSION }}


### PR DESCRIPTION
## Summary

Updates `actions/setup-python` to v4, as GitHub recently deprecated `::save-state` and `::set-output`:
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

pip also started emitting deprecation warnings for legacy builds, which as far as I know is resolved by just installing `wheel`:
> DEPRECATION: livereload is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
