### PR TITLE
fix: only send `rate_limit_per_user` parameter on thread creation if required

### DIFF
--- a/changelog/818.bugfix.rst
+++ b/changelog/818.bugfix.rst
@@ -1,0 +1,1 @@
+Fix creation of threads in text channels without :attr:`Permissions.manage_threads`.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -871,10 +871,10 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
             .. versionadded:: 2.3
 
-        slowmode_delay: :class:`int`
+        slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
-            If not provided, slowmode is disabled.
+            If not provided or ``None``, slowmode is inherited from the parent channel.
 
             .. versionadded:: 2.3
 
@@ -908,7 +908,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
                 auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
                 type=type.value,  # type: ignore
                 invitable=invitable if invitable is not None else True,
-                rate_limit_per_user=slowmode_delay or 0,
+                rate_limit_per_user=slowmode_delay,
                 reason=reason,
             )
         else:
@@ -917,7 +917,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
                 message.id,
                 name=name,
                 auto_archive_duration=auto_archive_duration or self.default_auto_archive_duration,
-                rate_limit_per_user=slowmode_delay or 0,
+                rate_limit_per_user=slowmode_delay,
                 reason=reason,
             )
 

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -874,7 +874,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
-            If not provided or ``None``, slowmode is inherited from the parent channel.
+            If set to ``None`` or not provided, slowmode is inherited from the parent channel.
 
             .. versionadded:: 2.3
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1066,7 +1066,7 @@ class HTTPClient:
         *,
         name: str,
         auto_archive_duration: threads.ThreadArchiveDurationLiteral,
-        rate_limit_per_user: int = 0,
+        rate_limit_per_user: Optional[int] = None,
         reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
         payload = {
@@ -1091,7 +1091,7 @@ class HTTPClient:
         auto_archive_duration: threads.ThreadArchiveDurationLiteral,
         type: threads.ThreadType,
         invitable: bool = True,
-        rate_limit_per_user: int = 0,
+        rate_limit_per_user: Optional[int] = None,
         reason: Optional[str] = None,
     ) -> Response[threads.Thread]:
         payload = {

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1072,8 +1072,10 @@ class HTTPClient:
         payload = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
-            "rate_limit_per_user": rate_limit_per_user,
         }
+
+        if rate_limit_per_user is not None:
+            payload["rate_limit_per_user"] = rate_limit_per_user
 
         route = Route(
             "POST",
@@ -1099,8 +1101,10 @@ class HTTPClient:
             "auto_archive_duration": auto_archive_duration,
             "type": type,
             "invitable": invitable,
-            "rate_limit_per_user": rate_limit_per_user,
         }
+
+        if rate_limit_per_user is not None:
+            payload["rate_limit_per_user"] = rate_limit_per_user
 
         route = Route("POST", "/channels/{channel_id}/threads", channel_id=channel_id)
         return self.request(route, json=payload, reason=reason)

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1879,10 +1879,10 @@ class Message(Hashable):
             The duration in minutes before a thread is automatically archived for inactivity.
             If not provided, the channel's default auto archive duration is used.
             Must be one of ``60``, ``1440``, ``4320``, or ``10080``.
-        slowmode_delay: :class:`int`
+        slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
-            If not provided, slowmode is disabled.
+            If not provided or ``None``, slowmode is inherited from the parent channel.
 
             .. versionadded:: 2.3
 
@@ -1921,7 +1921,7 @@ class Message(Hashable):
             self.id,
             name=name,
             auto_archive_duration=auto_archive_duration or default_auto_archive_duration,
-            rate_limit_per_user=slowmode_delay or 0,
+            rate_limit_per_user=slowmode_delay,
             reason=reason,
         )
         return Thread(guild=self.guild, state=self._state, data=data)

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1882,7 +1882,7 @@ class Message(Hashable):
         slowmode_delay: Optional[:class:`int`]
             Specifies the slowmode rate limit for users in this thread, in seconds.
             A value of ``0`` disables slowmode. The maximum value possible is ``21600``.
-            If not provided or ``None``, slowmode is inherited from the parent channel.
+            If set to ``None`` or not provided, slowmode is inherited from the parent channel.
 
             .. versionadded:: 2.3
 


### PR DESCRIPTION
## Summary

#746 2: electric boogaloo

It appears that text channels now support `default_thread_rate_limit_per_user` like forum channels (which, funnily enough, is documented in the api docs, since it was incorrectly documented initially and never removed).

This API change unfortunately breaks `channel.create_thread`/`message.create_thread` without `manage_threads` permissions, when the parent channel's `default_thread_rate_limit_per_user` is not `0`. Instead of sending `rate_limit_per_user: 0` by default, we want to inherit the parent's value now.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
