### PR TITLE
fix: fix off-by-one error in `AutoModKeywordPresets`

### DIFF
--- a/changelog/820.bugfix.rst
+++ b/changelog/820.bugfix.rst
@@ -1,0 +1,1 @@
+Fix off-by-one error in :class:`AutoModKeywordPresets` values.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -2099,18 +2099,18 @@ class AutoModKeywordPresets(ListBaseFlags):
         """:class:`bool`: Returns ``True`` if the profanity preset is enabled
         (contains words that may be considered swearing or cursing).
         """
-        return 1 << 0
+        return 1 << 1
 
     @flag_value
     def sexual_content(self):
         """:class:`bool`: Returns ``True`` if the sexual content preset is enabled
         (contains sexually explicit words).
         """
-        return 1 << 1
+        return 1 << 2
 
     @flag_value
     def slurs(self):
         """:class:`bool`: Returns ``True`` if the slurs preset is enabled
         (contains insults or words that may be considered hate speech).
         """
-        return 1 << 2
+        return 1 << 3


### PR DESCRIPTION
## Summary

Somehow missed this while testing, probably when `ListBaseFlags` got refactored. The API expects `1, 2, 3`, while the library would previously use `0, 1, 2` instead.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
