### PR TITLE
fix: optional variadic arguments no longer can be stuck in infinite loops

### DIFF
--- a/changelog/825.bugfix.rst
+++ b/changelog/825.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Fix a case where optional variadic arguments could have infinite loops in parsing depending on the user input.

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -576,7 +576,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             try:
                 argument = view.get_quoted_word()
             except ArgumentParsingError as exc:
-                if self._is_typing_optional(param.annotation):
+                if (
+                    self._is_typing_optional(param.annotation)
+                    and not param.kind == param.VAR_POSITIONAL
+                ):
                     view.index = previous
                     return None
                 else:


### PR DESCRIPTION
## Summary

prevents optional variadic arguments (*args: Optional[str]) from being stuck in infinite loops in specific cases.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
