### PR TITLE
backport(2.6): optional variadic arguments no longer can be stuck in infinite loops

### DIFF
--- a/changelog/825.bugfix.rst
+++ b/changelog/825.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Fix a case where optional variadic arguments could have infinite loops in parsing depending on the user input.

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -576,7 +576,10 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             try:
                 argument = view.get_quoted_word()
             except ArgumentParsingError as exc:
-                if self._is_typing_optional(param.annotation):
+                if (
+                    self._is_typing_optional(param.annotation)
+                    and not param.kind == param.VAR_POSITIONAL
+                ):
                     view.index = previous
                     return None
                 else:


### PR DESCRIPTION

## Summary

backport of #825
