### PR TITLE
feat: allow suppressing embeds when editing an interaction response

### DIFF
--- a/changelog/832.feature.rst
+++ b/changelog/832.feature.rst
@@ -1,0 +1,1 @@
+Add ``suppress_embeds`` parameter to :func:`Interaction.edit_original_response`.

--- a/changelog/832.feature.rst
+++ b/changelog/832.feature.rst
@@ -1,1 +1,1 @@
-Add ``suppress_embeds`` parameter to :func:`Interaction.edit_original_response`.
+Add ``suppress_embeds`` parameter to :meth:`Interaction.edit_original_response` and :meth:`InteractionMessage.edit`.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1561,7 +1561,6 @@ class InteractionMessage(Message):
             Whether to suppress embeds for the message. This removes
             all the embeds if set to ``True``. If set to ``False``
             this brings the embeds back if they were suppressed.
-            Using this parameter requires :attr:`~.Permissions.manage_messages`.
 
             .. versionadded:: 2.7
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1442,6 +1442,7 @@ class InteractionMessage(Message):
         embed: Optional[Embed] = ...,
         file: File = ...,
         attachments: Optional[List[Attachment]] = ...,
+        suppress_embeds: bool = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
         components: Optional[Components[MessageUIComponent]] = ...,
@@ -1456,6 +1457,7 @@ class InteractionMessage(Message):
         embed: Optional[Embed] = ...,
         files: List[File] = ...,
         attachments: Optional[List[Attachment]] = ...,
+        suppress_embeds: bool = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
         components: Optional[Components[MessageUIComponent]] = ...,
@@ -1470,6 +1472,7 @@ class InteractionMessage(Message):
         embeds: List[Embed] = ...,
         file: File = ...,
         attachments: Optional[List[Attachment]] = ...,
+        suppress_embeds: bool = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
         components: Optional[Components[MessageUIComponent]] = ...,
@@ -1484,6 +1487,7 @@ class InteractionMessage(Message):
         embeds: List[Embed] = ...,
         files: List[File] = ...,
         attachments: Optional[List[Attachment]] = ...,
+        suppress_embeds: bool = ...,
         allowed_mentions: Optional[AllowedMentions] = ...,
         view: Optional[View] = ...,
         components: Optional[Components[MessageUIComponent]] = ...,
@@ -1499,6 +1503,7 @@ class InteractionMessage(Message):
         file: File = MISSING,
         files: List[File] = MISSING,
         attachments: Optional[List[Attachment]] = MISSING,
+        suppress_embeds: bool = MISSING,
         allowed_mentions: Optional[AllowedMentions] = MISSING,
         view: Optional[View] = MISSING,
         components: Optional[Components[MessageUIComponent]] = MISSING,
@@ -1552,6 +1557,14 @@ class InteractionMessage(Message):
 
             .. versionadded:: 2.4
 
+        suppress_embeds: :class:`bool`
+            Whether to suppress embeds for the message. This removes
+            all the embeds if set to ``True``. If set to ``False``
+            this brings the embeds back if they were suppressed.
+            Using this parameter requires :attr:`~.Permissions.manage_messages`.
+
+            .. versionadded:: 2.7
+
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
@@ -1583,6 +1596,7 @@ class InteractionMessage(Message):
                 embeds=embeds,
                 files=files,
                 attachments=attachments,
+                suppress_embeds=suppress_embeds,
                 allowed_mentions=allowed_mentions,
                 view=view,
                 components=components,
@@ -1602,6 +1616,7 @@ class InteractionMessage(Message):
             file=file,
             files=files,
             attachments=attachments,
+            suppress_embeds=suppress_embeds,
             allowed_mentions=allowed_mentions,
             view=view,
             components=components,

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -381,6 +381,7 @@ class Interaction:
         attachments: Optional[List[Attachment]] = MISSING,
         view: Optional[View] = MISSING,
         components: Optional[Components[MessageUIComponent]] = MISSING,
+        suppress_embeds: bool = MISSING,
         allowed_mentions: Optional[AllowedMentions] = None,
     ) -> InteractionMessage:
         """|coro|
@@ -446,6 +447,12 @@ class Interaction:
             Controls the mentions being processed in this message.
             See :meth:`.abc.Messageable.send` for more information.
 
+        suppress_embeds: :class:`bool`
+            Whether to suppress embeds for the message. This hides
+            all embeds from the UI if set to ``True``.
+
+            .. versionadded:: 2.7
+
         Raises
         ------
         HTTPException
@@ -477,6 +484,7 @@ class Interaction:
             embeds=embeds,
             view=view,
             components=components,
+            suppress_embeds=suppress_embeds,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
         )


### PR DESCRIPTION
## Summary

implements https://github.com/discord/discord-api-docs/issues/4784

followup to #474

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
