### PR TITLE
feat: add `_MissingSentinel.__hash__`

### DIFF
--- a/disnake/ext/commands/flag_converter.py
+++ b/disnake/ext/commands/flag_converter.py
@@ -74,13 +74,13 @@ class Flag:
         Whether multiple given values overrides the previous value.
     """
 
-    name: str = field(default_factory=lambda: MISSING)
+    name: str = MISSING
     aliases: List[str] = field(default_factory=list)
-    attribute: str = field(default_factory=lambda: MISSING)
-    annotation: Any = field(default_factory=lambda: MISSING)
-    default: Any = field(default_factory=lambda: MISSING)
-    max_args: int = field(default_factory=lambda: MISSING)
-    override: bool = field(default_factory=lambda: MISSING)
+    attribute: str = MISSING
+    annotation: Any = MISSING
+    default: Any = MISSING
+    max_args: int = MISSING
+    override: bool = MISSING
     cast_to_dict: bool = False
 
     @property

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -77,13 +77,16 @@ DISCORD_EPOCH = 1420070400000
 
 
 class _MissingSentinel:
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return False
 
-    def __bool__(self):
+    def __hash__(self) -> int:
+        return 0
+
+    def __bool__(self) -> bool:
         return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "..."
 
 


### PR DESCRIPTION
## Summary

Testing 3.11 in one of my bots, I noticed the same dataclass error in my code that previously appeared in `commands.Flag`.
`MISSING` is used outside of this project too (even if it may be undocumented), this PR improves compatibility further.

An alternative to `0` would be returning `id(self)`, but since `MISSING` is meant to be a singleton (and hash collisions wouldn't matter even if it wasn't), using a constant is fine too.

(somewhat of a followup to #785)

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
