### PR TITLE
fix(ci): indent quoted multiline string

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -49,8 +49,8 @@ jobs:
       id: flake8
       if: always() && (steps.pre-commit.outcome == 'success' || steps.pre-commit.outcome == 'failure')
       run: "flake8 \
-      --format='::error file=%(path)s,line=%(row)d,col=%(col)d::\
-      [flake8] %(code)s: %(text)s'"
+        --format='::error file=%(path)s,line=%(row)d,col=%(col)d::\
+        [flake8] %(code)s: %(text)s'"
 
   docs:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run


### PR DESCRIPTION
## Summary

Haven't investigated what exactly happened, but GitHub Actions' yaml parser (YamlDotNet?) no longer likes `.github/workflows/lint-test.yml` and spits out this fun error:

> The workflow is not valid. .github/workflows/lint-test.yml: While scanning a multi-line double-quoted scalar, found wrong indentation.

While the yaml spec apparently isn't 100% clear about it, this PR fixes the indentation to make the parser happy.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
