### PR TITLE
docs: forward port the 2.6.2 changelog

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,10 +17,25 @@ in specific versions.
 
 .. towncrier release notes start
 
+.. _vp2p6p2:
+
+v2.6.2
+------
+
+This maintainence release contains backports from v2.7.0.
+
+Bug Fixes
+~~~~~~~~~
+- Fix creation of threads in text channels without :attr:`Permissions.manage_threads`. (:issue:`818`)
+- Fix off-by-one error in :class:`AutoModKeywordPresets` values. (:issue:`820`)
+- |commands| Fix a case where optional variadic arguments could have infinite loops in parsing depending on the user input. (:issue:`825`)
+
 .. _vp2p6p1:
 
 v2.6.1
 ------
+
+This maintainence release contains backports from v2.7.0.
 
 Bug Fixes
 ~~~~~~~~~


### PR DESCRIPTION
## Summary

forward port the 2.6.2 changelog

2.6.2 has not been published as of yet.

## Checklist
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
