### PR TITLE
typing: add trivial type annotations

### DIFF
--- a/disnake/__main__.py
+++ b/disnake/__main__.py
@@ -11,7 +11,7 @@ import aiohttp
 import disnake
 
 
-def show_version():
+def show_version() -> None:
     entries = []
 
     sys_ver = sys.version_info
@@ -35,7 +35,7 @@ def show_version():
     print("\n".join(entries))
 
 
-def core(parser: argparse.ArgumentParser, args):
+def core(parser: argparse.ArgumentParser, args) -> None:
     # this method runs when no subcommands are provided
     # as such, we can assume that we want to print help
     if args.version:
@@ -201,7 +201,7 @@ def to_path(parser, name, *, replace_spaces=False):
     return Path(name)
 
 
-def newbot(parser, args):
+def newbot(parser, args) -> None:
     new_directory = to_path(parser, args.directory) / to_path(parser, args.name)
 
     # as a note exist_ok for Path is a 3.5+ only feature
@@ -248,7 +248,7 @@ def newbot(parser, args):
     print("successfully made bot at", new_directory)
 
 
-def newcog(parser, args):
+def newcog(parser, args) -> None:
     cog_dir = to_path(parser, args.directory)
     try:
         cog_dir.mkdir(exist_ok=True)
@@ -282,7 +282,7 @@ def newcog(parser, args):
         print("successfully made cog at", directory)
 
 
-def add_newbot_args(subparser):
+def add_newbot_args(subparser) -> None:
     parser = subparser.add_parser("newbot", help="creates a command bot project quickly")
     parser.set_defaults(func=newbot)
 
@@ -309,7 +309,7 @@ def add_newbot_args(subparser):
     )
 
 
-def add_newcog_args(subparser):
+def add_newcog_args(subparser) -> None:
     parser = subparser.add_parser("newcog", help="creates a new cog template quickly")
     parser.set_defaults(func=newcog)
 
@@ -341,7 +341,7 @@ def parse_args():
     return parser, parser.parse_args()
 
 
-def main():
+def main() -> None:
     parser, args = parse_args()
     args.func(parser, args)
 

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -865,7 +865,9 @@ class GuildChannel(ABC):
     ) -> None:
         ...
 
-    async def set_permissions(self, target, *, overwrite=MISSING, reason=None, **permissions):
+    async def set_permissions(
+        self, target, *, overwrite=MISSING, reason=None, **permissions
+    ) -> None:
         """
         |coro|
 

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -177,7 +177,7 @@ class _Overwrites:
     ROLE = 0
     MEMBER = 1
 
-    def __init__(self, data: PermissionOverwritePayload):
+    def __init__(self, data: PermissionOverwritePayload) -> None:
         self.id: int = int(data["id"])
         self.allow: int = int(data.get("allow", 0))
         self.deny: int = int(data.get("deny", 0))
@@ -236,7 +236,9 @@ class GuildChannel(ABC):
 
     if TYPE_CHECKING:
 
-        def __init__(self, *, state: ConnectionState, guild: Guild, data: Mapping[str, Any]):
+        def __init__(
+            self, *, state: ConnectionState, guild: Guild, data: Mapping[str, Any]
+        ) -> None:
             ...
 
     def __str__(self) -> str:

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -762,7 +762,7 @@ class CustomActivity(BaseActivity):
         emoji: Optional[Union[ActivityEmojiPayload, str, PartialEmoji]] = None,
         state: Optional[str] = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.name: Optional[str] = name
         self.state: Optional[str] = state

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -88,7 +88,7 @@ class _BaseActivity:
         timestamps: Optional[ActivityTimestamps] = None,
         assets: Optional[ActivityAssets] = None,
         **kwargs: Any,  # discarded
-    ):
+    ) -> None:
         self._created_at: Optional[float] = created_at
         self._timestamps: ActivityTimestamps = timestamps or {}
         self.assets: ActivityAssets = assets or {}
@@ -254,7 +254,7 @@ class Activity(BaseActivity):
         sync_id: Optional[str] = None,
         session_id: Optional[str] = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.state: Optional[str] = state
         self.details: Optional[str] = details
@@ -400,7 +400,7 @@ class Game(BaseActivity):
         *,
         platform: Optional[str] = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.name: str = name
 
@@ -494,7 +494,7 @@ class Streaming(BaseActivity):
         details: Optional[str] = None,
         state: Optional[str] = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.platform: Optional[str] = name
         self.name: Optional[str] = details or name
@@ -590,7 +590,7 @@ class Spotify(_BaseActivity):
         sync_id: Optional[str] = None,
         session_id: Optional[str] = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self._state: str = state or ""
         self._details: str = details or ""

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -110,7 +110,7 @@ class OptionChoice:
         self,
         name: LocalizedRequired,
         value: ApplicationCommandOptionChoiceValue,
-    ):
+    ) -> None:
         name_loc = Localized._cast(name, True)
         self.name: str = name_loc.string
         self.name_localizations: LocalizationValue = name_loc.localizations
@@ -595,7 +595,7 @@ class UserCommand(ApplicationCommand):
         name: LocalizedRequired,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
-    ):
+    ) -> None:
         super().__init__(
             type=ApplicationCommandType.user,
             name=name,
@@ -678,7 +678,7 @@ class MessageCommand(ApplicationCommand):
         name: LocalizedRequired,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
-    ):
+    ) -> None:
         super().__init__(
             type=ApplicationCommandType.message,
             name=name,
@@ -779,7 +779,7 @@ class SlashCommand(ApplicationCommand):
         options: Optional[List[Option]] = None,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
-    ):
+    ) -> None:
         super().__init__(
             type=ApplicationCommandType.chat_input,
             name=name,
@@ -932,7 +932,7 @@ class ApplicationCommandPermissions:
 
     __slots__ = ("id", "type", "permission", "_guild_id")
 
-    def __init__(self, *, data: ApplicationCommandPermissionsPayload, guild_id: int):
+    def __init__(self, *, data: ApplicationCommandPermissionsPayload, guild_id: int) -> None:
         self.id: int = int(data["id"])
         self.type: ApplicationCommandPermissionType = try_enum(
             ApplicationCommandPermissionType, data["type"]
@@ -990,7 +990,9 @@ class GuildApplicationCommandPermissions:
 
     __slots__ = ("_state", "id", "application_id", "guild_id", "permissions")
 
-    def __init__(self, *, data: GuildApplicationCommandPermissionsPayload, state: ConnectionState):
+    def __init__(
+        self, *, data: GuildApplicationCommandPermissionsPayload, state: ConnectionState
+    ) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.application_id: int = int(data["application_id"])

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -235,7 +235,7 @@ class Option:
         max_value: Optional[float] = None,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
-    ):
+    ) -> None:
         name_loc = Localized._cast(name, True)
         _validate_name(name_loc.string)
         self.name: str = name_loc.string
@@ -468,7 +468,7 @@ class ApplicationCommand(ABC):
         name: LocalizedRequired,
         dm_permission: Optional[bool] = None,
         default_member_permissions: Optional[Union[Permissions, int]] = None,
-    ):
+    ) -> None:
         self.type: ApplicationCommandType = enum_if_int(ApplicationCommandType, type)
 
         name_loc = Localized._cast(name, True)

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -940,7 +940,7 @@ class ApplicationCommandPermissions:
         self.permission: bool = data["permission"]
         self._guild_id: int = guild_id
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<ApplicationCommandPermissions id={self.id!r} type={self.type!r} permission={self.permission!r}>"
 
     def __eq__(self, other):
@@ -1003,7 +1003,7 @@ class GuildApplicationCommandPermissions:
             for elem in data["permissions"]
         ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<GuildApplicationCommandPermissions id={self.id!r} application_id={self.application_id!r}"
             f" guild_id={self.guild_id!r} permissions={self.permissions!r}>"

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -46,7 +46,7 @@ class InstallParams:
         "permissions",
     )
 
-    def __init__(self, data: InstallParamsPayload, parent: AppInfo):
+    def __init__(self, data: InstallParamsPayload, parent: AppInfo) -> None:
         self._app_id = parent.id
         self.scopes = data["scopes"]
         self.permissions = Permissions(int(data["permissions"]))
@@ -172,7 +172,7 @@ class AppInfo:
         "custom_install_url",
     )
 
-    def __init__(self, state: ConnectionState, data: AppInfoPayload):
+    def __init__(self, state: ConnectionState, data: AppInfoPayload) -> None:
         from .team import Team
 
         self._state: ConnectionState = state
@@ -297,7 +297,7 @@ class PartialAppInfo:
         "_icon",
     )
 
-    def __init__(self, *, state: ConnectionState, data: PartialAppInfoPayload):
+    def __init__(self, *, state: ConnectionState, data: PartialAppInfoPayload) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.name: str = data["name"]

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -51,7 +51,7 @@ class InstallParams:
         self.scopes = data["scopes"]
         self.permissions = Permissions(int(data["permissions"]))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<InstallParams scopes={self.scopes!r} permissions={self.permissions!r}>"
 
     def to_url(self) -> str:

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -312,7 +312,7 @@ class Asset(AssetMixin):
     def __len__(self) -> int:
         return len(self._url)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         shorten = self._url.replace(self.BASE, "")
         return f"<Asset url={shorten!r}>"
 

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -191,7 +191,7 @@ class Asset(AssetMixin):
 
     BASE = "https://cdn.discordapp.com"
 
-    def __init__(self, state, *, url: str, key: str, animated: bool = False):
+    def __init__(self, state, *, url: str, key: str, animated: bool = False) -> None:
         self._state = state
         self._url = url
         self._animated = animated

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -365,7 +365,7 @@ class AuditLogChanges:
     }
     # fmt: on
 
-    def __init__(self, entry: AuditLogEntry, data: List[AuditLogChangePayload]):
+    def __init__(self, entry: AuditLogEntry, data: List[AuditLogChangePayload]) -> None:
         self.before = AuditLogDiff()
         self.after = AuditLogDiff()
 
@@ -561,7 +561,7 @@ class AuditLogEntry(Hashable):
         threads: Dict[int, Thread],
         users: Dict[int, User],
         webhooks: Dict[int, Webhook],
-    ):
+    ) -> None:
         self._state = guild._state
         self.guild = guild
 

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -87,7 +87,7 @@ class AutoModAction:
         self,
         *,
         type: AutoModActionType,
-    ):
+    ) -> None:
         self.type: AutoModActionType = enum_if_int(AutoModActionType, type)
         self._metadata: AutoModActionMetadata = {}
 
@@ -127,7 +127,7 @@ class AutoModBlockMessageAction(AutoModAction):
 
     _metadata: AutoModBlockMessageActionMetadata
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(type=AutoModActionType.block_message)
 
     def __repr__(self) -> str:
@@ -156,7 +156,7 @@ class AutoModSendAlertAction(AutoModAction):
 
     _metadata: AutoModSendAlertActionMetadata
 
-    def __init__(self, channel: Snowflake):
+    def __init__(self, channel: Snowflake) -> None:
         super().__init__(type=AutoModActionType.send_alert_message)
 
         self._metadata["channel_id"] = channel.id
@@ -192,7 +192,7 @@ class AutoModTimeoutAction(AutoModAction):
 
     _metadata: AutoModTimeoutActionMetadata
 
-    def __init__(self, duration: Union[int, timedelta]):
+    def __init__(self, duration: Union[int, timedelta]) -> None:
         super().__init__(type=AutoModActionType.timeout)
 
         if isinstance(duration, timedelta):
@@ -241,7 +241,7 @@ class AutoModTriggerMetadata:
     )
 
     @overload
-    def __init__(self, *, keyword_filter: Sequence[str]):
+    def __init__(self, *, keyword_filter: Sequence[str]) -> None:
         ...
 
     @overload
@@ -250,11 +250,11 @@ class AutoModTriggerMetadata:
         *,
         presets: AutoModKeywordPresets,
         allow_list: Optional[Sequence[str]] = None,
-    ):
+    ) -> None:
         ...
 
     @overload
-    def __init__(self, *, mention_total_limit: int):
+    def __init__(self, *, mention_total_limit: int) -> None:
         ...
 
     def __init__(
@@ -264,7 +264,7 @@ class AutoModTriggerMetadata:
         presets: Optional[AutoModKeywordPresets] = None,
         allow_list: Optional[Sequence[str]] = None,
         mention_total_limit: Optional[int] = None,
-    ):
+    ) -> None:
         self.keyword_filter: Optional[Sequence[str]] = keyword_filter
         self.presets: Optional[AutoModKeywordPresets] = presets
         self.allow_list: Optional[Sequence[str]] = allow_list
@@ -379,7 +379,7 @@ class AutoModRule:
         "exempt_channel_ids",
     )
 
-    def __init__(self, *, data: AutoModRulePayload, guild: Guild):
+    def __init__(self, *, data: AutoModRulePayload, guild: Guild) -> None:
         self.guild: Guild = guild
 
         self.id: int = int(data["id"])

--- a/disnake/backoff.py
+++ b/disnake/backoff.py
@@ -33,7 +33,7 @@ class ExponentialBackoff(Generic[T]):
         number in between may be returned.
     """
 
-    def __init__(self, base: int = 1, *, integral: T = False):
+    def __init__(self, base: int = 1, *, integral: T = False) -> None:
         self._base: int = base
 
         self._exp: int = 0

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
     from .webhook import Webhook
 
 
-async def _single_delete_strategy(messages: Iterable[Message]):
+async def _single_delete_strategy(messages: Iterable[Message]) -> None:
     for m in messages:
         await m.delete()
 
@@ -2282,9 +2282,9 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         ...
 
     @utils.copy_doc(disnake.abc.GuildChannel.move)
-    async def move(self, **kwargs):
+    async def move(self, **kwargs) -> None:
         kwargs.pop("category", None)
-        await super().move(**kwargs)
+        return await super().move(**kwargs)
 
     @property
     def channels(self) -> List[GuildChannelType]:

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -176,7 +176,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
         "_type",
     )
 
-    def __init__(self, *, state: ConnectionState, guild: Guild, data: TextChannelPayload):
+    def __init__(self, *, state: ConnectionState, guild: Guild, data: TextChannelPayload) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self._type: Literal[0, 5] = data["type"]
@@ -991,7 +991,7 @@ class VocalGuildChannel(disnake.abc.Connectable, disnake.abc.GuildChannel, Hasha
         state: ConnectionState,
         guild: Guild,
         data: Union[VoiceChannelPayload, StageChannelPayload],
-    ):
+    ) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self._update(guild, data)
@@ -2093,7 +2093,9 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         "_flags",
     )
 
-    def __init__(self, *, state: ConnectionState, guild: Guild, data: CategoryChannelPayload):
+    def __init__(
+        self, *, state: ConnectionState, guild: Guild, data: CategoryChannelPayload
+    ) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self._update(guild, data)
@@ -3346,7 +3348,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         "_flags",
     )
 
-    def __init__(self, *, me: ClientUser, state: ConnectionState, data: DMChannelPayload):
+    def __init__(self, *, me: ClientUser, state: ConnectionState, data: DMChannelPayload) -> None:
         self._state: ConnectionState = state
         self.recipient: Optional[User] = state.store_user(data["recipients"][0])  # type: ignore
         self.me: ClientUser = me
@@ -3505,7 +3507,9 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
 
     __slots__ = ("id", "recipients", "owner_id", "owner", "_icon", "name", "me", "_state")
 
-    def __init__(self, *, me: ClientUser, state: ConnectionState, data: GroupChannelPayload):
+    def __init__(
+        self, *, me: ClientUser, state: ConnectionState, data: GroupChannelPayload
+    ) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.me: ClientUser = me
@@ -3645,7 +3649,7 @@ class PartialMessageable(disnake.abc.Messageable, Hashable):
         The channel type associated with this partial messageable, if given.
     """
 
-    def __init__(self, state: ConnectionState, id: int, type: Optional[ChannelType] = None):
+    def __init__(self, state: ConnectionState, id: int, type: Optional[ChannelType] = None) -> None:
         self._state: ConnectionState = state
         self.id: int = id
         self.type: Optional[ChannelType] = type

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -170,7 +170,7 @@ class SessionStartLimit:
 
         self.reset_time: datetime = utils.utcnow() + timedelta(milliseconds=self.reset_after)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<SessionStartLimit total={self.total!r} remaining={self.remaining!r} "
             f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time!s}>"
@@ -1610,7 +1610,7 @@ class Client:
         future = self.loop.create_future()
         if check is None:
 
-            def _check(*args):
+            def _check(*args) -> bool:
                 return True
 
             check = _check

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -376,7 +376,7 @@ class Client:
         intents: Optional[Intents] = None,
         chunk_guilds_at_startup: Optional[bool] = None,
         member_cache_flags: Optional[MemberCacheFlags] = None,
-    ):
+    ) -> None:
         # self.ws is set in the connect method
         self.ws: DiscordWebSocket = None  # type: ignore
 
@@ -1160,7 +1160,7 @@ class Client:
         return Status.online
 
     @status.setter
-    def status(self, value):
+    def status(self, value) -> None:
         if value is Status.offline:
             self._connection._status = "invisible"
         elif isinstance(value, Status):

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -162,7 +162,7 @@ class SessionStartLimit:
         "reset_time",
     )
 
-    def __init__(self, data: SessionStartLimitPayload):
+    def __init__(self, data: SessionStartLimitPayload) -> None:
         self.total: int = data["total"]
         self.remaining: int = data["remaining"]
         self.reset_after: int = data["reset_after"]

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1097,14 +1097,14 @@ class Client:
         except NotImplementedError:
             pass
 
-        async def runner():
+        async def runner() -> None:
             try:
                 await self.start(*args, **kwargs)
             finally:
                 if not self.is_closed():
                     await self.close()
 
-        def stop_loop_on_completion(f):
+        def stop_loop_on_completion(f) -> None:
             loop.stop()
 
         future = asyncio.ensure_future(runner(), loop=loop)
@@ -1660,7 +1660,7 @@ class Client:
         *,
         activity: Optional[BaseActivity] = None,
         status: Optional[Status] = None,
-    ):
+    ) -> None:
         """|coro|
 
         Changes the client's presence.

--- a/disnake/colour.py
+++ b/disnake/colour.py
@@ -52,7 +52,7 @@ class Colour:
 
     __slots__ = ("value",)
 
-    def __init__(self, value: int):
+    def __init__(self, value: int) -> None:
         if not isinstance(value, int):
             raise TypeError(f"Expected int parameter, received {value.__class__.__name__} instead.")
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -141,7 +141,7 @@ class ActionRow(Component, Generic[ComponentT]):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: ActionRowPayload):
+    def __init__(self, data: ActionRowPayload) -> None:
         self.type: ComponentType = try_enum(ComponentType, data["type"])
         self.children: List[ComponentT] = [
             _component_factory(d) for d in data.get("components", [])
@@ -194,7 +194,7 @@ class Button(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: ButtonComponentPayload):
+    def __init__(self, data: ButtonComponentPayload) -> None:
         self.type: ComponentType = try_enum(ComponentType, data["type"])
         self.style: ButtonStyle = try_enum(ButtonStyle, data["style"])
         self.custom_id: Optional[str] = data.get("custom_id")
@@ -273,7 +273,7 @@ class BaseSelectMenu(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: BaseSelectMenuPayload):
+    def __init__(self, data: BaseSelectMenuPayload) -> None:
         self.type: ComponentType = try_enum(ComponentType, data["type"])
         self.custom_id: str = data["custom_id"]
         self.placeholder: Optional[str] = data.get("placeholder")

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -330,7 +330,7 @@ class StringSelectMenu(BaseSelectMenu):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = BaseSelectMenu.__repr_info__ + __slots__
 
-    def __init__(self, data: StringSelectMenuPayload):
+    def __init__(self, data: StringSelectMenuPayload) -> None:
         super().__init__(data)
         self.options: List[SelectOption] = [
             SelectOption.from_dict(option) for option in data.get("options", [])
@@ -476,7 +476,7 @@ class ChannelSelectMenu(BaseSelectMenu):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = BaseSelectMenu.__repr_info__ + __slots__
 
-    def __init__(self, data: ChannelSelectMenuPayload):
+    def __init__(self, data: ChannelSelectMenuPayload) -> None:
         super().__init__(data)
         # on the API side, an empty list is (currently) equivalent to no value
         channel_types = data.get("channel_types")

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -349,7 +349,7 @@ class Embed:
             )
 
     @colour.deleter
-    def colour(self):
+    def colour(self) -> None:
         self._colour = MISSING
 
     color = colour

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -338,7 +338,7 @@ class Embed:
         return col if col is not MISSING else type(self)._default_colour
 
     @colour.setter
-    def colour(self, value: Optional[Union[int, Colour]]):
+    def colour(self, value: Optional[Union[int, Colour]]) -> None:
         if isinstance(value, int):
             self._colour = Colour(value=value)
         elif value is MISSING or value is None or isinstance(value, Colour):
@@ -359,7 +359,7 @@ class Embed:
         return self._timestamp
 
     @timestamp.setter
-    def timestamp(self, value: Optional[datetime.datetime]):
+    def timestamp(self, value: Optional[datetime.datetime]) -> None:
         if isinstance(value, datetime.datetime):
             if value.tzinfo is None:
                 value = value.astimezone()

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -41,7 +41,7 @@ if not TYPE_CHECKING:
 
 
 class EmbedProxy:
-    def __init__(self, layer: Optional[Mapping[str, Any]]):
+    def __init__(self, layer: Optional[Mapping[str, Any]]) -> None:
         if layer is not None:
             self.__dict__.update(layer)
 
@@ -197,7 +197,7 @@ class Embed:
         timestamp: Optional[datetime.datetime] = None,
         colour: Optional[Union[int, Colour]] = MISSING,
         color: Optional[Union[int, Colour]] = MISSING,
-    ):
+    ) -> None:
         self.title: Optional[str] = str(title) if title is not None else None
         self.type: Optional[EmbedType] = type
         self.description: Optional[str] = str(description) if description is not None else None

--- a/disnake/emoji.py
+++ b/disnake/emoji.py
@@ -86,7 +86,7 @@ class Emoji(_EmojiTag, AssetMixin):
 
     def __init__(
         self, *, guild: Union[Guild, GuildPreview], state: ConnectionState, data: EmojiPayload
-    ):
+    ) -> None:
         self.guild_id: int = guild.id
         self._state: ConnectionState = state
         self._from_data(data)

--- a/disnake/emoji.py
+++ b/disnake/emoji.py
@@ -91,7 +91,7 @@ class Emoji(_EmojiTag, AssetMixin):
         self._state: ConnectionState = state
         self._from_data(data)
 
-    def _from_data(self, emoji: EmojiPayload):
+    def _from_data(self, emoji: EmojiPayload) -> None:
         self.require_colons: bool = emoji.get("require_colons", False)
         self.managed: bool = emoji.get("managed", False)
         self.id: int = int(emoji["id"])  # type: ignore

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -144,7 +144,7 @@ class EnumMeta(type):
     def __reversed__(cls):
         return (cls._enum_member_map_[name] for name in reversed(cls._enum_member_names_))
 
-    def __len__(cls):
+    def __len__(cls) -> int:
         return len(cls._enum_member_names_)
 
     def __repr__(cls) -> str:
@@ -205,7 +205,7 @@ class ChannelType(Enum):
     guild_directory = 14
     forum = 15
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -258,10 +258,10 @@ class SpeakingState(Enum):
     soundshare = 2
     priority = 4
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self.value
 
 
@@ -272,7 +272,7 @@ class VerificationLevel(Enum, comparable=True):
     high = 3
     highest = 4
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -281,7 +281,7 @@ class ContentFilter(Enum, comparable=True):
     no_role = 1
     all_members = 2
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -294,7 +294,7 @@ class Status(Enum):
     invisible = "invisible"
     streaming = "streaming"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
@@ -306,7 +306,7 @@ class DefaultAvatar(Enum):
     orange = 3
     red = 4
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -517,7 +517,7 @@ class ActivityType(Enum):
     custom = 4
     competing = 5
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self.value
 
 
@@ -590,7 +590,7 @@ class VideoQualityMode(Enum):
     auto = 1
     full = 2
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self.value
 
 
@@ -605,7 +605,7 @@ class ComponentType(Enum):
     mentionable_select = 7
     channel_select = 8
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self.value
 
 
@@ -624,7 +624,7 @@ class ButtonStyle(Enum):
     red = 4
     url = 5
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self.value
 
 
@@ -651,7 +651,7 @@ class ApplicationCommandPermissionType(Enum):
     user = 2
     channel = 3
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self.value
 
 
@@ -706,7 +706,7 @@ class ThreadArchiveDuration(Enum):
     three_days = 4320
     week = 10080
 
-    def __int__(self):
+    def __int__(self) -> int:
         return self.value
 
 
@@ -717,7 +717,7 @@ class WidgetStyle(Enum):
     banner3 = "banner3"
     banner4 = "banner4"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 
@@ -784,7 +784,7 @@ class Locale(Enum):
     zh_TW = "zh-TW"
     "Chinese, Taiwan | 繁體中文"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -147,7 +147,7 @@ class EnumMeta(type):
     def __len__(cls):
         return len(cls._enum_member_names_)
 
-    def __repr__(cls):
+    def __repr__(cls) -> str:
         return f"<enum {cls.__name__}>"
 
     @property
@@ -169,7 +169,7 @@ class EnumMeta(type):
     def __delattr__(cls, attr) -> NoReturn:
         raise TypeError("Enums are immutable")
 
-    def __instancecheck__(self, instance):
+    def __instancecheck__(self, instance) -> bool:
         # isinstance(x, Y)
         # -> __instancecheck__(Y, x)
         try:

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -152,10 +152,10 @@ class EnumMeta(type):
     def __getitem__(cls, key):
         return cls._enum_member_map_[key]
 
-    def __setattr__(cls, name, value):
+    def __setattr__(cls, name, value) -> None:
         raise TypeError("Enums are immutable.")
 
-    def __delattr__(cls, attr):
+    def __delattr__(cls, attr) -> None:
         raise TypeError("Enums are immutable")
 
     def __instancecheck__(self, instance):

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -2,7 +2,18 @@
 
 import types
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, NamedTuple, Optional, Type, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    NamedTuple,
+    NoReturn,
+    Optional,
+    Type,
+    TypeVar,
+)
 
 __all__ = (
     "Enum",
@@ -152,10 +163,10 @@ class EnumMeta(type):
     def __getitem__(cls, key):
         return cls._enum_member_map_[key]
 
-    def __setattr__(cls, name, value) -> None:
+    def __setattr__(cls, name, value) -> NoReturn:
         raise TypeError("Enums are immutable.")
 
-    def __delattr__(cls, attr) -> None:
+    def __delattr__(cls, attr) -> NoReturn:
         raise TypeError("Enums are immutable")
 
     def __instancecheck__(self, instance):

--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -106,7 +106,9 @@ class HTTPException(DiscordException):
         The Discord specific error code for the failure.
     """
 
-    def __init__(self, response: _ResponseType, message: Optional[Union[str, Dict[str, Any]]]):
+    def __init__(
+        self, response: _ResponseType, message: Optional[Union[str, Dict[str, Any]]]
+    ) -> None:
         self.response: _ResponseType = response
         self.status: int = response.status  # type: ignore
         self.code: int
@@ -200,7 +202,7 @@ class SessionStartLimitReached(ClientException):
 
     """
 
-    def __init__(self, session_start_limit: SessionStartLimit, requested: int = 1):
+    def __init__(self, session_start_limit: SessionStartLimit, requested: int = 1) -> None:
         self.session_start_limit: SessionStartLimit = session_start_limit
         super().__init__(
             f"Daily session start limit has been reached, resets at {self.session_start_limit.reset_time} "
@@ -228,7 +230,7 @@ class ConnectionClosed(ClientException):
         *,
         shard_id: Optional[int],
         code: Optional[int] = None,
-    ):
+    ) -> None:
         # This exception is just the same exception except
         # reconfigured to subclass ClientException for users
         self.code: int = code or socket.close_code or -1
@@ -255,7 +257,7 @@ class PrivilegedIntentsRequired(ClientException):
         The shard ID that got closed if applicable.
     """
 
-    def __init__(self, shard_id: Optional[int]):
+    def __init__(self, shard_id: Optional[int]) -> None:
         self.shard_id: Optional[int] = shard_id
         msg = (
             f"Shard ID {shard_id} is requesting privileged intents that have not been explicitly enabled in the "
@@ -292,7 +294,7 @@ class InteractionTimedOut(InteractionException):
         The interaction that was responded to.
     """
 
-    def __init__(self, interaction: Interaction):
+    def __init__(self, interaction: Interaction) -> None:
         self.interaction: Interaction = interaction
 
         msg = (
@@ -321,7 +323,7 @@ class InteractionResponded(InteractionException):
         The interaction that's already been responded to.
     """
 
-    def __init__(self, interaction: Interaction):
+    def __init__(self, interaction: Interaction) -> None:
         self.interaction: Interaction = interaction
         super().__init__("This interaction has already been responded to before")
 
@@ -340,7 +342,7 @@ class InteractionNotResponded(InteractionException):
         The interaction that hasn't been responded to.
     """
 
-    def __init__(self, interaction: Interaction):
+    def __init__(self, interaction: Interaction) -> None:
         self.interaction: Interaction = interaction
         super().__init__("This interaction hasn't been responded to yet")
 
@@ -356,7 +358,7 @@ class ModalChainNotSupported(InteractionException):
         The interaction that was responded to.
     """
 
-    def __init__(self, interaction: ModalInteraction):
+    def __init__(self, interaction: ModalInteraction) -> None:
         self.interaction: ModalInteraction = interaction
         super().__init__("You cannot respond to a modal with another modal.")
 
@@ -373,7 +375,7 @@ class InteractionNotEditable(InteractionException):
         The interaction that was responded to.
     """
 
-    def __init__(self, interaction: Interaction):
+    def __init__(self, interaction: Interaction) -> None:
         self.interaction: Interaction = interaction
         super().__init__("This interaction does not have a message to edit.")
 
@@ -389,6 +391,6 @@ class LocalizationKeyError(DiscordException):
         The localization key that couldn't be found.
     """
 
-    def __init__(self, key: str):
+    def __init__(self, key: str) -> None:
         self.key: str = key
         super().__init__(f"No localizations were found for the key '{key}'.")

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -130,7 +130,7 @@ class InvokableApplicationCommand(ABC):
         self.__original_kwargs__ = {k: v for k, v in kwargs.items() if v is not None}
         return self
 
-    def __init__(self, func: CommandCallback, *, name: Optional[str] = None, **kwargs):
+    def __init__(self, func: CommandCallback, *, name: Optional[str] = None, **kwargs) -> None:
         self.__command_flag__ = None
         self._callback: CommandCallback = func
         self.name: str = name or func.__name__

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -261,7 +261,7 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
             member_cache_flags: Optional[MemberCacheFlags] = None,
             localization_provider: Optional[LocalizationProtocol] = None,
             strict_localization: bool = False,
-        ):
+        ) -> None:
             ...
 
 
@@ -313,7 +313,7 @@ class AutoShardedBot(BotBase, InteractionBotBase, disnake.AutoShardedClient):
             member_cache_flags: Optional[MemberCacheFlags] = None,
             localization_provider: Optional[LocalizationProtocol] = None,
             strict_localization: bool = False,
-        ):
+        ) -> None:
             ...
 
 
@@ -462,7 +462,7 @@ class InteractionBot(InteractionBotBase, disnake.Client):
             member_cache_flags: Optional[MemberCacheFlags] = None,
             localization_provider: Optional[LocalizationProtocol] = None,
             strict_localization: bool = False,
-        ):
+        ) -> None:
             ...
 
 
@@ -507,5 +507,5 @@ class AutoShardedInteractionBot(InteractionBotBase, disnake.AutoShardedClient):
             member_cache_flags: Optional[MemberCacheFlags] = None,
             localization_provider: Optional[LocalizationProtocol] = None,
             strict_localization: bool = False,
-        ):
+        ) -> None:
             ...

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -109,7 +109,7 @@ def _is_submodule(parent: str, child: str) -> bool:
 
 
 class _DefaultRepr:
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<default-help-command>"
 
 

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -127,7 +127,7 @@ class BotBase(CommonBotBase, GroupMixin):
         *,
         strip_after_prefix: bool = False,
         **options: Any,
-    ):
+    ) -> None:
         super().__init__(**options)
 
         if not isinstance(self, disnake.Client):

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -627,5 +627,5 @@ class BotBase(CommonBotBase, GroupMixin):
         ctx = await self.get_context(message)
         await self.invoke(ctx)
 
-    async def on_message(self, message):
+    async def on_message(self, message) -> None:
         await self.process_commands(message)

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -58,7 +58,7 @@ class CommonBotBase(Generic[CogT]):
         owner_ids: Optional[Set[int]] = None,
         reload: bool = False,
         **kwargs: Any,
-    ):
+    ) -> None:
         self.__cogs: Dict[str, Cog] = {}
         self.__extensions: Dict[str, types.ModuleType] = {}
         self.extra_events: Dict[str, List[CoroFunc]] = {}

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -594,7 +594,7 @@ class CommonBotBase(Generic[CogT]):
         """Mapping[:class:`str`, :class:`py:types.ModuleType`]: A read-only mapping of extension name to extension."""
         return types.MappingProxyType(self.__extensions)
 
-    async def _watchdog(self):
+    async def _watchdog(self) -> None:
         """|coro|
 
         Starts the bot watchdog which will watch currently loaded extensions

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -114,7 +114,7 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
         subcommand_passed: Optional[str] = None,
         command_failed: bool = False,
         current_parameter: Optional[inspect.Parameter] = None,
-    ):
+    ) -> None:
         self.message: Message = message
         self.bot: BotT = bot
         self.args: List[Any] = args or []

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -1095,7 +1095,7 @@ class Greedy(List[T]):
     def __init__(self, *, converter: T) -> None:
         self.converter = converter
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         converter = getattr(self.converter, "__name__", repr(self.converter))
         return f"Greedy[{converter}]"
 

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -1092,7 +1092,7 @@ class Greedy(List[T]):
 
     __slots__ = ("converter",)
 
-    def __init__(self, *, converter: T):
+    def __init__(self, *, converter: T) -> None:
         self.converter = converter
 
     def __repr__(self):

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -307,7 +307,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self,
         func: CommandCallback[CogT, ContextT, P, T],
         **kwargs: Any,
-    ):
+    ) -> None:
         if not asyncio.iscoroutinefunction(func):
             raise TypeError("Callback must be a coroutine.")
 

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -206,7 +206,7 @@ class _CaseInsensitiveDict(dict):
     def pop(self, k, default=None):
         return super().pop(k.casefold(), default)
 
-    def __setitem__(self, k, v):
+    def __setitem__(self, k, v) -> None:
         super().__setitem__(k.casefold(), v)
 
 

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -191,7 +191,7 @@ def hooked_wrapped_callback(command, ctx, coro):
 
 
 class _CaseInsensitiveDict(dict):
-    def __contains__(self, k):
+    def __contains__(self, k) -> bool:
         return super().__contains__(k.casefold())
 
     def __delitem__(self, k):

--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -178,7 +178,7 @@ class InvokableMessageCommand(InvokableApplicationCommand):
         guild_ids: Optional[Sequence[int]] = None,
         auto_sync: Optional[bool] = None,
         **kwargs,
-    ):
+    ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
         self.guild_ids: Optional[Tuple[int, ...]] = None if guild_ids is None else tuple(guild_ids)

--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -78,7 +78,7 @@ class InvokableUserCommand(InvokableApplicationCommand):
         guild_ids: Optional[Sequence[int]] = None,
         auto_sync: Optional[bool] = None,
         **kwargs,
-    ):
+    ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
         self.guild_ids: Optional[Tuple[int, ...]] = None if guild_ids is None else tuple(guild_ids)

--- a/disnake/ext/commands/flag_converter.py
+++ b/disnake/ext/commands/flag_converter.py
@@ -124,7 +124,7 @@ def flag(
     return Flag(name=name, aliases=aliases, default=default, max_args=max_args, override=override)
 
 
-def validate_flag_name(name: str, forbidden: Set[str]):
+def validate_flag_name(name: str, forbidden: Set[str]) -> None:
     if not name:
         raise ValueError("flag names should not be empty")
 

--- a/disnake/ext/commands/flags.py
+++ b/disnake/ext/commands/flags.py
@@ -100,12 +100,12 @@ class CommandSyncFlags(BaseFlags):
         sync_global_commands: bool = ...,
         sync_guild_commands: bool = ...,
         sync_on_cog_actions: bool = ...,
-    ):
+    ) -> None:
         ...
 
     @overload
     @_generated
-    def __init__(self: NoReturn):
+    def __init__(self: NoReturn) -> None:
         ...
 
     def __init__(self, **kwargs: bool):

--- a/disnake/ext/commands/flags.py
+++ b/disnake/ext/commands/flags.py
@@ -108,7 +108,7 @@ class CommandSyncFlags(BaseFlags):
     def __init__(self: NoReturn) -> None:
         ...
 
-    def __init__(self, **kwargs: bool):
+    def __init__(self, **kwargs: bool) -> None:
         self.value = all_flags_value(self.VALID_FLAGS)
         for key, value in kwargs.items():
             if key not in self.VALID_FLAGS:

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -1357,8 +1357,10 @@ class InteractionBotBase(CommonBotBase):
         except errors.CommandError as exc:
             await app_command.dispatch_error(interaction, exc)
 
-    async def on_application_command(self, interaction: ApplicationCommandInteraction):
+    async def on_application_command(self, interaction: ApplicationCommandInteraction) -> None:
         await self.process_application_commands(interaction)
 
-    async def on_application_command_autocomplete(self, interaction: ApplicationCommandInteraction):
+    async def on_application_command_autocomplete(
+        self, interaction: ApplicationCommandInteraction
+    ) -> None:
         await self.process_app_command_autocompletion(interaction)

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -149,7 +149,7 @@ class InteractionBotBase(CommonBotBase):
         sync_commands_on_cog_unload: bool = MISSING,
         test_guilds: Optional[Sequence[int]] = None,
         **options: Any,
-    ):
+    ) -> None:
         if test_guilds and not all(isinstance(guild_id, int) for guild_id in test_guilds):
             raise ValueError("test_guilds must be a sequence of int.")
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -1291,7 +1291,7 @@ def option_enum(
 class ConverterMethod(classmethod):
     """A class to help register a method as a converter method."""
 
-    def __set_name__(self, owner: Any, name: str):
+    def __set_name__(self, owner: Any, name: str) -> None:
         # this feels wrong
         function = self.__get__(None, owner)
         ParamInfo._registered_converters[owner] = function

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -438,7 +438,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         connectors: Optional[Dict[str, str]] = None,
         auto_sync: Optional[bool] = None,
         **kwargs,
-    ):
+    ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
         self.parent = None

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -143,7 +143,7 @@ class SubCommandGroup(InvokableApplicationCommand):
         *,
         name: LocalizedOptional = None,
         **kwargs,
-    ):
+    ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
         self.parent: InvokableSlashCommand = parent
@@ -274,7 +274,7 @@ class SubCommand(InvokableApplicationCommand):
         options: Optional[list] = None,
         connectors: Optional[Dict[str, str]] = None,
         **kwargs,
-    ):
+    ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
         self.parent: Union[InvokableSlashCommand, SubCommandGroup] = parent
@@ -684,7 +684,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         if choices is not None:
             await inter.response.autocomplete(choices=choices)
 
-    async def invoke_children(self, inter: ApplicationCommandInteraction):
+    async def invoke_children(self, inter: ApplicationCommandInteraction) -> None:
         chain, kwargs = inter.data._get_chain_and_kwargs()
 
         if len(chain) == 0:
@@ -715,7 +715,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
                 if not await subcmd._call_local_error_handler(inter, exc):
                     raise
 
-    async def invoke(self, inter: ApplicationCommandInteraction):
+    async def invoke(self, inter: ApplicationCommandInteraction) -> None:
         await self.prepare(inter)
 
         try:

--- a/disnake/ext/commands/view.py
+++ b/disnake/ext/commands/view.py
@@ -40,7 +40,7 @@ class StringView:
     def eof(self):
         return self.index >= self.end
 
-    def undo(self):
+    def undo(self) -> None:
         self.index = self.previous
 
     def skip_ws(self):

--- a/disnake/ext/commands/view.py
+++ b/disnake/ext/commands/view.py
@@ -58,7 +58,7 @@ class StringView:
         self.index += pos
         return self.previous != self.index
 
-    def skip_string(self, string):
+    def skip_string(self, string) -> bool:
         strlen = len(string)
         if self.buffer[self.index : self.index + strlen] == string:
             self.previous = self.index
@@ -166,7 +166,7 @@ class StringView:
 
             result.append(current)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<StringView pos: {self.index} prev: {self.previous} end: {self.end} eof: {self.eof}>"
         )

--- a/disnake/ext/commands/view.py
+++ b/disnake/ext/commands/view.py
@@ -26,7 +26,7 @@ _all_quotes = set(_quotes.keys()) | set(_quotes.values())
 
 
 class StringView:
-    def __init__(self, buffer: str):
+    def __init__(self, buffer: str) -> None:
         self.index = 0
         self.buffer = buffer
         self.end = len(buffer)

--- a/disnake/file.py
+++ b/disnake/file.py
@@ -60,7 +60,7 @@ class File:
         *,
         spoiler: bool = False,
         description: Optional[str] = None,
-    ):
+    ) -> None:
         if isinstance(fp, io.IOBase):
             if not (fp.seekable() and fp.readable()):
                 raise ValueError(f"File buffer {fp!r} must be seekable and readable")

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -46,7 +46,7 @@ T = TypeVar("T", bound="BaseFlags")
 
 
 class flag_value(Generic[T]):
-    def __init__(self, func: Callable[[Any], int]):
+    def __init__(self, func: Callable[[Any], int]) -> None:
         self.flag = func(None)
         self.__doc__ = func.__doc__
         self._parent: Type[T] = MISSING
@@ -418,7 +418,7 @@ class SystemChannelFlags(BaseFlags, inverted=True):
             join_notification_replies: bool = ...,
             join_notifications: bool = ...,
             premium_subscriptions: bool = ...,
-        ):
+        ) -> None:
             ...
 
     # For some reason the flags for system channels are "inverted"
@@ -571,7 +571,7 @@ class MessageFlags(BaseFlags):
             source_message_deleted: bool = ...,
             suppress_embeds: bool = ...,
             urgent: bool = ...,
-        ):
+        ) -> None:
             ...
 
     @flag_value
@@ -750,7 +750,7 @@ class PublicUserFlags(BaseFlags):
             team_user: bool = ...,
             verified_bot: bool = ...,
             verified_bot_developer: bool = ...,
-        ):
+        ) -> None:
             ...
 
     @flag_value
@@ -989,12 +989,12 @@ class Intents(BaseFlags):
         typing: bool = ...,
         voice_states: bool = ...,
         webhooks: bool = ...,
-    ):
+    ) -> None:
         ...
 
     @overload
     @_generated
-    def __init__(self: NoReturn):
+    def __init__(self: NoReturn) -> None:
         ...
 
     def __init__(self, value: Optional[int] = None, **kwargs: bool):
@@ -1632,12 +1632,12 @@ class MemberCacheFlags(BaseFlags):
 
     @overload
     @_generated
-    def __init__(self, *, joined: bool = ..., voice: bool = ...):
+    def __init__(self, *, joined: bool = ..., voice: bool = ...) -> None:
         ...
 
     @overload
     @_generated
-    def __init__(self: NoReturn):
+    def __init__(self: NoReturn) -> None:
         ...
 
     def __init__(self, **kwargs: bool):
@@ -1825,7 +1825,7 @@ class ApplicationFlags(BaseFlags):
             gateway_presence: bool = ...,
             gateway_presence_limited: bool = ...,
             verification_pending_guild_limit: bool = ...,
-        ):
+        ) -> None:
             ...
 
     @flag_value
@@ -1982,7 +1982,7 @@ class ChannelFlags(BaseFlags):
     if TYPE_CHECKING:
 
         @_generated
-        def __init__(self, *, pinned: bool = ..., require_tag: bool = ...):
+        def __init__(self, *, pinned: bool = ..., require_tag: bool = ...) -> None:
             ...
 
     @flag_value
@@ -2077,7 +2077,9 @@ class AutoModKeywordPresets(ListBaseFlags):
     if TYPE_CHECKING:
 
         @_generated
-        def __init__(self, *, profanity: bool = ..., sexual_content: bool = ..., slurs: bool = ...):
+        def __init__(
+            self, *, profanity: bool = ..., sexual_content: bool = ..., slurs: bool = ...
+        ) -> None:
             ...
 
     @classmethod

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -107,7 +107,7 @@ class BaseFlags:
 
     __slots__ = ("value",)
 
-    def __init__(self, **kwargs: bool):
+    def __init__(self, **kwargs: bool) -> None:
         self.value = self.DEFAULT_VALUE
         for key, value in kwargs.items():
             if key not in self.VALID_FLAGS:
@@ -997,7 +997,7 @@ class Intents(BaseFlags):
     def __init__(self: NoReturn) -> None:
         ...
 
-    def __init__(self, value: Optional[int] = None, **kwargs: bool):
+    def __init__(self, value: Optional[int] = None, **kwargs: bool) -> None:
         if value is not None:
             if not isinstance(value, int):
                 raise TypeError(
@@ -1640,7 +1640,7 @@ class MemberCacheFlags(BaseFlags):
     def __init__(self: NoReturn) -> None:
         ...
 
-    def __init__(self, **kwargs: bool):
+    def __init__(self, **kwargs: bool) -> None:
         self.value = all_flags_value(self.VALID_FLAGS)
         for key, value in kwargs.items():
             if key not in self.VALID_FLAGS:
@@ -1709,7 +1709,7 @@ class MemberCacheFlags(BaseFlags):
 
         return self
 
-    def _verify_intents(self, intents: Intents):
+    def _verify_intents(self, intents: Intents) -> None:
         if self.voice and not intents.voice_states:
             raise ValueError("MemberCacheFlags.voice requires Intents.voice_states")
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -87,7 +87,7 @@ class flag_value(Generic[T]):
     def __set__(self, instance: BaseFlags, value: bool) -> None:
         instance._set_flag(self.flag, value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<flag_value flag={self.flag!r}>"
 
 

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -932,7 +932,7 @@ class DiscordVoiceWebSocket:
         }
         await self.send_as_json(payload)
 
-    async def identify(self):
+    async def identify(self) -> None:
         state = self._connection
         payload: VoiceIdentifyCommand = {
             "op": self.IDENTIFY,

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -94,7 +94,7 @@ __all__ = (
 class ReconnectWebSocket(Exception):
     """Signals to safely reconnect the websocket."""
 
-    def __init__(self, shard_id: Optional[int], *, resume: bool = True):
+    def __init__(self, shard_id: Optional[int], *, resume: bool = True) -> None:
         self.shard_id = shard_id
         self.resume = resume
         self.op = "RESUME" if resume else "IDENTIFY"
@@ -113,7 +113,7 @@ class EventListener(NamedTuple):
 
 class GatewayRatelimiter:
     # The default is 110 to give room for at least 10 heartbeats per minute
-    def __init__(self, count: int = 110, per: float = 60.0):
+    def __init__(self, count: int = 110, per: float = 60.0) -> None:
         # maximum number of commands per interval (`self.per`)
         self.max: int = count
         # interval length in seconds
@@ -172,7 +172,7 @@ class KeepAliveHandler(threading.Thread):
         interval: float,
         shard_id: Optional[int] = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.ws: HeartbeatWebSocket = ws
         self._main_thread_id: int = ws.thread_id
@@ -252,7 +252,7 @@ class KeepAliveHandler(threading.Thread):
 
 
 class VoiceKeepAliveHandler(KeepAliveHandler):
-    def __init__(self, *args: Any, ws: HeartbeatWebSocket, interval: float, **kwargs: Any):
+    def __init__(self, *args: Any, ws: HeartbeatWebSocket, interval: float, **kwargs: Any) -> None:
         super().__init__(*args, ws=ws, interval=interval, **kwargs)
         self.recent_ack_latencies: Deque[float] = deque(maxlen=20)
         self.msg = "Keeping shard ID %s voice websocket alive with timestamp %s."
@@ -343,7 +343,9 @@ class DiscordWebSocket:
     HEARTBEAT_ACK: Final[Literal[11]] = 11
     GUILD_SYNC: Final[Literal[12]] = 12
 
-    def __init__(self, socket: aiohttp.ClientWebSocketResponse, *, loop: asyncio.AbstractEventLoop):
+    def __init__(
+        self, socket: aiohttp.ClientWebSocketResponse, *, loop: asyncio.AbstractEventLoop
+    ) -> None:
         self.socket: aiohttp.ClientWebSocketResponse = socket
         self.loop: asyncio.AbstractEventLoop = loop
 
@@ -891,7 +893,7 @@ class DiscordVoiceWebSocket:
         loop: asyncio.AbstractEventLoop,
         *,
         hook: Optional[HookFunc] = None,
-    ):
+    ) -> None:
         self.ws: aiohttp.ClientWebSocketResponse = socket
         self.loop: asyncio.AbstractEventLoop = loop
         self._keep_alive: Optional[VoiceKeepAliveHandler] = None

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -339,7 +339,7 @@ class Guild(Hashable):
         3: _GuildLimit(emoji=250, stickers=60, bitrate=384e3, filesize=104857600),
     }
 
-    def __init__(self, *, data: GuildPayload, state: ConnectionState):
+    def __init__(self, *, data: GuildPayload, state: ConnectionState) -> None:
         self._channels: Dict[int, GuildChannel] = {}
         self._members: Dict[int, Member] = {}
         self._voice_states: Dict[int, VoiceState] = {}

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4266,7 +4266,7 @@ class Guild(Hashable):
 
     async def change_voice_state(
         self, *, channel: Optional[Snowflake], self_mute: bool = False, self_deaf: bool = False
-    ):
+    ) -> None:
         """|coro|
 
         Changes client's voice state in the guild.

--- a/disnake/guild_preview.py
+++ b/disnake/guild_preview.py
@@ -59,7 +59,7 @@ class GuildPreview:
         "_state",
     )
 
-    def __init__(self, *, data: GuildPreviewPayload, state: ConnectionState):
+    def __init__(self, *, data: GuildPreviewPayload, state: ConnectionState) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.name: str = data["name"]

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -55,7 +55,7 @@ class GuildScheduledEventMetadata:
 
     __slots__ = ("location",)
 
-    def __init__(self, *, location: Optional[str] = None):
+    def __init__(self, *, location: Optional[str] = None) -> None:
         self.location: Optional[str] = location
 
     def __repr__(self) -> str:
@@ -153,7 +153,7 @@ class GuildScheduledEvent(Hashable):
         "_cs_channel",
     )
 
-    def __init__(self, *, state: ConnectionState, data: GuildScheduledEventPayload):
+    def __init__(self, *, state: ConnectionState, data: GuildScheduledEventPayload) -> None:
         self._state: ConnectionState = state
         self._update(data)
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -84,7 +84,7 @@ if TYPE_CHECKING:
 _API_VERSION = 10
 
 
-def _workaround_set_api_version(version: Literal[9, 10]):
+def _workaround_set_api_version(version: Literal[9, 10]) -> None:
     """Stopgap measure for verified bots without message content intent while intent is not enforced on api v9.
 
 

--- a/disnake/i18n.py
+++ b/disnake/i18n.py
@@ -88,11 +88,11 @@ class Localized(Generic[StringT]):
     __slots__ = ("string", "localizations")
 
     @overload
-    def __init__(self: Localized[StringT], string: StringT, *, key: str):
+    def __init__(self: Localized[StringT], string: StringT, *, key: str) -> None:
         ...
 
     @overload
-    def __init__(self: Localized[Optional[str]], *, key: str):
+    def __init__(self: Localized[Optional[str]], *, key: str) -> None:
         ...
 
     @overload
@@ -101,7 +101,7 @@ class Localized(Generic[StringT]):
         string: StringT,
         *,
         data: Union[Optional[LocalizationsDict], LocalizationValue],
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -109,7 +109,7 @@ class Localized(Generic[StringT]):
         self: Localized[Optional[str]],
         *,
         data: Union[Optional[LocalizationsDict], LocalizationValue],
-    ):
+    ) -> None:
         ...
 
     # note: `data` accepting `LocalizationValue` is intentionally undocumented,
@@ -318,7 +318,7 @@ class LocalizationStore(LocalizationProtocol):
         Specifies whether :meth:`.get` raises an exception if localizations for a provided key couldn't be found.
     """
 
-    def __init__(self, *, strict: bool):
+    def __init__(self, *, strict: bool) -> None:
         self.strict = strict
 
         self._loc: DefaultDict[str, Dict[str, str]] = defaultdict(dict)

--- a/disnake/i18n.py
+++ b/disnake/i18n.py
@@ -120,7 +120,7 @@ class Localized(Generic[StringT]):
         *,
         key: str = MISSING,
         data: Union[Optional[LocalizationsDict], LocalizationValue] = MISSING,
-    ):
+    ) -> None:
         self.string: StringT = string
 
         if not (key is MISSING) ^ (data is MISSING):
@@ -185,7 +185,7 @@ class LocalizationValue:
 
     __slots__ = ("_key", "_data")
 
-    def __init__(self, localizations: Optional[Localizations]):
+    def __init__(self, localizations: Optional[Localizations]) -> None:
         self._key: Optional[str]
         self._data: Optional[Dict[str, str]]
 

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -339,7 +339,7 @@ class IntegrationApplication:
         "user",
     )
 
-    def __init__(self, *, data: IntegrationApplicationPayload, state):
+    def __init__(self, *, data: IntegrationApplicationPayload, state) -> None:
         self.id: int = int(data["id"])
         self.name: str = data["name"]
         self.icon: Optional[str] = data["icon"]

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -89,7 +89,7 @@ class PartialIntegration:
         self.guild = guild
         self._from_data(data)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id} name={self.name!r}>"
 
     def _from_data(self, data: PartialIntegrationPayload) -> None:
@@ -401,7 +401,7 @@ class BotIntegration(Integration):
         )
         self.scopes: List[str] = data.get("scopes") or []
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<{self.__class__.__name__} id={self.id}"
             f" name={self.name!r} scopes={self.scopes!r}>"

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -214,7 +214,7 @@ class ApplicationCommandInteractionData(Dict[str, Any]):
             for d in data.get("options", [])
         ]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<ApplicationCommandInteractionData id={self.id!r} name={self.name!r} type={self.type!r} "
             f"target_id={self.target_id!r} target={self.target!r} resolved={self.resolved!r} options={self.options!r}>"
@@ -289,7 +289,7 @@ class ApplicationCommandInteractionDataOption(Dict[str, Any]):
         ]
         self.focused: bool = data.get("focused", False)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<ApplicationCommandInteractionDataOption name={self.name!r} type={self.type!r}>"
             f"value={self.value!r} focused={self.focused!r} options={self.options!r}>"

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -92,7 +92,9 @@ class ApplicationCommandInteraction(Interaction):
         Whether the command failed to be checked or invoked.
     """
 
-    def __init__(self, *, data: ApplicationCommandInteractionPayload, state: ConnectionState):
+    def __init__(
+        self, *, data: ApplicationCommandInteractionPayload, state: ConnectionState
+    ) -> None:
         super().__init__(data=data, state=state)
         self.data: ApplicationCommandInteractionData = ApplicationCommandInteractionData(
             data=data["data"], state=state, guild_id=self.guild_id
@@ -194,7 +196,7 @@ class ApplicationCommandInteractionData(Dict[str, Any]):
         data: ApplicationCommandInteractionDataPayload,
         state: ConnectionState,
         guild_id: Optional[int],
-    ):
+    ) -> None:
         super().__init__(data)
         self.id: int = int(data["id"])
         self.name: str = data["name"]
@@ -272,7 +274,7 @@ class ApplicationCommandInteractionDataOption(Dict[str, Any]):
 
     __slots__ = ("name", "type", "value", "options", "focused")
 
-    def __init__(self, *, data: Mapping[str, Any], resolved: InteractionDataResolved):
+    def __init__(self, *, data: Mapping[str, Any], resolved: InteractionDataResolved) -> None:
         super().__init__(data)
         self.name: str = data["name"]
         self.type: OptionType = try_enum(OptionType, data["type"])

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -552,7 +552,7 @@ class Interaction:
 
         if delay is not None:
 
-            async def delete(delay: float):
+            async def delete(delay: float) -> None:
                 await asyncio.sleep(delay)
                 try:
                     await deleter
@@ -1649,7 +1649,7 @@ class InteractionMessage(Message):
             return await super().delete(delay=delay)
         if delay is not None:
 
-            async def inner_call(delay: float = delay):
+            async def inner_call(delay: float = delay) -> None:
                 await asyncio.sleep(delay)
                 try:
                     await self._state._interaction.delete_original_response()

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -170,7 +170,7 @@ class Interaction:
         "_cs_expires_at",
     )
 
-    def __init__(self, *, data: InteractionPayload, state: ConnectionState):
+    def __init__(self, *, data: InteractionPayload, state: ConnectionState) -> None:
         self.data: Mapping[str, Any] = data.get("data") or {}
         self._state: ConnectionState = state
         # TODO: Maybe use a unique session
@@ -698,7 +698,7 @@ class InteractionResponse:
         "_response_type",
     )
 
-    def __init__(self, parent: Interaction):
+    def __init__(self, parent: Interaction) -> None:
         self._parent: Interaction = parent
         self._response_type: Optional[InteractionResponseType] = None
 
@@ -1341,7 +1341,7 @@ class InteractionResponse:
 class _InteractionMessageState:
     __slots__ = ("_parent", "_interaction")
 
-    def __init__(self, interaction: Interaction, parent: ConnectionState):
+    def __init__(self, interaction: Interaction, parent: ConnectionState) -> None:
         self._interaction: Interaction = interaction
         self._parent: ConnectionState = parent
 
@@ -1696,7 +1696,7 @@ class InteractionDataResolved(Dict[str, Any]):
         data: InteractionDataResolvedPayload,
         state: ConnectionState,
         guild_id: Optional[int],
-    ):
+    ) -> None:
         data = data or {}
         super().__init__(data)
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1781,7 +1781,7 @@ class InteractionDataResolved(Dict[str, Any]):
         for str_id, attachment in attachments.items():
             self.attachments[int(str_id)] = Attachment(data=attachment, state=state)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<InteractionDataResolved members={self.members!r} users={self.users!r} "
             f"roles={self.roles!r} channels={self.channels!r} messages={self.messages!r} attachments={self.attachments!r}>"

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -77,7 +77,7 @@ class MessageInteraction(Interaction):
         The interaction client.
     """
 
-    def __init__(self, *, data: MessageInteractionPayload, state: ConnectionState):
+    def __init__(self, *, data: MessageInteractionPayload, state: ConnectionState) -> None:
         super().__init__(data=data, state=state)
         self.data: MessageInteractionData = MessageInteractionData(
             data=data["data"], state=state, guild_id=self.guild_id
@@ -163,7 +163,7 @@ class MessageInteractionData(Dict[str, Any]):
         data: MessageComponentInteractionDataPayload,
         state: ConnectionState,
         guild_id: Optional[int],
-    ):
+    ) -> None:
         super().__init__(data)
         self.custom_id: str = data["custom_id"]
         self.component_type: ComponentType = try_enum(ComponentType, data["component_type"])

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -176,7 +176,7 @@ class MessageInteractionData(Dict[str, Any]):
             data=data.get("resolved", empty_resolved), state=state, guild_id=guild_id
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<MessageInteractionData custom_id={self.custom_id!r} "
             f"component_type={self.component_type!r} values={self.values!r}>"

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -138,5 +138,5 @@ class ModalInteractionData(Dict[str, Any]):
         # and relevant fields like a select's `values`.
         self.components: List[ModalInteractionActionRowPayload] = data["components"]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<ModalInteractionData custom_id={self.custom_id!r} components={self.components!r}>"

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -71,7 +71,7 @@ class ModalInteraction(Interaction):
 
     __slots__ = ("message", "_cs_text_values")
 
-    def __init__(self, *, data: ModalInteractionPayload, state: ConnectionState):
+    def __init__(self, *, data: ModalInteractionPayload, state: ConnectionState) -> None:
         super().__init__(data=data, state=state)
         self.data: ModalInteractionData = ModalInteractionData(data=data["data"])
 
@@ -130,7 +130,7 @@ class ModalInteractionData(Dict[str, Any]):
 
     __slots__ = ("custom_id", "components")
 
-    def __init__(self, *, data: ModalInteractionDataPayload):
+    def __init__(self, *, data: ModalInteractionDataPayload) -> None:
         super().__init__(data)
         self.custom_id: str = data["custom_id"]
         # This uses a stripped-down action row TypedDict, as we only receive

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -547,7 +547,7 @@ class Invite(Hashable):
             url += f"?event={self.guild_scheduled_event.id}"
         return url
 
-    async def delete(self, *, reason: Optional[str] = None):
+    async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|
 
         Revokes the instant invite.

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -89,7 +89,7 @@ class PartialInviteChannel:
         "_state",
     )
 
-    def __init__(self, *, state: ConnectionState, data: InviteChannelPayload):
+    def __init__(self, *, state: ConnectionState, data: InviteChannelPayload) -> None:
         self._state = state
         self.id: int = int(data["id"])
         self.name: Optional[str] = data.get("name")
@@ -198,7 +198,7 @@ class PartialInviteGuild:
         "premium_subscription_count",
     )
 
-    def __init__(self, state: ConnectionState, data: InviteGuildPayload, id: int):
+    def __init__(self, state: ConnectionState, data: InviteGuildPayload, id: int) -> None:
         self._state: ConnectionState = state
         self.id: int = id
         self.name: str = data["name"]
@@ -392,7 +392,7 @@ class Invite(Hashable):
         data: Union[InvitePayload, GatewayInvitePayload],
         guild: Optional[Union[PartialInviteGuild, Guild]] = None,
         channel: Optional[Union[PartialInviteChannel, GuildChannel]] = None,
-    ):
+    ) -> None:
         self._state: ConnectionState = state
         self.max_age: Optional[int] = data.get("max_age")
         self.code: str = data["code"]

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -260,7 +260,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         after: Optional[Union[Snowflake, datetime.datetime]] = None,
         around: Optional[Union[Snowflake, datetime.datetime]] = None,
         oldest_first: Optional[bool] = None,
-    ):
+    ) -> None:
 
         if isinstance(before, datetime.datetime):
             before = Object(id=time_snowflake(before, high=False))
@@ -801,7 +801,7 @@ class ArchivedThreadIterator(_AsyncIterator["Thread"]):
         joined: bool,
         private: bool,
         before: Optional[Union[Snowflake, datetime.datetime]] = None,
-    ):
+    ) -> None:
         self.channel_id = channel_id
         self.guild = guild
         self.limit = limit

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -193,7 +193,7 @@ class ReactionIterator(_AsyncIterator[Union["User", "Member"]]):
         except asyncio.QueueEmpty:
             raise NoMoreItems()
 
-    async def fill_users(self):
+    async def fill_users(self) -> None:
         if self.limit > 0:
             retrieve = min(self.limit, 100)
 
@@ -329,7 +329,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         self.retrieve = retrieve
         return retrieve > 0
 
-    async def fill_messages(self):
+    async def fill_messages(self) -> None:
         if not hasattr(self, "channel"):
             # do the required set up
             channel = await self.messageable._get_channel()
@@ -449,7 +449,7 @@ class BanIterator(_AsyncIterator["BanEntry"]):
         self.retrieve = min(self.limit, 1000) if self.limit is not None else 1000
         return self.retrieve > 0
 
-    async def fill_bans(self):
+    async def fill_bans(self) -> None:
         if self._get_retrieve():
             data = await self._retrieve_bans(self.retrieve)
             if len(data) < 1000:
@@ -553,7 +553,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         self.retrieve = retrieve
         return retrieve > 0
 
-    async def _fill(self):
+    async def _fill(self) -> None:
         if self._get_retrieve():
             log_data = await self._retrieve_data(self.retrieve)
             entries = log_data.get("audit_log_entries")
@@ -699,7 +699,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
 
         return Guild(state=self.state, data=data)
 
-    async def fill_guilds(self):
+    async def fill_guilds(self) -> None:
         if self._get_retrieve():
             data = await self._retrieve_guilds(self.retrieve)
             if len(data) < 200:
@@ -770,7 +770,7 @@ class MemberIterator(_AsyncIterator["Member"]):
         self.retrieve = retrieve
         return retrieve > 0
 
-    async def fill_members(self):
+    async def fill_members(self) -> None:
         if self._get_retrieve():
             after = self.after.id if self.after else None
             data = await self.get_members(self.guild.id, self.retrieve, after)

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -74,7 +74,7 @@ class _AsyncIterator(AsyncIterator[T]):
         raise NotImplementedError
 
     def get(self, **attrs: Any) -> Awaitable[Optional[T]]:
-        def predicate(elem: T):
+        def predicate(elem: T) -> bool:
             for attr, val in attrs.items():
                 nested = attr.split("__")
                 obj = elem

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -120,7 +120,7 @@ class _AsyncIterator(AsyncIterator[T]):
 
 
 class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
-    def __init__(self, iterator, max_size):
+    def __init__(self, iterator, max_size) -> None:
         self.iterator = iterator
         self.max_size = max_size
 
@@ -141,7 +141,7 @@ class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
 
 
 class _MappedAsyncIterator(_AsyncIterator[OT]):
-    def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]):
+    def __init__(self, iterator: _AsyncIterator[T], func: _Func[T, OT]) -> None:
         self.iterator = iterator
         self.func = func
 
@@ -152,7 +152,7 @@ class _MappedAsyncIterator(_AsyncIterator[OT]):
 
 
 class _FilteredAsyncIterator(_AsyncIterator[T]):
-    def __init__(self, iterator: _AsyncIterator[T], predicate: _Func[T, bool]):
+    def __init__(self, iterator: _AsyncIterator[T], predicate: _Func[T, bool]) -> None:
         self.iterator = iterator
 
         if predicate is None:
@@ -172,7 +172,7 @@ class _FilteredAsyncIterator(_AsyncIterator[T]):
 
 
 class ReactionIterator(_AsyncIterator[Union["User", "Member"]]):
-    def __init__(self, message, emoji, limit=100, after=None):
+    def __init__(self, message, emoji, limit=100, after=None) -> None:
         self.message = message
         self.limit = limit
         self.after = after
@@ -417,7 +417,7 @@ class BanIterator(_AsyncIterator["BanEntry"]):
         limit: Optional[int] = None,
         before: Optional[Snowflake] = None,
         after: Optional[Snowflake] = None,
-    ):
+    ) -> None:
         self.guild = guild
         self.limit = limit
         self.before = before
@@ -496,7 +496,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         after: Optional[Union[Snowflake, datetime.datetime]] = None,
         user_id: Optional[int] = None,
         action_type: Optional[AuditLogEvent] = None,
-    ):
+    ) -> None:
         if isinstance(before, datetime.datetime):
             before = Object(id=time_snowflake(before, high=False))
         if isinstance(after, datetime.datetime):
@@ -649,7 +649,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         Object after which all guilds must be.
     """
 
-    def __init__(self, bot, limit, before=None, after=None):
+    def __init__(self, bot, limit, before=None, after=None) -> None:
 
         if isinstance(before, datetime.datetime):
             before = Object(id=time_snowflake(before, high=False))
@@ -739,7 +739,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
 
 
 class MemberIterator(_AsyncIterator["Member"]):
-    def __init__(self, guild, limit=1000, after=None):
+    def __init__(self, guild, limit=1000, after=None) -> None:
 
         if isinstance(after, datetime.datetime):
             after = Object(id=time_snowflake(after, high=True))
@@ -891,7 +891,7 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
         with_members: bool,
         before: Optional[Snowflake],
         after: Optional[Snowflake],
-    ):
+    ) -> None:
         self.event: GuildScheduledEvent = event
         self.limit: Optional[int] = limit
         self.with_members: bool = with_members

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -128,7 +128,7 @@ class VoiceState:
         *,
         data: Union[VoiceStatePayload, GuildVoiceStatePayload],
         channel: Optional[VocalGuildChannel] = None,
-    ):
+    ) -> None:
         self.session_id: str = data["session_id"]
         self._update(data, channel)
 
@@ -296,7 +296,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         data: Union[MemberWithUserPayload, GuildMemberUpdateEvent],
         guild: Guild,
         state: ConnectionState,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -307,7 +307,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         guild: Guild,
         state: ConnectionState,
         user_data: UserPayload,
-    ):
+    ) -> None:
         ...
 
     def __init__(
@@ -317,7 +317,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         guild: Guild,
         state: ConnectionState,
         user_data: Optional[UserPayload] = None,
-    ):
+    ) -> None:
         self._state: ConnectionState = state
         if user_data is None:
             user_data = cast("MemberWithUserPayload", data)["user"]

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -136,7 +136,7 @@ class VoiceState:
         self,
         data: Union[VoiceStatePayload, GuildVoiceStatePayload],
         channel: Optional[VocalGuildChannel],
-    ):
+    ) -> None:
         self.self_mute: bool = data.get("self_mute", False)
         self.self_deaf: bool = data.get("self_deaf", False)
         self.self_stream: bool = data.get("self_stream", False)

--- a/disnake/mentions.py
+++ b/disnake/mentions.py
@@ -17,13 +17,13 @@ if TYPE_CHECKING:
 
 
 class _FakeBool:
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "True"
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return other is True
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return True
 
 

--- a/disnake/mentions.py
+++ b/disnake/mentions.py
@@ -69,7 +69,7 @@ class AllowedMentions:
         users: Union[bool, List[Snowflake]] = default,
         roles: Union[bool, List[Snowflake]] = default,
         replied_user: bool = default,
-    ):
+    ) -> None:
         self.everyone = everyone
         self.users = users
         self.roles = roles

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1125,7 +1125,7 @@ class Message(Hashable):
                 if role is not None:
                     self.role_mentions.append(role)
 
-    def _handle_components(self, components: List[ComponentPayload]):
+    def _handle_components(self, components: List[ComponentPayload]) -> None:
         self.components = [
             _component_factory(d, type=ActionRow[MessageComponent]) for d in components
         ]
@@ -1424,7 +1424,7 @@ class Message(Hashable):
         """
         if delay is not None:
 
-            async def delete(delay: float):
+            async def delete(delay: float) -> None:
                 await asyncio.sleep(delay)
                 try:
                     await self._state.http.delete_message(self.channel.id, self.id)

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -279,7 +279,7 @@ class Attachment(Hashable):
         "description",
     )
 
-    def __init__(self, *, data: AttachmentPayload, state: ConnectionState):
+    def __init__(self, *, data: AttachmentPayload, state: ConnectionState) -> None:
         self.id: int = int(data["id"])
         self.size: int = data["size"]
         self.height: Optional[int] = data.get("height")
@@ -480,7 +480,7 @@ class DeletedReferencedMessage:
 
     __slots__ = ("_parent",)
 
-    def __init__(self, parent: MessageReference):
+    def __init__(self, parent: MessageReference) -> None:
         self._parent: MessageReference = parent
 
     def __repr__(self) -> str:
@@ -546,7 +546,7 @@ class MessageReference:
         channel_id: int,
         guild_id: Optional[int] = None,
         fail_if_not_exists: bool = True,
-    ):
+    ) -> None:
         self._state: Optional[ConnectionState] = None
         self.resolved: Optional[Union[Message, DeletedReferencedMessage]] = None
         self.message_id: Optional[int] = message_id
@@ -655,7 +655,7 @@ class InteractionReference:
 
     __slots__ = ("id", "type", "name", "user", "_state")
 
-    def __init__(self, *, state: ConnectionState, data: InteractionMessageReferencePayload):
+    def __init__(self, *, state: ConnectionState, data: InteractionMessageReferencePayload) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.type: InteractionType = try_enum(InteractionType, int(data["type"]))
@@ -872,7 +872,7 @@ class Message(Hashable):
         state: ConnectionState,
         channel: MessageableChannel,
         data: MessagePayload,
-    ):
+    ) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.application_id: Optional[int] = utils._get_as_snowflake(data, "application_id")

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -2064,7 +2064,7 @@ class PartialMessage(Hashable):
     to_reference = Message.to_reference
     to_message_reference_dict = Message.to_message_reference_dict
 
-    def __init__(self, *, channel: MessageableChannel, id: int):
+    def __init__(self, *, channel: MessageableChannel, id: int) -> None:
         if channel.type not in (
             ChannelType.text,
             ChannelType.news,

--- a/disnake/object.py
+++ b/disnake/object.py
@@ -49,7 +49,7 @@ class Object(Hashable):
         The ID of the object.
     """
 
-    def __init__(self, id: SupportsIntCast):
+    def __init__(self, id: SupportsIntCast) -> None:
         try:
             id = int(id)
         except ValueError:

--- a/disnake/opus.py
+++ b/disnake/opus.py
@@ -309,7 +309,7 @@ class OpusError(DiscordException):
         The error code returned.
     """
 
-    def __init__(self, code: int):
+    def __init__(self, code: int) -> None:
         self.code: int = code
         msg = _lib.opus_strerror(self.code).decode("utf-8")
         _log.info('"%s" has happened', msg)
@@ -340,7 +340,7 @@ class _OpusStruct:
 
 
 class Encoder(_OpusStruct):
-    def __init__(self, application: int = APPLICATION_AUDIO):
+    def __init__(self, application: int = APPLICATION_AUDIO) -> None:
         _OpusStruct.get_opus_version()
 
         self.application: int = application
@@ -405,7 +405,7 @@ class Encoder(_OpusStruct):
 
 
 class Decoder(_OpusStruct):
-    def __init__(self):
+    def __init__(self) -> None:
         _OpusStruct.get_opus_version()
 
         self._state: DecoderStruct = self._create_state()

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -160,7 +160,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
             return f"<a:{self.name}:{self.id}>"
         return f"<:{self.name}:{self.id}>"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"<{self.__class__.__name__} animated={self.animated} name={self.name!r} id={self.id}>"
         )

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -77,7 +77,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
     if TYPE_CHECKING:
         id: Optional[int]
 
-    def __init__(self, *, name: str, animated: bool = False, id: Optional[int] = None):
+    def __init__(self, *, name: str, animated: bool = False, id: Optional[int] = None) -> None:
         self.animated = animated
         self.name = name
         self.id = id

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -207,7 +207,7 @@ class Permissions(BaseFlags):
         view_audit_log: bool = ...,
         view_channel: bool = ...,
         view_guild_insights: bool = ...,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -215,7 +215,7 @@ class Permissions(BaseFlags):
     def __init__(
         self,
         permissions: int = 0,
-    ):
+    ) -> None:
         ...
 
     @_overload_with_permissions
@@ -1097,14 +1097,14 @@ class PermissionOverwrite:
         view_audit_log: Optional[bool] = ...,
         view_channel: Optional[bool] = ...,
         view_guild_insights: Optional[bool] = ...,
-    ):
+    ) -> None:
         ...
 
     @overload
     @_generated
     def __init__(
         self,
-    ):
+    ) -> None:
         ...
 
     @_overload_with_permissions

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -941,7 +941,7 @@ def _augment_from_permissions(cls):
         def getter(self, x=key):
             return self._values.get(x)
 
-        def setter(self, value, x=key):
+        def setter(self, value, x=key) -> None:
             self._set(x, value)
 
         prop = property(getter, setter)

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -219,7 +219,7 @@ class Permissions(BaseFlags):
         ...
 
     @_overload_with_permissions
-    def __init__(self, permissions: int = 0, **kwargs: bool):
+    def __init__(self, permissions: int = 0, **kwargs: bool) -> None:
         if not isinstance(permissions, int):
             raise TypeError(
                 f"Expected int parameter, received {permissions.__class__.__name__} instead."
@@ -1108,7 +1108,7 @@ class PermissionOverwrite:
         ...
 
     @_overload_with_permissions
-    def __init__(self, **kwargs: Optional[bool]):
+    def __init__(self, **kwargs: Optional[bool]) -> None:
         self._values: Dict[str, Optional[bool]] = {}
 
         for key, value in kwargs.items():

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -135,7 +135,7 @@ class FFmpegAudio(AudioSource):
         executable: str = "ffmpeg",
         args: Any,
         **subprocess_kwargs: Any,
-    ):
+    ) -> None:
         piping = subprocess_kwargs.get("stdin") == subprocess.PIPE
         if piping and isinstance(source, str):
             raise TypeError(
@@ -642,7 +642,7 @@ class PCMVolumeTransformer(AudioSource, Generic[AT]):
         The audio source is opus encoded.
     """
 
-    def __init__(self, original: AT, volume: float = 1.0):
+    def __init__(self, original: AT, volume: float = 1.0) -> None:
         if not isinstance(original, AudioSource):
             raise TypeError(f"expected AudioSource not {original.__class__.__name__}.")
 
@@ -672,7 +672,7 @@ class PCMVolumeTransformer(AudioSource, Generic[AT]):
 class AudioPlayer(threading.Thread):
     DELAY: float = OpusEncoder.FRAME_LENGTH / 1000.0
 
-    def __init__(self, source: AudioSource, client: VoiceClient, *, after=None):
+    def __init__(self, source: AudioSource, client: VoiceClient, *, after=None) -> None:
         threading.Thread.__init__(self)
         self.daemon: bool = True
         self.source: AudioSource = source

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -296,7 +296,7 @@ class RawGuildScheduledEventUserActionEvent(_RawReprMixin):
 
     def __init__(
         self, data: Union[GuildScheduledEventUserAddEvent, GuildScheduledEventUserRemoveEvent]
-    ):
+    ) -> None:
         self.event_id: int = int(data["guild_scheduled_event_id"])
         self.user_id: int = int(data["user_id"])
         self.guild_id: int = int(data["guild_id"])
@@ -329,7 +329,7 @@ class RawThreadDeleteEvent(_RawReprMixin):
         "thread",
     )
 
-    def __init__(self, data: ThreadDeleteEvent):
+    def __init__(self, data: ThreadDeleteEvent) -> None:
         self.thread_id: int = int(data["id"])
         self.thread_type: ThreadType = cast("ThreadType", try_enum(ChannelType, data["type"]))
         self.guild_id: int = int(data["guild_id"])
@@ -358,7 +358,7 @@ class RawThreadMemberRemoveEvent(_RawReprMixin):
         "cached_member",
     )
 
-    def __init__(self, thread: Thread, member_id: int):
+    def __init__(self, thread: Thread, member_id: int) -> None:
         self.thread: Thread = thread
         self.member_id: int = member_id
         self.cached_member: Optional[ThreadMember] = None
@@ -414,6 +414,6 @@ class RawGuildMemberRemoveEvent(_RawReprMixin):
         "user",
     )
 
-    def __init__(self, user: Union[User, Member], guild_id: int):
+    def __init__(self, user: Union[User, Member], guild_id: int) -> None:
         self.user: Union[User, Member] = user
         self.guild_id: int = guild_id

--- a/disnake/reaction.py
+++ b/disnake/reaction.py
@@ -62,7 +62,7 @@ class Reaction:
         message: Message,
         data: ReactionPayload,
         emoji: Optional[Union[PartialEmoji, Emoji, str]] = None,
-    ):
+    ) -> None:
         self.message: Message = message
         self.emoji: Union[PartialEmoji, Emoji, str] = emoji or message._state.get_reaction_emoji(
             data["emoji"]

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -54,7 +54,7 @@ class RoleTags:
         "_premium_subscriber",
     )
 
-    def __init__(self, data: RoleTagPayload):
+    def __init__(self, data: RoleTagPayload) -> None:
         self.bot_id: Optional[int] = _get_as_snowflake(data, "bot_id")
         self.integration_id: Optional[int] = _get_as_snowflake(data, "integration_id")
         # NOTE: The API returns "null" for this if it's valid, which corresponds to None.
@@ -174,7 +174,7 @@ class Role(Hashable):
         "_state",
     )
 
-    def __init__(self, *, guild: Guild, state: ConnectionState, data: RolePayload):
+    def __init__(self, *, guild: Guild, state: ConnectionState, data: RolePayload) -> None:
         self.guild: Guild = guild
         self._state: ConnectionState = state
         self.id: int = int(data["id"])

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -222,7 +222,7 @@ class Role(Hashable):
             return NotImplemented
         return not r
 
-    def _update(self, data: RolePayload):
+    def _update(self, data: RolePayload) -> None:
         self.name: str = data["name"]
         self._permissions: int = int(data.get("permissions", 0))
         self.position: int = data.get("position", 0)

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -350,11 +350,11 @@ class AutoShardedClient(Client):
         member_cache_flags: Optional[MemberCacheFlags] = None,
         localization_provider: Optional[LocalizationProtocol] = None,
         strict_localization: bool = False,
-    ):
+    ) -> None:
         ...
 
     @overload
-    def __init__(self: NoReturn):
+    def __init__(self: NoReturn) -> None:
         ...
 
     def __init__(self, *args: Any, shard_ids: Optional[List[int]] = None, **kwargs: Any) -> None:

--- a/disnake/stage_instance.py
+++ b/disnake/stage_instance.py
@@ -71,7 +71,7 @@ class StageInstance(Hashable):
         self.guild = guild
         self._update(data)
 
-    def _update(self, data: StageInstancePayload):
+    def _update(self, data: StageInstancePayload) -> None:
         self.id: int = int(data["id"])
         self.channel_id: int = int(data["channel_id"])
         self.topic: str = data["topic"]

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1415,7 +1415,7 @@ class ConnectionState:
             return await request.wait()
         return request.get_future()
 
-    async def _chunk_and_dispatch(self, guild, unavailable):
+    async def _chunk_and_dispatch(self, guild, unavailable) -> None:
         try:
             await asyncio.wait_for(self.chunk_guild(guild), timeout=60.0)
         except asyncio.TimeoutError:

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -181,7 +181,7 @@ class StickerItem(_StickerTag):
 
     __slots__ = ("name", "id", "format", "url")
 
-    def __init__(self, *, state: ConnectionState, data: StickerItemPayload):
+    def __init__(self, *, state: ConnectionState, data: StickerItemPayload) -> None:
         self._state: ConnectionState = state
         self.name: str = data["name"]
         self.id: int = int(data["id"])

--- a/disnake/team.py
+++ b/disnake/team.py
@@ -38,7 +38,7 @@ class Team:
 
     __slots__ = ("_state", "id", "name", "_icon", "owner_id", "members")
 
-    def __init__(self, state: ConnectionState, data: TeamPayload):
+    def __init__(self, state: ConnectionState, data: TeamPayload) -> None:
         self._state: ConnectionState = state
 
         self.id: int = int(data["id"])
@@ -108,7 +108,7 @@ class TeamMember(BaseUser):
 
     __slots__ = ("team", "membership_state", "permissions")
 
-    def __init__(self, team: Team, state: ConnectionState, data: TeamMemberPayload):
+    def __init__(self, team: Team, state: ConnectionState, data: TeamMemberPayload) -> None:
         self.team: Team = team
         self.membership_state: TeamMembershipState = try_enum(
             TeamMembershipState, data["membership_state"]

--- a/disnake/template.py
+++ b/disnake/template.py
@@ -26,7 +26,7 @@ class _FriendlyHttpAttributeErrorHelper:
 
 
 class _PartialTemplateState:
-    def __init__(self, *, state):
+    def __init__(self, *, state) -> None:
         self.__state = state
         self.http = _FriendlyHttpAttributeErrorHelper()
 

--- a/disnake/template.py
+++ b/disnake/template.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, NoReturn, Optional
 
 from .guild import Guild
 from .utils import MISSING, _assetbytes_to_base64_data, parse_time
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 class _FriendlyHttpAttributeErrorHelper:
     __slots__ = ()
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr) -> NoReturn:
         raise AttributeError("PartialTemplateState does not support http methods.")
 
 
@@ -61,7 +61,7 @@ class _PartialTemplateState:
     async def query_members(self, **kwargs: Any):
         return []
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr) -> NoReturn:
         raise AttributeError(f"PartialTemplateState does not support {attr!r}.")
 
 

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -182,7 +182,7 @@ class Thread(Messageable, Hashable):
     def __str__(self) -> str:
         return self.name
 
-    def _from_data(self, data: ThreadPayload):
+    def _from_data(self, data: ThreadPayload) -> None:
         self.id = int(data["id"])
         self.parent_id = int(data["parent_id"])
         self.owner_id = _get_as_snowflake(data, "owner_id")
@@ -207,7 +207,7 @@ class Thread(Messageable, Hashable):
         else:
             self.me = ThreadMember(self, member)
 
-    def _unroll_metadata(self, data: ThreadMetadata):
+    def _unroll_metadata(self, data: ThreadMetadata) -> None:
         self.archived = data["archived"]
         self.auto_archive_duration = data["auto_archive_duration"]
         self.archive_timestamp = parse_time(data["archive_timestamp"])
@@ -215,7 +215,7 @@ class Thread(Messageable, Hashable):
         self.invitable = data.get("invitable", True)
         self.create_timestamp = parse_time(data.get("create_timestamp"))
 
-    def _update(self, data):
+    def _update(self, data) -> None:
         try:
             self.name = data["name"]
         except KeyError:
@@ -594,7 +594,7 @@ class Thread(Messageable, Hashable):
 
         minimum_time = int((time.time() - 14 * 24 * 60 * 60) * 1000.0 - 1420070400000) << 22
 
-        async def _single_delete_strategy(messages: Iterable[Message]):
+        async def _single_delete_strategy(messages: Iterable[Message]) -> None:
             for m in messages:
                 await m.delete()
 
@@ -749,7 +749,7 @@ class Thread(Messageable, Hashable):
         # The data payload will always be a Thread payload
         return Thread(data=data, state=self._state, guild=self.guild)  # type: ignore
 
-    async def join(self):
+    async def join(self) -> None:
         """|coro|
 
         Joins this thread.
@@ -766,7 +766,7 @@ class Thread(Messageable, Hashable):
         """
         await self._state.http.join_thread(self.id)
 
-    async def leave(self):
+    async def leave(self) -> None:
         """|coro|
 
         Leaves this thread.
@@ -778,7 +778,7 @@ class Thread(Messageable, Hashable):
         """
         await self._state.http.leave_thread(self.id)
 
-    async def add_user(self, user: Snowflake):
+    async def add_user(self, user: Snowflake) -> None:
         """|coro|
 
         Adds a user to this thread.
@@ -802,7 +802,7 @@ class Thread(Messageable, Hashable):
         """
         await self._state.http.add_user_to_thread(self.id, user.id)
 
-    async def remove_user(self, user: Snowflake):
+    async def remove_user(self, user: Snowflake) -> None:
         """|coro|
 
         Removes a user from this thread.

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -1052,7 +1052,7 @@ class ThreadMember(Hashable):
             f"<ThreadMember id={self.id} thread_id={self.thread_id} joined_at={self.joined_at!r}>"
         )
 
-    def _from_data(self, data: ThreadMemberPayload):
+    def _from_data(self, data: ThreadMemberPayload) -> None:
         try:
             self.id = int(data["user_id"])
         except KeyError:
@@ -1146,7 +1146,7 @@ class ForumTag(Hashable):
         name: str,
         emoji: Optional[Union[str, PartialEmoji, Emoji]] = None,
         moderated: bool = False,
-    ):
+    ) -> None:
         self.id: int = 0
         self.name: str = name
         self.moderated: bool = moderated

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -163,7 +163,7 @@ class Thread(Messageable, Hashable):
         "_members",
     )
 
-    def __init__(self, *, guild: Guild, state: ConnectionState, data: ThreadPayload):
+    def __init__(self, *, guild: Guild, state: ConnectionState, data: ThreadPayload) -> None:
         self._state: ConnectionState = state
         self.guild = guild
         self._members: Dict[int, ThreadMember] = {}
@@ -1042,7 +1042,7 @@ class ThreadMember(Hashable):
         "parent",
     )
 
-    def __init__(self, parent: Thread, data: ThreadMemberPayload):
+    def __init__(self, parent: Thread, data: ThreadMemberPayload) -> None:
         self.parent = parent
         self._state = parent._state
         self._from_data(data)

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -137,7 +137,7 @@ class ActionRow(Generic[UIComponentT]):
     # When unspecified and called empty, default to an ActionRow that takes any kind of component.
 
     @overload
-    def __init__(self: ActionRow[WrappedComponent]):
+    def __init__(self: ActionRow[WrappedComponent]) -> None:
         ...
 
     # Explicit definitions are needed to make
@@ -146,17 +146,17 @@ class ActionRow(Generic[UIComponentT]):
     # differentiate themselves properly.
 
     @overload
-    def __init__(self: ActionRow[MessageUIComponent], *components: MessageUIComponent):
+    def __init__(self: ActionRow[MessageUIComponent], *components: MessageUIComponent) -> None:
         ...
 
     @overload
-    def __init__(self: ActionRow[ModalUIComponent], *components: ModalUIComponent):
+    def __init__(self: ActionRow[ModalUIComponent], *components: ModalUIComponent) -> None:
         ...
 
     # Allow use of "ActionRow[StrictUIComponent]" externally.
 
     @overload
-    def __init__(self: ActionRow[StrictUIComponentT], *components: StrictUIComponentT):
+    def __init__(self: ActionRow[StrictUIComponentT], *components: StrictUIComponentT) -> None:
         ...
 
     def __init__(self, *components: UIComponentT):

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -159,7 +159,7 @@ class ActionRow(Generic[UIComponentT]):
     def __init__(self: ActionRow[StrictUIComponentT], *components: StrictUIComponentT) -> None:
         ...
 
-    def __init__(self, *components: UIComponentT):
+    def __init__(self, *components: UIComponentT) -> None:
         self._children: List[UIComponentT] = []
 
         for component in components:

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -94,7 +94,7 @@ class Button(Item[V_co]):
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -108,7 +108,7 @@ class Button(Item[V_co]):
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     def __init__(

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -164,7 +164,7 @@ class Button(Item[V_co]):
         return self._underlying.style
 
     @style.setter
-    def style(self, value: ButtonStyle):
+    def style(self, value: ButtonStyle) -> None:
         self._underlying.style = value
 
     @property
@@ -199,7 +199,7 @@ class Button(Item[V_co]):
         return self._underlying.disabled
 
     @disabled.setter
-    def disabled(self, value: bool):
+    def disabled(self, value: bool) -> None:
         self._underlying.disabled = bool(value)
 
     @property
@@ -208,7 +208,7 @@ class Button(Item[V_co]):
         return self._underlying.label
 
     @label.setter
-    def label(self, value: Optional[str]):
+    def label(self, value: Optional[str]) -> None:
         self._underlying.label = str(value) if value is not None else value
 
     @property

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -121,7 +121,7 @@ class Button(Item[V_co]):
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         super().__init__()
         if custom_id is not None and url is not None:
             raise TypeError("cannot mix both url and custom_id with Button")
@@ -176,7 +176,7 @@ class Button(Item[V_co]):
         return self._underlying.custom_id
 
     @custom_id.setter
-    def custom_id(self, value: Optional[str]):
+    def custom_id(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("custom_id must be None or str")
 
@@ -188,7 +188,7 @@ class Button(Item[V_co]):
         return self._underlying.url
 
     @url.setter
-    def url(self, value: Optional[str]):
+    def url(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("url must be None or str")
         self._underlying.url = value
@@ -217,7 +217,7 @@ class Button(Item[V_co]):
         return self._underlying.emoji
 
     @emoji.setter
-    def emoji(self, value: Optional[Union[str, Emoji, PartialEmoji]]):
+    def emoji(self, value: Optional[Union[str, Emoji, PartialEmoji]]) -> None:
         if value is not None:
             if isinstance(value, str):
                 self._underlying.emoji = PartialEmoji.from_str(value)

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -129,7 +129,7 @@ class Item(WrappedComponent, Generic[V_co]):
         return self._row
 
     @row.setter
-    def row(self, value: Optional[int]):
+    def row(self, value: Optional[int]) -> None:
         if value is None:
             self._row = None
         elif 5 > value >= 0:

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -142,7 +142,7 @@ class Item(WrappedComponent, Generic[V_co]):
         """Optional[:class:`View`]: The underlying view for this item."""
         return self._view
 
-    async def callback(self, interaction: MessageInteraction, /):
+    async def callback(self, interaction: MessageInteraction, /) -> None:
         """|coro|
 
         The callback associated with this UI item.

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -89,14 +89,14 @@ class Item(WrappedComponent, Generic[V_co]):
     __repr_attributes__: Tuple[str, ...] = ("row",)
 
     @overload
-    def __init__(self: Item[None]):
+    def __init__(self: Item[None]) -> None:
         ...
 
     @overload
-    def __init__(self: Item[V_co]):
+    def __init__(self: Item[V_co]) -> None:
         ...
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._view: V_co = None  # type: ignore
         self._row: Optional[int] = None
         self._rendered_row: Optional[int] = None

--- a/disnake/ui/select/base.py
+++ b/disnake/ui/select/base.py
@@ -100,7 +100,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         return self._underlying.custom_id
 
     @custom_id.setter
-    def custom_id(self, value: str):
+    def custom_id(self, value: str) -> None:
         if not isinstance(value, str):
             raise TypeError("custom_id must be None or str")
 
@@ -112,7 +112,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         return self._underlying.placeholder
 
     @placeholder.setter
-    def placeholder(self, value: Optional[str]):
+    def placeholder(self, value: Optional[str]) -> None:
         if value is not None and not isinstance(value, str):
             raise TypeError("placeholder must be None or str")
 

--- a/disnake/ui/select/base.py
+++ b/disnake/ui/select/base.py
@@ -124,7 +124,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         return self._underlying.min_values
 
     @min_values.setter
-    def min_values(self, value: int):
+    def min_values(self, value: int) -> None:
         self._underlying.min_values = int(value)
 
     @property
@@ -133,7 +133,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         return self._underlying.max_values
 
     @max_values.setter
-    def max_values(self, value: int):
+    def max_values(self, value: int) -> None:
         self._underlying.max_values = int(value)
 
     @property
@@ -142,7 +142,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         return self._underlying.disabled
 
     @disabled.setter
-    def disabled(self, value: bool):
+    def disabled(self, value: bool) -> None:
         self._underlying.disabled = bool(value)
 
     @property

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -75,7 +75,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "InteractionChannel", V_co]):
         disabled: bool = False,
         channel_types: Optional[List[ChannelType]] = None,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -89,7 +89,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "InteractionChannel", V_co]):
         disabled: bool = False,
         channel_types: Optional[List[ChannelType]] = None,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     def __init__(

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -71,7 +71,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -84,7 +84,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     def __init__(

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -69,7 +69,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -82,7 +82,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     def __init__(

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -183,7 +183,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         description: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         default: bool = False,
-    ):
+    ) -> None:
         """Adds an option to the select menu.
 
         To append a pre-existing :class:`.SelectOption` use the

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -167,7 +167,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         return self._underlying.options
 
     @options.setter
-    def options(self, value: List[SelectOption]):
+    def options(self, value: List[SelectOption]) -> None:
         if not isinstance(value, list):
             raise TypeError("options must be a list of SelectOption")
         if not all(isinstance(obj, SelectOption) for obj in value):
@@ -221,7 +221,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
 
         self.append_option(option)
 
-    def append_option(self, option: SelectOption):
+    def append_option(self, option: SelectOption) -> None:
         """Appends an option to the select menu.
 
         Parameters

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -109,7 +109,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         options: SelectOptionInput = ...,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -123,7 +123,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         options: SelectOptionInput = ...,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     def __init__(

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -70,7 +70,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     @overload
@@ -83,7 +83,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         row: Optional[int] = None,
-    ):
+    ) -> None:
         ...
 
     def __init__(

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -558,7 +558,7 @@ class ViewStore:
         item.refresh_state(interaction)
         view._dispatch_item(item, interaction)
 
-    def is_message_tracked(self, message_id: int):
+    def is_message_tracked(self, message_id: int) -> bool:
         return message_id in self._synced_message_views
 
     def remove_message_tracking(self, message_id: int) -> Optional[View]:

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -89,7 +89,7 @@ def _component_to_item(component: MessageComponent) -> Item:
 class _ViewWeights:
     __slots__ = ("weights",)
 
-    def __init__(self, children: List[Item]):
+    def __init__(self, children: List[Item]) -> None:
         self.weights: List[int] = [0, 0, 0, 0, 0]
 
         key: Callable[[Item[View]], int] = lambda i: sys.maxsize if i.row is None else i.row
@@ -167,7 +167,7 @@ class View:
 
         cls.__view_children_items__ = children
 
-    def __init__(self, *, timeout: Optional[float] = 180.0):
+    def __init__(self, *, timeout: Optional[float] = 180.0) -> None:
         self.timeout = timeout
         self.children: List[Item] = []
         for func in self.__view_children_items__:
@@ -500,7 +500,7 @@ class View:
 
 
 class ViewStore:
-    def __init__(self, state: ConnectionState):
+    def __init__(self, state: ConnectionState) -> None:
         # (component_type, message_id, custom_id): (View, Item)
         self._views: Dict[Tuple[int, Optional[int], str], Tuple[View, Item]] = {}
         # message_id: View

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -396,14 +396,14 @@ class View:
             self.__timeout_expiry = time.monotonic() + self.timeout
             self.__timeout_task = loop.create_task(self.__timeout_task_impl())
 
-    def _dispatch_timeout(self):
+    def _dispatch_timeout(self) -> None:
         if self.__stopped.done():
             return
 
         self.__stopped.set_result(True)
         asyncio.create_task(self.on_timeout(), name=f"disnake-ui-view-timeout-{self.id}")
 
-    def _dispatch_item(self, item: Item, interaction: MessageInteraction):
+    def _dispatch_item(self, item: Item, interaction: MessageInteraction) -> None:
         if self.__stopped.done():
             return
 
@@ -411,7 +411,7 @@ class View:
             self._scheduled_task(item, interaction), name=f"disnake-ui-view-dispatch-{self.id}"
         )
 
-    def refresh(self, components: List[ActionRowComponent[MessageComponent]]):
+    def refresh(self, components: List[ActionRowComponent[MessageComponent]]) -> None:
         # TODO: this is pretty hacky at the moment
         old_state: Dict[Tuple[int, str], Item] = {
             (item.type.value, item.custom_id): item  # type: ignore
@@ -512,7 +512,7 @@ class ViewStore:
         views = {view.id: view for view, _ in self._views.values() if view.is_persistent()}
         return list(views.values())
 
-    def __verify_integrity(self):
+    def __verify_integrity(self) -> None:
         to_remove: List[Tuple[int, Optional[int], str]] = []
         for (k, (view, _)) in self._views.items():
             if view.is_finished():
@@ -521,7 +521,7 @@ class ViewStore:
         for k in to_remove:
             del self._views[k]
 
-    def add_view(self, view: View, message_id: Optional[int] = None):
+    def add_view(self, view: View, message_id: Optional[int] = None) -> None:
         self.__verify_integrity()
 
         view._start_listening_from_store(self)
@@ -532,7 +532,7 @@ class ViewStore:
         if message_id is not None:
             self._synced_message_views[message_id] = view
 
-    def remove_view(self, view: View):
+    def remove_view(self, view: View) -> None:
         for item in view.children:
             if item.is_dispatchable():
                 self._views.pop((item.type.value, item.custom_id), None)  # type: ignore
@@ -542,7 +542,7 @@ class ViewStore:
                 del self._synced_message_views[key]
                 break
 
-    def dispatch(self, interaction: MessageInteraction):
+    def dispatch(self, interaction: MessageInteraction) -> None:
         self.__verify_integrity()
         message_id: Optional[int] = interaction.message and interaction.message.id
         component_type = try_enum_to_int(interaction.data.component_type)
@@ -564,7 +564,7 @@ class ViewStore:
     def remove_message_tracking(self, message_id: int) -> Optional[View]:
         return self._synced_message_views.pop(message_id, None)
 
-    def update_from_message(self, message_id: int, components: List[ComponentPayload]):
+    def update_from_message(self, message_id: int, components: List[ComponentPayload]) -> None:
         # pre-req: is_message_tracked == true
         view = self._synced_message_views[message_id]
         view.refresh(

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -31,6 +31,7 @@ from typing import (
     List,
     Literal,
     Mapping,
+    NoReturn,
     Optional,
     Protocol,
     Sequence,
@@ -167,7 +168,7 @@ class classproperty(Generic[T_co]):
     def __get__(self, instance: Optional[Any], owner: Type[Any]) -> T_co:
         return self.fget(owner)
 
-    def __set__(self, instance, value) -> None:
+    def __set__(self, instance, value) -> NoReturn:
         raise AttributeError("cannot set attribute")
 
 

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -94,7 +94,7 @@ MISSING: Any = _MissingSentinel()
 
 
 class _cached_property:
-    def __init__(self, function):
+    def __init__(self, function) -> None:
         self.function = function
         self.__doc__: Optional[str] = function.__doc__
 
@@ -181,7 +181,7 @@ def cached_slot_property(name: str) -> Callable[[Callable[[T], T_co]], CachedSlo
 class SequenceProxy(Sequence[T_co]):
     """Read-only proxy of a Sequence."""
 
-    def __init__(self, proxied: Sequence[T_co]):
+    def __init__(self, proxied: Sequence[T_co]) -> None:
         self.__proxied = proxied
 
     def __getitem__(self, idx: int) -> T_co:
@@ -694,7 +694,7 @@ class SnowflakeList(array.array):
 
     if TYPE_CHECKING:
 
-        def __init__(self, data: Iterable[int], *, is_sorted: bool = False):
+        def __init__(self, data: Iterable[int], *, is_sorted: bool = False) -> None:
             ...
 
     def __new__(cls, data: Iterable[int], *, is_sorted: bool = False):

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -197,7 +197,7 @@ class VoiceClient(VoiceProtocol):
     ip: str
     port: int
 
-    def __init__(self, client: Client, channel: abc.Connectable):
+    def __init__(self, client: Client, channel: abc.Connectable) -> None:
         if not has_nacl:
             raise RuntimeError("PyNaCl library needed in order to use voice")
 

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -243,7 +243,7 @@ class VoiceClient(VoiceProtocol):
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user
 
-    def checked_add(self, attr, value, limit):
+    def checked_add(self, attr, value, limit) -> None:
         val = getattr(self, attr)
         if val + value > limit:
             setattr(self, attr, 0)

--- a/disnake/voice_region.py
+++ b/disnake/voice_region.py
@@ -45,7 +45,7 @@ class VoiceRegion:
         self.optimal: bool = data.get("optimal", False)
         self.custom: bool = data.get("custom", False)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.id
 
     def __repr__(self) -> str:

--- a/disnake/voice_region.py
+++ b/disnake/voice_region.py
@@ -38,7 +38,7 @@ class VoiceRegion:
         "custom",
     )
 
-    def __init__(self, *, data: VoiceRegionPayload):
+    def __init__(self, *, data: VoiceRegionPayload) -> None:
         self.id: str = data["id"]
         self.name: str = data["name"]
         self.deprecated: bool = data.get("deprecated", False)

--- a/disnake/voice_region.py
+++ b/disnake/voice_region.py
@@ -48,5 +48,5 @@ class VoiceRegion:
     def __str__(self):
         return self.id
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<VoiceRegion id={self.id!r} name={self.name!r} optimal={self.optimal!r}>"

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -14,6 +14,7 @@ from typing import (
     List,
     Literal,
     NamedTuple,
+    NoReturn,
     Optional,
     Sequence,
     Tuple,
@@ -662,7 +663,7 @@ class PartialWebhookGuild(Hashable):
 class _FriendlyHttpAttributeErrorHelper:
     __slots__ = ()
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr) -> NoReturn:
         raise AttributeError("PartialWebhookState does not support http methods.")
 
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -622,7 +622,7 @@ class PartialWebhookChannel(Hashable):
         self.id = int(data["id"])
         self.name = data["name"]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<PartialWebhookChannel name={self.name!r} id={self.id}>"
 
 
@@ -649,7 +649,7 @@ class PartialWebhookGuild(Hashable):
         self.name = data["name"]
         self._icon = data["icon"]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<PartialWebhookGuild name={self.name!r} id={self.id}>"
 
     @property
@@ -1088,7 +1088,7 @@ class Webhook(BaseWebhook):
         super().__init__(data, token, state)
         self.session = session
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Webhook id={self.id!r}>"
 
     @property

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1257,7 +1257,7 @@ class Webhook(BaseWebhook):
 
         return Webhook(data, self.session, token=self.auth_token, state=self._state)
 
-    async def delete(self, *, reason: Optional[str] = None, prefer_auth: bool = True):
+    async def delete(self, *, reason: Optional[str] = None, prefer_auth: bool = True) -> None:
         """|coro|
 
         Deletes this Webhook.

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -18,6 +18,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
     overload,
@@ -49,6 +50,7 @@ _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import datetime
+    from types import TracebackType
 
     from ..abc import Snowflake
     from ..asset import AssetBytes
@@ -81,7 +83,12 @@ class AsyncDeferredLock:
     def delay_by(self, delta: float) -> None:
         self.delta = delta
 
-    async def __aexit__(self, type, value, traceback) -> None:
+    async def __aexit__(
+        self,
+        type: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         if self.delta:
             await asyncio.sleep(self.delta)
         self.lock.release()

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -864,7 +864,7 @@ class WebhookMessage(Message):
         """
         if delay is not None:
 
-            async def inner_call(delay: float = delay):
+            async def inner_call(delay: float = delay) -> None:
                 await asyncio.sleep(delay)
                 try:
                     await self._state._webhook.delete_message(self.id)
@@ -905,7 +905,7 @@ class BaseWebhook(Hashable):
         )
         self._update(data)
 
-    def _update(self, data: WebhookPayload):
+    def _update(self, data: WebhookPayload) -> None:
         self.id = int(data["id"])
         self.type = try_enum(WebhookType, int(data["type"]))
         self.channel_id = utils._get_as_snowflake(data, "channel_id")

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -69,7 +69,7 @@ MISSING = utils.MISSING
 
 
 class AsyncDeferredLock:
-    def __init__(self, lock: asyncio.Lock):
+    def __init__(self, lock: asyncio.Lock) -> None:
         self.lock = lock
         self.delta: Optional[float] = None
 
@@ -80,14 +80,14 @@ class AsyncDeferredLock:
     def delay_by(self, delta: float) -> None:
         self.delta = delta
 
-    async def __aexit__(self, type, value, traceback):
+    async def __aexit__(self, type, value, traceback) -> None:
         if self.delta:
             await asyncio.sleep(self.delta)
         self.lock.release()
 
 
 class AsyncWebhookAdapter:
-    def __init__(self):
+    def __init__(self) -> None:
         self._locks: Dict[Any, asyncio.Lock] = {}
 
     async def request(
@@ -617,7 +617,7 @@ class PartialWebhookChannel(Hashable):
 
     __slots__ = ("id", "name")
 
-    def __init__(self, *, data):
+    def __init__(self, *, data) -> None:
         self.id = int(data["id"])
         self.name = data["name"]
 
@@ -642,7 +642,7 @@ class PartialWebhookGuild(Hashable):
 
     __slots__ = ("id", "name", "_icon", "_state")
 
-    def __init__(self, *, data, state):
+    def __init__(self, *, data, state) -> None:
         self._state = state
         self.id = int(data["id"])
         self.name = data["name"]
@@ -672,7 +672,9 @@ WebhookT = TypeVar("WebhookT", bound="BaseWebhook")
 class _WebhookState(Generic[WebhookT]):
     __slots__ = ("_parent", "_webhook")
 
-    def __init__(self, webhook: WebhookT, parent: Optional[Union[ConnectionState, _WebhookState]]):
+    def __init__(
+        self, webhook: WebhookT, parent: Optional[Union[ConnectionState, _WebhookState]]
+    ) -> None:
         self._webhook: WebhookT = webhook
 
         self._parent: Optional[ConnectionState]
@@ -896,7 +898,7 @@ class BaseWebhook(Hashable):
         data: WebhookPayload,
         token: Optional[str] = None,
         state: Optional[ConnectionState] = None,
-    ):
+    ) -> None:
         self.auth_token: Optional[str] = token
         self._state: Union[ConnectionState, _WebhookState] = state or _WebhookState(
             self, parent=state
@@ -1081,7 +1083,7 @@ class Webhook(BaseWebhook):
         session: aiohttp.ClientSession,
         token: Optional[str] = None,
         state=None,
-    ):
+    ) -> None:
         super().__init__(data, token, state)
         self.session = session
 

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -46,7 +46,7 @@ MISSING = utils.MISSING
 
 
 class DeferredLock:
-    def __init__(self, lock: threading.Lock):
+    def __init__(self, lock: threading.Lock) -> None:
         self.lock = lock
         self.delta: Optional[float] = None
 
@@ -57,14 +57,14 @@ class DeferredLock:
     def delay_by(self, delta: float) -> None:
         self.delta = delta
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type, value, traceback) -> None:
         if self.delta:
             time.sleep(self.delta)
         self.lock.release()
 
 
 class WebhookAdapter:
-    def __init__(self):
+    def __init__(self) -> None:
         self._locks: Dict[Any, threading.Lock] = {}
 
     def request(
@@ -561,7 +561,7 @@ class SyncWebhook(BaseWebhook):
 
     def __init__(
         self, data: WebhookPayload, session: Session, token: Optional[str] = None, state=None
-    ):
+    ) -> None:
         super().__init__(data, token, state)
         self.session = session
 

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -565,7 +565,7 @@ class SyncWebhook(BaseWebhook):
         super().__init__(data, token, state)
         self.session = session
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<Webhook id={self.id!r}>"
 
     @property

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -12,7 +12,7 @@ import logging
 import re
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, Union, overload
 from urllib.parse import quote as urlquote
 
 from .. import utils
@@ -30,6 +30,8 @@ __all__ = (
 _log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from ..abc import Snowflake
     from ..embeds import Embed
     from ..file import File
@@ -57,7 +59,12 @@ class DeferredLock:
     def delay_by(self, delta: float) -> None:
         self.delta = delta
 
-    def __exit__(self, type, value, traceback) -> None:
+    def __exit__(
+        self,
+        type: Optional[Type[BaseException]],
+        value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         if self.delta:
             time.sleep(self.delta)
         self.lock.release()

--- a/disnake/welcome_screen.py
+++ b/disnake/welcome_screen.py
@@ -65,7 +65,7 @@ class WelcomeScreenChannel:
         else:
             raise TypeError("emoji must be None, a str, PartialEmoji, or Emoji instance.")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<WelcomeScreenChannel id={self.id!r} emoji={self.emoji!r} description={self.description!r}>"
 
     @classmethod

--- a/disnake/welcome_screen.py
+++ b/disnake/welcome_screen.py
@@ -52,7 +52,7 @@ class WelcomeScreenChannel:
         id: int,
         description: str,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
-    ):
+    ) -> None:
         self.id: int = id
         self.description: str = description
         self.emoji: Optional[Union[Emoji, PartialEmoji]] = None

--- a/disnake/welcome_screen.py
+++ b/disnake/welcome_screen.py
@@ -128,7 +128,7 @@ class WelcomeScreen:
         data: WelcomeScreenPayload,
         state: ConnectionState,
         guild: Union[Guild, PartialInviteGuild],
-    ):
+    ) -> None:
         self._state = state
         self._guild = guild
         self.description: Optional[str] = data.get("description")


### PR DESCRIPTION
## Summary

Adds a bunch of simple parameter/return type annotations (like `-> None`), mostly thanks to https://github.com/JelleZijlstra/autotyping; I've looked at all the changes manually and discarded the ones that didn't make sense, for now.
Should not have any runtime impact.

Part 2/x of my `--verifytypes` quest, increases type completeness by ~1.5%.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
