### PR TITLE
fix(ci): move concurrency rules from steps to workflow top level

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,19 +7,16 @@ on: [push, pull_request]
 permissions:
   read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
 
 jobs:
   lint:
-    # Thanks to black for this rule
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. Without this if check, checks are duplicated since
-    # internal PRs match both the push and pull_request events.
-    if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
     runs-on: ubuntu-latest
 
     steps:
@@ -53,12 +50,6 @@ jobs:
         [flake8] %(code)s: %(text)s'"
 
   docs:
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. Without this if check, checks are duplicated since
-    # internal PRs match both the push and pull_request events.
-    if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
     # unlike the other workflows, we are using version 20.04 here as
     # readthedocs uses 20.04 for building our docs, and we want to be explicit
     runs-on: ubuntu-20.04
@@ -75,19 +66,14 @@ jobs:
       run: nox -s docs -- --keep-going -W -w $GITHUB_STEP_SUMMARY
 
   pyright:
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. Without this if check, checks are duplicated since
-    # internal PRs match both the push and pull_request events.
-    continue-on-error: ${{ matrix.experimental }}
-    if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         experimental: [false]
       fail-fast: false
+    continue-on-error: ${{ matrix.experimental }}
+
     steps:
     - uses: actions/checkout@v3
 
@@ -123,14 +109,7 @@ jobs:
         warnings: true
 
   misc:
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. Without this if check, checks are duplicated since
-    # internal PRs match both the push and pull_request events.
-    if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
 
@@ -169,22 +148,14 @@ jobs:
         fi
 
   pytest:
-    # Thanks to black for this rule
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. Without this if check, checks are duplicated since
-    # internal PRs match both the push and pull_request events.
-    continue-on-error: ${{ matrix.experimental }}
-    if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         experimental: [false]
       fail-fast: true
-
-    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
 
     env:
       GITHUB_STEP_SUMMARY_HEADER: "<details><summary>#name#</summary>\n<pre>"
@@ -266,11 +237,7 @@ jobs:
 
   # thanks to aiohttp for this part of the workflow
   check:  # This job does nothing and is only used for the branch protection
-    if:
-      always() &&
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
-
+    if: always()
     needs:
     - lint
     - docs

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -2,7 +2,16 @@
 
 name: Lint & Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'v[0-9]+.[0-9]+.x'  # matches to backport branches, e.g. 3.6
+    tags: [ 'v*' ]
+  pull_request:
+    branches:
+      - 'master'
+      - 'v[0-9]+.[0-9]+.x'
 
 permissions:
   read-all

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - 'master'
       - 'v[0-9]+.[0-9]+.x'  # matches to backport branches, e.g. 3.6
+      - 'run-ci/*'
     tags: [ 'v*' ]
   pull_request:
     branches:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -8,7 +8,7 @@ on:
       - 'master'
       - 'v[0-9]+.[0-9]+.x'  # matches to backport branches, e.g. 3.6
       - 'run-ci/*'
-    tags: [ 'v*' ]
+    tags:
   pull_request:
 
 permissions:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,9 +10,6 @@ on:
       - 'run-ci/*'
     tags: [ 'v*' ]
   pull_request:
-    branches:
-      - 'master'
-      - 'v[0-9]+.[0-9]+.x'
 
 permissions:
   read-all


### PR DESCRIPTION
## Summary

partially closes #819

this has the side-effect that we will no longer have ci on branches that are not linked to a pull request or a release branch

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
