### PR TITLE
chore: update alls-green to fix ci deprecation warnings

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -282,6 +282,6 @@ jobs:
 
     steps:
     - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@v1.2.1
+      uses: re-actors/alls-green@v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

as shown in the logs [here](https://github.com/DisnakeDev/disnake/actions/runs/3388788779), alls-green is using the deprecated set-output command by github, and needs to be updated.

