### PR TITLE
fix: revert to weakrefs for user cache

### DIFF
--- a/changelog/858.bugfix.rst
+++ b/changelog/858.bugfix.rst
@@ -1,0 +1,1 @@
+Fix user cache memory leak where unused objects weren't being evicted (provided that :attr:`Intents.members` is enabled).

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -9,6 +9,7 @@ import inspect
 import itertools
 import logging
 import os
+import weakref
 from collections import OrderedDict, deque
 from typing import (
     TYPE_CHECKING,
@@ -271,7 +272,6 @@ class ConnectionState:
 
         if not self._intents.members or member_cache_flags._empty:
             self.store_user = self.create_user
-            self.deref_user = self.deref_user_no_intents
 
         self.parsers = parsers = {}
         for attr, func in inspect.getmembers(self):
@@ -284,19 +284,7 @@ class ConnectionState:
         self, *, views: bool = True, application_commands: bool = True, modals: bool = True
     ) -> None:
         self.user: ClientUser = MISSING
-        # Originally, this code used WeakValueDictionary to maintain references to the
-        # global user mapping.
-
-        # However, profiling showed that this came with two cons:
-
-        # 1. The __weakref__ slot caused a non-trivial increase in memory
-        # 2. The performance of the mapping caused store_user to be a bottleneck.
-
-        # Since this is undesirable, a mapping is now used instead with stored
-        # references now using a regular dictionary with eviction being done
-        # using __del__. Testing this for memory leaks led to no discernable leaks,
-        # though more testing will have to be done.
-        self._users: Dict[int, User] = {}
+        self._users: weakref.WeakValueDictionary[int, User] = weakref.WeakValueDictionary()
         self._emojis: Dict[int, Emoji] = {}
         self._stickers: Dict[int, GuildSticker] = {}
         self._guilds: Dict[int, Guild] = {}
@@ -389,17 +377,10 @@ class ConnectionState:
             user = User(state=self, data=data)
             if user.discriminator != "0000":
                 self._users[user_id] = user
-                user._stored = True
             return user
-
-    def deref_user(self, user_id: int) -> None:
-        self._users.pop(user_id, None)
 
     def create_user(self, data: UserPayload) -> User:
         return User(state=self, data=data)
-
-    def deref_user_no_intents(self, user_id: int) -> None:
-        return
 
     def get_user(self, id: Optional[int]) -> Optional[User]:
         # the keys of self._users are ints
@@ -735,7 +716,8 @@ class ConnectionState:
         self._ready_state: asyncio.Queue[Guild] = asyncio.Queue()
         self.clear(views=False, application_commands=False, modals=False)
         self.user = ClientUser(state=self, data=data["user"])
-        self.store_user(data["user"])
+        # self._users is a list of Users, we're setting a ClientUser
+        self._users[self.user.id] = self.user  # type: ignore
 
         if self.application_id is None:
             try:
@@ -1004,11 +986,8 @@ class ConnectionState:
         self.dispatch("presence_update", old_member, member)
 
     def parse_user_update(self, data: gateway.UserUpdateEvent) -> None:
-        user: ClientUser = self.user
-        user._update(data)
-        ref = self._users.get(user.id)
-        if ref:
-            ref._update(data)
+        if user := self.user:
+            user._update(data)
 
     def parse_invite_create(self, data: gateway.InviteCreateEvent) -> None:
         invite = Invite.from_gateway(state=self, data=data)

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -284,6 +284,10 @@ class ConnectionState:
         self, *, views: bool = True, application_commands: bool = True, modals: bool = True
     ) -> None:
         self.user: ClientUser = MISSING
+        # NOTE: without weakrefs, these user objects would otherwise be kept in memory indefinitely.
+        # However, using weakrefs here unfortunately has a few drawbacks:
+        # - the weakref slot + object in user objects likely results in a small increase in memory usage
+        # - accesses on `_users` are slower, e.g. `__getitem__` takes ~1us with weakrefs and ~0.2us without
         self._users: weakref.WeakValueDictionary[int, User] = weakref.WeakValueDictionary()
         self._emojis: Dict[int, Emoji] = {}
         self._stickers: Dict[int, GuildSticker] = {}

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -424,29 +424,10 @@ class User(BaseUser, disnake.abc.Messageable):
         Specifies if the user is a system user (i.e. represents Discord officially).
     """
 
-    __slots__ = ("_stored",)
-
-    def __init__(
-        self, *, state: ConnectionState, data: Union[UserPayload, PartialUserPayload]
-    ) -> None:
-        super().__init__(state=state, data=data)
-        self._stored: bool = False
+    __slots__ = ("__weakref__",)
 
     def __repr__(self) -> str:
         return f"<User id={self.id} name={self.name!r} discriminator={self.discriminator!r} bot={self.bot}>"
-
-    def __del__(self) -> None:
-        try:
-            if self._stored:
-                self._state.deref_user(self.id)
-        except KeyError:
-            pass
-
-    @classmethod
-    def _copy(cls, user: User) -> Self:
-        self = super()._copy(user)
-        self._stored = False
-        return self
 
     async def _get_channel(self) -> DMChannel:
         ch = await self.create_dm()


### PR DESCRIPTION
## Summary

This largely reverts cb2363f0fd819ce1a5c38b42cd403fcb8994be6f.

Users were not being evicted as expected, resulting in objects being retained solely in the user cache, with no other strong references.
See https://docs.python.org/3.10/library/weakref.html#weakref.WeakValueDictionary and [https://docs.python.org/3.10/reference/datamodel.html#object.__del__](https://docs.python.org/3.10/reference/datamodel.html#object.__del__).
The difference in performance and memory usage is insignificant, at least in 3.10; haven't tested other versions, but this is a bug regardless of version.

To reproduce, anything that uses `state.store_user` can be used, for example the `GUILD_BAN_REMOVE` handler:
```py
print(bot.get_user(21414249976823808))
await ctx.guild.ban(disnake.Object(21414249976823808))
await ctx.guild.unban(disnake.Object(21414249976823808))
await asyncio.sleep(0.5)
print(bot.get_user(21414249976823808))
```

With the previous implementation, the second `print` would output the user (assuming members intent is enabled) - with the changes in this PR, both print `None` as expected.

(for context, this was originally noticed a while ago in an internal channel [here](https://canary.discord.com/channels/808030843078836254/943880644948295732/1010120633293750333))

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
