### PR TITLE
docs: enable opensearch

### DIFF
--- a/changelog/859.doc.rst
+++ b/changelog/859.doc.rst
@@ -1,0 +1,1 @@
+Enable `OpenSearch <https://developer.mozilla.org/en-US/docs/Web/OpenSearch>`_, allowing easy integration of the search functionality into browsers.

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -29,6 +29,11 @@
   {%- if pageurl %}
   <link rel="canonical" href="{{ pageurl|e }}" />
   {%- endif %}
+  {%- if use_opensearch %}
+  <link rel="search" type="application/opensearchdescription+xml"
+        title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"
+        href="{{ pathto('_static/opensearch.xml', 1) }}"/>
+  {%- endif %}
   {%- if favicon %}
   <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1)|e }}"/>
   {%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,7 @@ hoverxref_role_types = dict.fromkeys(
 hoverxref_tooltip_theme = ["tooltipster-custom"]
 hoverxref_tooltip_lazy = True
 
-# these have to match the keys on intersphinx_mapping, and those projects must be hosted on read the docs.
+# these have to match the keys on intersphinx_mapping, and those projects must be hosted on readthedocs.
 hoverxref_intersphinx = [
     "py",
     "aio",
@@ -248,11 +248,11 @@ intersphinx_mapping = {
 }
 
 
-# use proxied API endpoint on rtd to avoid CORS issues
+# use proxied API endpoint on readthedocs to avoid CORS issues
 if _IS_READTHEDOCS:
     hoverxref_api_host = "/_"
 
-# when not on read the docs, assume no prefix for the 404 page.
+# when not on readthedocs, assume no prefix for the 404 page.
 # this means that /404.html should properly render on local builds
 if not _IS_READTHEDOCS:
     notfound_urls_prefix = "/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ with open("../disnake/__init__.py") as f:
 release = version
 
 
-_is_readthedocs = bool(os.getenv("READTHEDOCS"))
+_IS_READTHEDOCS = bool(os.getenv("READTHEDOCS"))
 
 
 def git(*args: str) -> str:
@@ -249,12 +249,12 @@ intersphinx_mapping = {
 
 
 # use proxied API endpoint on rtd to avoid CORS issues
-if _is_readthedocs:
+if _IS_READTHEDOCS:
     hoverxref_api_host = "/_"
 
 # when not on read the docs, assume no prefix for the 404 page.
 # this means that /404.html should properly render on local builds
-if not _is_readthedocs:
+if not _IS_READTHEDOCS:
     notfound_urls_prefix = "/"
 
 linkcheck_ignore = [
@@ -471,7 +471,7 @@ def setup(app: Sphinx) -> None:
 
     # readthedocs appends additional stuff to conf.py,
     # we can't access it above since it wouldn't have run yet
-    if _is_readthedocs:
+    if _IS_READTHEDOCS:
         # this is the "canonical" url, which always points to stable in our case
         if not (base_url := globals().get("html_baseurl")):
             raise RuntimeError("Expected `html_baseurl` to be set on readthedocs")


### PR DESCRIPTION
## Summary

Adds an [OpenSearch](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) description file to the docs:
![image](https://user-images.githubusercontent.com/8530778/200385775-4b06b6b3-f76e-4379-a16e-1818f4929133.png)

It only registers *sometimes* in chromium-based browsers and no-one really seems to know why, I think at this point I've spent more time looking at the chromium bugtracker and other projects' GitHub issues than actually implementing this.
It works fine in Firefox (see screenshot) :shrug: 

sphinx config docs: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_use_opensearch

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
