### PR TITLE
fix: handle `public_flags` value for `Message.author` when member cache is disabled

### DIFF
--- a/changelog/870.bugfix.rst
+++ b/changelog/870.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :attr:`Message.author.public_flags <Member.public_flags>` always being ``0`` when the member cache is disabled.

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -121,6 +121,7 @@ class BaseUser(_UserTag):
             "avatar": self._avatar,
             "discriminator": self.discriminator,
             "bot": self.bot,
+            "public_flags": self._public_flags,
         }
 
     @property


### PR DESCRIPTION
## Summary

The `Message.__init__ -> Message._handle_member -> Member._from_message` path calls `User._to_minimal_user_json`, which previously didn't copy over the user's `public_flags` value.
With the member cache (and therefore also the user cache) enabled, this isn't an issue as `Member.__init__` uses the cached user and not the (previously incomplete) user data. With the cache disabled, the user data gets parsed, which didn't include that value.

To reproduce, just `print(ctx.author.public_flags)`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
