### PR TITLE
docs: private threads no longer require boost/guild feature

### DIFF
--- a/changelog/872.doc.rst
+++ b/changelog/872.doc.rst
@@ -1,1 +1,1 @@
-Remove documentation parts about private threads requiring boosts.
+Remove documentation regarding private threads requiring boosts.

--- a/changelog/872.doc.rst
+++ b/changelog/872.doc.rst
@@ -1,0 +1,1 @@
+Update documentation surrounding private threads no longer requiring boosts.

--- a/changelog/872.doc.rst
+++ b/changelog/872.doc.rst
@@ -1,1 +1,1 @@
-Update documentation surrounding private threads no longer requiring boosts.
+Remove documentation parts about private threads requiring boosts.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -829,7 +829,6 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
         To create a public thread, you must have :attr:`~disnake.Permissions.create_public_threads` permission.
         For a private thread, :attr:`~disnake.Permissions.create_private_threads` permission is needed instead.
-        Additionally, the guild must have ``PRIVATE_THREADS`` in :attr:`Guild.features` to create private threads.
 
         .. versionadded:: 2.0
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -211,7 +211,7 @@ class Guild(Hashable):
         - ``NEW_THREAD_PERMISSIONS``: Guild is using the new thread permission system.
         - ``PARTNERED``: Guild is a partnered server.
         - ``PREVIEW_ENABLED``: Guild can be viewed before being accepted via Membership Screening.
-        - ``PRIVATE_THREADS``: Guild has access to create private threads.
+        - ``PRIVATE_THREADS``: Guild has access to create private threads (no longer has any effect).
         - ``ROLE_ICONS``: Guild has access to role icons.
         - ``SEVEN_DAY_THREAD_ARCHIVE``: Guild has access to the seven day archive time for threads (no longer has any effect).
         - ``TEXT_IN_VOICE_ENABLED``: Guild has text in voice channels enabled (no longer has any effect).

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -357,7 +357,7 @@ class Thread(Messageable, Hashable):
         """Whether the thread is a private thread.
 
         A private thread is only viewable by those that have been explicitly
-        invited or have :attr:`~.Permissions.manage_threads`.
+        invited or have :attr:`~.Permissions.manage_threads` permissions.
 
         :return type: :class:`bool`
         """

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -60,7 +60,7 @@ GuildFeature = Literal[
     "NEW_THREAD_PERMISSIONS",  # deprecated
     "PARTNERED",
     "PREVIEW_ENABLED",
-    "PRIVATE_THREADS",
+    "PRIVATE_THREADS",  # deprecated
     "RELAY_ENABLED",
     "ROLE_ICONS",
     "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE",  # not yet documented/finalised


### PR DESCRIPTION
## Summary

title.

See https://github.com/discord/discord-api-docs/commit/2d24487e83ddd92c69fab0523c572f4d50a0e687; The API and client UI already reflect this change.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
