### PR TITLE
feat(bot): Add a option for listening to bot-sent commands

### DIFF
--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -124,6 +124,7 @@ class BotBase(CommonBotBase, GroupMixin):
         ] = None,
         help_command: HelpCommand = _default,
         description: Optional[str] = None,
+        heed_bots: bool = False
         *,
         strip_after_prefix: bool = False,
         **options: Any,
@@ -621,7 +622,7 @@ class BotBase(CommonBotBase, GroupMixin):
         message: :class:`disnake.Message`
             The message to process commands for.
         """
-        if message.author.bot:
+        if message.author.bot and not self.heed_bots:
             return
 
         ctx = await self.get_context(message)


### PR DESCRIPTION
## Summary
I think adding a option to listen to bot-sent commands would help with testing complex commands.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
