### PR TITLE
Add content to Message repr

### DIFF
--- a/disnake/message.py
+++ b/disnake/message.py
@@ -955,7 +955,7 @@ class Message(Hashable):
 
     def __repr__(self) -> str:
         name = self.__class__.__name__
-        return f"<{name} id={self.id} channel={self.channel!r} type={self.type!r} author={self.author!r} flags={self.flags!r}>"
+        return f"<{name} id={self.id} content={self.content} channel={self.channel!r} type={self.type!r} author={self.author!r} flags={self.flags!r}>"
 
     def _try_patch(self, data, key, transform=None) -> None:
         try:


### PR DESCRIPTION
Signed-off-by: HedTB

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
It's a very simple change to include the message content in `Message`'s repr. I don't see why this wouldn't be shown, as its purpose is to give information on the message.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
