### PR TITLE
fix: change `default_layout` value from `...` to `MISSING`

### DIFF
--- a/changelog/903.feature.rst
+++ b/changelog/903.feature.rst
@@ -1,0 +1,1 @@
+Add :attr:`ForumChannel.default_layout`, and ``default_layout`` parameter to channel edit methods.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -2804,7 +2804,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         available_tags: Sequence[ForumTag] = MISSING,
         default_reaction: Optional[Union[str, Emoji, PartialEmoji]] = MISSING,
         default_sort_order: Optional[ThreadSortOrder] = MISSING,
-        default_layout: ThreadLayout = ...,
+        default_layout: ThreadLayout = MISSING,
         reason: Optional[str] = None,
         **kwargs: Never,
     ) -> Optional[ForumChannel]:


### PR DESCRIPTION
## Summary

Fixes the default value of `default_layout` in `ForumChannel.edit`, which prevented editing forum channels when the parameter wasn't specified.

followup to #885
[context](https://canary.discord.com/channels/808030843078836254/1060004812135079996)

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
