### PR TITLE
feat: implement role subscription fields

### DIFF
--- a/changelog/904.feature.rst
+++ b/changelog/904.feature.rst
@@ -1,0 +1,3 @@
+Add features related to role subscriptions.
+- :attr:`MessageType.role_subscription_purchase`
+- :attr:`RoleTags.subscription_listing_id`, :attr:`RoleTags.is_available_for_purchase`, and :attr:`RoleTags.is_subscription`

--- a/disnake/emoji.py
+++ b/disnake/emoji.py
@@ -217,6 +217,10 @@ class Emoji(_EmojiTag, AssetMixin):
             The new emoji name.
         roles: Optional[List[:class:`~disnake.abc.Snowflake`]]
             A list of roles that can use this emoji. An empty list can be passed to make it available to everyone.
+
+            An emoji cannot have both subscription roles (see :attr:`RoleTags.integration_id`) and
+            non-subscription roles, and emojis can't be converted between premium and non-premium
+            after creation.
         reason: Optional[:class:`str`]
             The reason for editing this emoji. Shows up on the audit log.
 

--- a/disnake/emoji.py
+++ b/disnake/emoji.py
@@ -146,7 +146,7 @@ class Emoji(_EmojiTag, AssetMixin):
 
         If roles is empty, the emoji is unrestricted.
 
-        Emojis with :attr:`subscription roles <RoleTags.integration_id>` are considered premium emoji,
+        Emojis with :attr:`subscription roles <RoleTags.integration_id>` are considered premium emojis,
         and count towards a separate limit of 25 emojis.
         """
         guild = self.guild

--- a/disnake/emoji.py
+++ b/disnake/emoji.py
@@ -145,6 +145,9 @@ class Emoji(_EmojiTag, AssetMixin):
         """List[:class:`Role`]: A :class:`list` of roles that are allowed to use this emoji.
 
         If roles is empty, the emoji is unrestricted.
+
+        Emojis with :attr:`subscription roles <RoleTags.integration_id>` are considered premium emoji,
+        and count towards a separate limit of 25 emojis.
         """
         guild = self.guild
         if guild is None:

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -236,6 +236,7 @@ class MessageType(Enum):
     guild_invite_reminder = 22
     context_menu_command = 23
     auto_moderation_action = 24
+    role_subscription_purchase = 25
 
 
 class PartyType(Enum):

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -206,7 +206,6 @@ class Guild(Hashable):
         - ``INVITES_DISABLED``: Guild has paused invites, preventing new users from joining.
         - ``LINKED_TO_HUB``: Guild is linked to a student hub.
         - ``MEMBER_VERIFICATION_GATE_ENABLED``: Guild has Membership Screening enabled.
-        - ``MONETIZATION_ENABLED``: Guild has enabled monetization.
         - ``MORE_EMOJI``: Guild has increased custom emoji slots.
         - ``MORE_STICKERS``: Guild has increased custom sticker slots.
         - ``NEWS``: Guild can create news channels.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -194,6 +194,8 @@ class Guild(Hashable):
         - ``AUTO_MODERATION``: Guild has set up auto moderation rules.
         - ``BANNER``: Guild can upload and use a banner. (i.e. :attr:`.banner`)
         - ``COMMUNITY``: Guild is a community server.
+        - ``CREATOR_MONETIZABLE_PROVISIONAL``: Guild has enabled monetization.
+        - ``CREATOR_STORE_PAGE``: Guild has enabled the role subscription promo page.
         - ``DEVELOPER_SUPPORT_SERVER``: Guild is set as a support server in the app directory.
         - ``DISCOVERABLE``: Guild shows up in Server Discovery.
         - ``ENABLED_DISCOVERABLE_BEFORE``: Guild had Server Discovery enabled at least once.
@@ -213,6 +215,8 @@ class Guild(Hashable):
         - ``PREVIEW_ENABLED``: Guild can be viewed before being accepted via Membership Screening.
         - ``PRIVATE_THREADS``: Guild has access to create private threads (no longer has any effect).
         - ``ROLE_ICONS``: Guild has access to role icons.
+        - ``ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE``: Guild has role subscriptions that can be purchased.
+        - ``ROLE_SUBSCRIPTIONS_ENABLED``: Guild has enabled role subscriptions.
         - ``SEVEN_DAY_THREAD_ARCHIVE``: Guild has access to the seven day archive time for threads (no longer has any effect).
         - ``TEXT_IN_VOICE_ENABLED``: Guild has text in voice channels enabled (no longer has any effect).
         - ``THREE_DAY_THREAD_ARCHIVE``: Guild has access to the three day archive time for threads (no longer has any effect).

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -837,7 +837,11 @@ class Guild(Hashable):
 
     @property
     def emoji_limit(self) -> int:
-        """:class:`int`: The maximum number of emoji slots this guild has."""
+        """:class:`int`: The maximum number of emoji slots this guild has.
+
+        Premium emojis (those associated with subscription roles) count towards a
+        separate limit of 25.
+        """
         more_emoji = 200 if "MORE_EMOJI" in self.features else 50
         return max(more_emoji, self._PREMIUM_GUILD_LIMITS[self.premium_tier].emoji)
 
@@ -3229,6 +3233,9 @@ class Guild(Hashable):
             "1", "100"
             "2", "150"
             "3", "250"
+
+        Emojis with :attr:`subscription roles <RoleTags.integration_id>` are considered premium emoji,
+        and count towards a separate limit of 25 emojis.
 
         You must have :attr:`~Permissions.manage_emojis` permission to
         do this.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -839,7 +839,7 @@ class Guild(Hashable):
     def emoji_limit(self) -> int:
         """:class:`int`: The maximum number of emoji slots this guild has.
 
-        Premium emojis (those associated with subscription roles) count towards a
+        Premium emojis (i.e. those associated with subscription roles) count towards a
         separate limit of 25.
         """
         more_emoji = 200 if "MORE_EMOJI" in self.features else 50
@@ -3234,7 +3234,7 @@ class Guild(Hashable):
             "2", "150"
             "3", "250"
 
-        Emojis with :attr:`subscription roles <RoleTags.integration_id>` are considered premium emoji,
+        Emojis with subscription roles (see ``roles`` below) are considered premium emoji,
         and count towards a separate limit of 25 emojis.
 
         You must have :attr:`~Permissions.manage_emojis` permission to
@@ -3252,7 +3252,12 @@ class Guild(Hashable):
                 Now accepts various resource types in addition to :class:`bytes`.
 
         roles: List[:class:`Role`]
-            A :class:`list` of :class:`Role`\\s that can use this emoji. Leave empty to make it available to everyone.
+            A list of roles that can use this emoji. Leave empty to make it available to everyone.
+
+            An emoji cannot have both subscription roles (see :attr:`RoleTags.integration_id`) and
+            non-subscription roles, and emojis can't be converted between premium and non-premium
+            after creation.
+
         reason: Optional[:class:`str`]
             The reason for creating this emoji. Shows up on the audit log.
 

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -69,7 +69,7 @@ class PartialIntegration:
     guild: :class:`Guild`
         The guild of the integration.
     type: :class:`str`
-        The integration type (i.e. Twitch).
+        The integration type (i.e. ``"twitch"``).
     account: :class:`IntegrationAccount`
         The account linked to this integration.
     application_id: Optional[:class:`int`]

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -69,7 +69,7 @@ class PartialIntegration:
     guild: :class:`Guild`
         The guild of the integration.
     type: :class:`str`
-        The integration type (i.e. ``"twitch"``).
+        The integration type (i.e. ``twitch``).
     account: :class:`IntegrationAccount`
         The account linked to this integration.
     application_id: Optional[:class:`int`]
@@ -119,7 +119,7 @@ class Integration(PartialIntegration):
         Whether the integration is currently enabled.
     account: :class:`IntegrationAccount`
         The account linked to this integration.
-    user: :class:`User`
+    user: Optional[:class:`User`]
         The user that added this integration.
     """
 

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1398,6 +1398,9 @@ class Message(Hashable):
         if self.type is MessageType.auto_moderation_action:
             return self.content
 
+        # TODO: `MessageType.role_subscription_purchase` requires `Message.role_subscription_data`,
+        #       which is currently undocumented
+
         # in the event of an unknown or unsupported message type, we return nothing
         return None
 

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -52,7 +52,7 @@ class RoleTags:
     subscription_listing_id: Optional[:class:`int`]
         The ID of this role's subscription listing, if applicable.
 
-        .. versionadded:: 2.8
+        .. versionadded:: 2.9
     """
 
     __slots__ = (
@@ -111,7 +111,7 @@ class RoleTags:
     def is_available_for_purchase(self) -> bool:
         """Whether the role is a subscription role and available for purchase.
 
-        .. versionadded:: 2.8
+        .. versionadded:: 2.9
 
         :return type: :class:`bool`
         """
@@ -120,7 +120,7 @@ class RoleTags:
     def is_subscription(self) -> bool:
         """Whether the role is associated with a role subscription.
 
-        .. versionadded:: 2.8
+        .. versionadded:: 2.9
 
         :return type: :class:`bool`
         """
@@ -330,7 +330,7 @@ class Role(Hashable):
     def is_available_for_purchase(self) -> bool:
         """Whether the role is a subscription role and available for purchase.
 
-        .. versionadded:: 2.8
+        .. versionadded:: 2.9
 
         :return type: :class:`bool`
         """
@@ -339,7 +339,7 @@ class Role(Hashable):
     def is_subscription(self) -> bool:
         """Whether the role is associated with a role subscription.
 
-        .. versionadded:: 2.8
+        .. versionadded:: 2.9
 
         :return type: :class:`bool`
         """

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -46,6 +46,9 @@ class RoleTags:
         The bot's user ID that manages this role.
     integration_id: Optional[:class:`int`]
         The integration ID that manages the role.
+
+        Roles with this ID matching the guild's ``guild_subscription`` integration
+        are considered subscription roles.
     subscription_listing_id: Optional[:class:`int`]
         The ID of this role's subscription listing, if applicable.
 
@@ -95,7 +98,7 @@ class RoleTags:
         return self._premium_subscriber is None
 
     def is_available_for_purchase(self) -> bool:
-        """Whether the role is available for purchase as part of a role subscription.
+        """Whether the role is a subscription role and available for purchase.
 
         .. versionadded:: 2.8
 
@@ -304,7 +307,7 @@ class Role(Hashable):
         return self.tags is not None and self.tags.is_integration()
 
     def is_available_for_purchase(self) -> bool:
-        """Whether the role is available for purchase as part of a role subscription.
+        """Whether the role is a subscription role and available for purchase.
 
         .. versionadded:: 2.8
 

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -41,6 +41,8 @@ GuildFeature = Literal[
     "BANNER",
     "COMMUNITY",
     "CREATOR_MONETIZABLE",  # not yet documented/finalised
+    "CREATOR_MONETIZABLE_PROVISIONAL",
+    "CREATOR_STORE_PAGE",
     "DEVELOPER_SUPPORT_SERVER",
     "DISCOVERABLE",
     "ENABLED_DISCOVERABLE_BEFORE",
@@ -63,8 +65,8 @@ GuildFeature = Literal[
     "PRIVATE_THREADS",  # deprecated
     "RELAY_ENABLED",
     "ROLE_ICONS",
-    "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE",  # not yet documented/finalised
-    "ROLE_SUBSCRIPTIONS_ENABLED",  # not yet documented/finalised
+    "ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE",
+    "ROLE_SUBSCRIPTIONS_ENABLED",
     "SEVEN_DAY_THREAD_ARCHIVE",  # deprecated
     "TEXT_IN_VOICE_ENABLED",  # deprecated
     "THREADS_ENABLED",  # deprecated

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -55,7 +55,6 @@ GuildFeature = Literal[
     "LINKED_TO_HUB",
     "MEMBER_PROFILES",  # not sure what this does, if anything
     "MEMBER_VERIFICATION_GATE_ENABLED",
-    "MONETIZATION_ENABLED",
     "MORE_EMOJI",
     "MORE_STICKERS",
     "NEWS",

--- a/disnake/types/integration.py
+++ b/disnake/types/integration.py
@@ -36,7 +36,7 @@ class PartialIntegration(TypedDict):
     application_id: NotRequired[Snowflake]
 
 
-IntegrationType = Literal["twitch", "youtube", "discord"]
+IntegrationType = Literal["twitch", "youtube", "discord", "guild_subscription"]
 
 
 class BaseIntegration(PartialIntegration):

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -68,7 +68,7 @@ class MessageReference(TypedDict, total=False):
 
 
 # fmt: off
-MessageType = Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 29, 30, 31, 32]
+MessageType = Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]
 # fmt: on
 
 

--- a/disnake/types/role.py
+++ b/disnake/types/role.py
@@ -27,3 +27,5 @@ class RoleTags(TypedDict, total=False):
     bot_id: Snowflake
     integration_id: Snowflake
     premium_subscriber: None
+    subscription_listing_id: Snowflake
+    available_for_purchase: None

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1789,7 +1789,7 @@ of :class:`enum.Enum`.
 
         The system message denoting that a role subscription was purchased.
 
-        .. versionadded:: 2.8
+        .. versionadded:: 2.9
     .. attribute:: interaction_premium_upsell
 
         The system message for an application premium subscription upsell.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1764,6 +1764,11 @@ of :class:`enum.Enum`.
         The system message denoting that an auto moderation action was executed.
 
         .. versionadded:: 2.5
+    .. attribute:: role_subscription_purchase
+
+        The system message denoting that an auto moderation action was executed.
+
+        .. versionadded:: 2.8
 
 .. class:: UserFlags
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1766,7 +1766,7 @@ of :class:`enum.Enum`.
         .. versionadded:: 2.5
     .. attribute:: role_subscription_purchase
 
-        The system message denoting that an auto moderation action was executed.
+        The system message denoting that a role subscription was purchased.
 
         .. versionadded:: 2.8
 


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/pull/5724

The new integration type is untested due to region locks (:/), though I don't see why it wouldn't work as the integration structure wasn't changed.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
