### PR TITLE
fix: avoid stale local command cache when deleting guild application command

### DIFF
--- a/changelog/907.bugfix.rst
+++ b/changelog/907.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :meth:`Client.delete_guild_command` not updating the local command cache.

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -2475,7 +2475,7 @@ class Client:
         command_id: :class:`int`
             The ID of the application command to delete.
         """
-        return await self._connection.delete_global_command(command_id)
+        await self._connection.delete_global_command(command_id)
 
     async def bulk_overwrite_global_commands(
         self, application_commands: List[ApplicationCommand]
@@ -2617,7 +2617,7 @@ class Client:
         command_id: :class:`int`
             The ID of the application command to delete.
         """
-        return await self._connection.delete_guild_command(guild_id, command_id)
+        await self._connection.delete_guild_command(guild_id, command_id)
 
     async def bulk_overwrite_guild_commands(
         self, guild_id: int, application_commands: List[ApplicationCommand]

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -2617,7 +2617,7 @@ class Client:
         command_id: :class:`int`
             The ID of the application command to delete.
         """
-        await self.http.delete_guild_command(self.application_id, guild_id, command_id)
+        return await self._connection.delete_guild_command(guild_id, command_id)
 
     async def bulk_overwrite_guild_commands(
         self, guild_id: int, application_commands: List[ApplicationCommand]


### PR DESCRIPTION
## Summary

`ConnectionState.delete_guild_command` was previously unused, with `Client.delete_guild_command` directly calling the http endpoint and not removing the command from the local command cache.

This is a pretty minor (and ancient) bug, and mainly resulted in `Client.get_guild_command`/`.get_guild_application_commands` possibly returning now-deleted commands.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
