### PR TITLE
fix: fix errors when trying to deserialize stickers with unknown formats

### DIFF
--- a/changelog/911.bugfix.rst
+++ b/changelog/911.bugfix.rst
@@ -1,0 +1,1 @@
+Fix errors when trying to deserialize stickers with unknown formats.

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -553,10 +553,8 @@ class StickerFormatType(Enum):
     lottie = 3
 
     @property
-    def file_extension(self) -> str:
-        # this default value isn't correct, but it's better than raising a KeyError if
-        # we encounter an unknown format
-        return STICKER_FORMAT_LOOKUP.get(self, "png")
+    def file_extension(self) -> Optional[str]:
+        return STICKER_FORMAT_LOOKUP[self]
 
 
 STICKER_FORMAT_LOOKUP: Dict[StickerFormatType, str] = {

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -554,12 +554,16 @@ class StickerFormatType(Enum):
 
     @property
     def file_extension(self) -> str:
-        lookup: Dict[StickerFormatType, str] = {
-            StickerFormatType.png: "png",
-            StickerFormatType.apng: "png",
-            StickerFormatType.lottie: "json",
-        }
-        return lookup[self]
+        # this default value isn't correct, but it's better than raising a KeyError if
+        # we encounter an unknown format
+        return STICKER_FORMAT_LOOKUP.get(self, "png")
+
+
+STICKER_FORMAT_LOOKUP: Dict[StickerFormatType, str] = {
+    StickerFormatType.png: "png",
+    StickerFormatType.apng: "png",
+    StickerFormatType.lottie: "json",
+}
 
 
 class InviteTarget(Enum):

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -553,7 +553,7 @@ class StickerFormatType(Enum):
     lottie = 3
 
     @property
-    def file_extension(self) -> Optional[str]:
+    def file_extension(self) -> str:
         return STICKER_FORMAT_LOOKUP[self]
 
 

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -120,6 +120,11 @@ class _StickerTag(Hashable, AssetMixin):
     id: int
     format: StickerFormatType
 
+    @property
+    def url(self) -> str:
+        """:class:`str`: The url for the sticker's image."""
+        return f"{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}"
+
     async def read(self) -> bytes:
         """|coro|
 
@@ -175,18 +180,15 @@ class StickerItem(_StickerTag):
         The ID of the sticker.
     format: :class:`StickerFormatType`
         The format for the sticker's image.
-    url: :class:`str`
-        The URL for the sticker's image.
     """
 
-    __slots__ = ("name", "id", "format", "url")
+    __slots__ = ("name", "id", "format")
 
     def __init__(self, *, state: ConnectionState, data: StickerItemPayload) -> None:
         self._state: ConnectionState = state
         self.name: str = data["name"]
         self.id: int = int(data["id"])
         self.format: StickerFormatType = try_enum(StickerFormatType, data["format_type"])
-        self.url: str = f"{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}"
 
     def __repr__(self) -> str:
         return f"<StickerItem id={self.id} name={self.name!r} format={self.format}>"
@@ -245,11 +247,9 @@ class Sticker(_StickerTag):
         The ID of the sticker's pack.
     format: :class:`StickerFormatType`
         The format for the sticker's image.
-    url: :class:`str`
-        The URL for the sticker's image.
     """
 
-    __slots__ = ("id", "name", "description", "format", "url")
+    __slots__ = ("id", "name", "description", "format")
 
     def __init__(self, *, state: ConnectionState, data: StickerPayload) -> None:
         self._state: ConnectionState = state
@@ -260,7 +260,6 @@ class Sticker(_StickerTag):
         self.name: str = data["name"]
         self.description: str = data["description"]
         self.format: StickerFormatType = try_enum(StickerFormatType, data["format_type"])
-        self.url: str = f"{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}"
 
     def __repr__(self) -> str:
         return f"<Sticker id={self.id} name={self.name!r}>"

--- a/disnake/types/sticker.py
+++ b/disnake/types/sticker.py
@@ -9,7 +9,7 @@ from typing_extensions import NotRequired
 from .snowflake import Snowflake
 from .user import User
 
-StickerFormatType = Literal[1, 2, 3]
+StickerFormatType = Literal[1, 2, 3, 4]
 
 
 class StickerItem(TypedDict):


### PR DESCRIPTION
## Summary

The current sticker deserialization code doesn't account for unknown `format_type`s, potentially resulting in `KeyError`s when trying to parse stickers due to the file extension lookup.
The new .gif sticker format (see #910) is one such format, meaning messages sent with such a sticker will result in exceptions.
This won't result in full crashes in >=2.6, but will still prevent messages with such stickers from being handled.

Instead of computing the url at initialization, it is now essentially deferring the `KeyError` to whenever a bot tries to access `.url`; one potential future change would be to make `url` optional to account for unknown formats.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
