### PR TITLE
fix!: `StickerPack.cover_sticker_id` and `.banner_asset_id` are optional

### DIFF
--- a/changelog/912.breaking.rst
+++ b/changelog/912.breaking.rst
@@ -1,0 +1,1 @@
+:attr:`StickerPack.cover_sticker_id`, :attr:`.cover_sticker <StickerPack.cover_sticker>` and :attr:`.banner <StickerPack.banner>` are now optional and may return ``None``.

--- a/changelog/912.bugfix.rst
+++ b/changelog/912.bugfix.rst
@@ -1,0 +1,1 @@
+Make :attr:`StickerPack.cover_sticker_id`, :attr:`.cover_sticker <StickerPack.cover_sticker>` and :attr:`.banner <StickerPack.banner>` optional.

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -389,7 +389,8 @@ class GuildSticker(Sticker):
     guild_id: :class:`int`
         The ID of the guild that this sticker is from.
     user: Optional[:class:`User`]
-        The user that created this sticker. This can only be retrieved using :meth:`Guild.fetch_sticker` and
+        The user that created this sticker. This can only be retrieved using
+        :meth:`Guild.fetch_sticker`/:meth:`Guild.fetch_stickers` and
         having the :attr:`~Permissions.manage_emojis_and_stickers` permission.
     emoji: :class:`str`
         The name of a unicode emoji that represents this sticker.

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -68,9 +68,9 @@ class StickerPack(Hashable):
     sku_id: :class:`int`
         The SKU ID of the sticker pack.
     cover_sticker_id: Optional[:class:`int`]
-         The ID of the sticker used for the cover of the sticker pack.
+         The ID of the sticker used for the cover of the sticker pack, if any.
     cover_sticker: Optional[:class:`StandardSticker`]
-        The sticker used for the cover of the sticker pack.
+        The sticker used for the cover of the sticker pack, if any.
     """
 
     __slots__ = (
@@ -104,7 +104,7 @@ class StickerPack(Hashable):
 
     @property
     def banner(self) -> Optional[Asset]:
-        """Optional[:class:`Asset`]: The banner asset of the sticker pack."""
+        """Optional[:class:`Asset`]: The banner asset of the sticker pack, if any."""
         if not self._banner:
             return None
         return Asset._from_sticker_banner(self._state, self._banner)

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -9,7 +9,7 @@ from .asset import Asset, AssetMixin
 from .enums import StickerFormatType, StickerType, try_enum
 from .errors import InvalidData
 from .mixins import Hashable
-from .utils import MISSING, cached_slot_property, find, get, snowflake_time
+from .utils import MISSING, _get_as_snowflake, cached_slot_property, find, get, snowflake_time
 
 __all__ = (
     "StickerPack",
@@ -67,9 +67,9 @@ class StickerPack(Hashable):
         The stickers of this sticker pack.
     sku_id: :class:`int`
         The SKU ID of the sticker pack.
-    cover_sticker_id: :class:`int`
+    cover_sticker_id: Optional[:class:`int`]
          The ID of the sticker used for the cover of the sticker pack.
-    cover_sticker: :class:`StandardSticker`
+    cover_sticker: Optional[:class:`StandardSticker`]
         The sticker used for the cover of the sticker pack.
     """
 
@@ -97,14 +97,16 @@ class StickerPack(Hashable):
         ]
         self.name: str = data["name"]
         self.sku_id: int = int(data["sku_id"])
-        self.cover_sticker_id: int = int(data["cover_sticker_id"])
-        self.cover_sticker: StandardSticker = get(self.stickers, id=self.cover_sticker_id)  # type: ignore
+        self.cover_sticker_id: Optional[int] = _get_as_snowflake(data, "cover_sticker_id")
+        self.cover_sticker: Optional[StandardSticker] = get(self.stickers, id=self.cover_sticker_id)
         self.description: str = data["description"]
-        self._banner: int = int(data["banner_asset_id"])
+        self._banner: Optional[int] = _get_as_snowflake(data, "banner_asset_id")
 
     @property
-    def banner(self) -> Asset:
-        """:class:`Asset`: The banner asset of the sticker pack."""
+    def banner(self) -> Optional[Asset]:
+        """Optional[:class:`Asset`]: The banner asset of the sticker pack."""
+        if not self._banner:
+            return None
         return Asset._from_sticker_banner(self._state, self._banner)
 
     def __repr__(self) -> str:

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -41,6 +41,9 @@ class StickerPack(Hashable):
 
     .. versionadded:: 2.0
 
+    .. versionchanged:: 2.8
+        :attr:`cover_sticker_id`, :attr:`cover_sticker` and :attr:`banner` are now optional.
+
     .. container:: operations
 
         .. describe:: str(x)

--- a/disnake/types/sticker.py
+++ b/disnake/types/sticker.py
@@ -47,9 +47,9 @@ class StickerPack(TypedDict):
     stickers: List[StandardSticker]
     name: str
     sku_id: Snowflake
-    cover_sticker_id: Snowflake
+    cover_sticker_id: NotRequired[Snowflake]
     description: str
-    banner_asset_id: Snowflake
+    banner_asset_id: NotRequired[Snowflake]
 
 
 class CreateGuildSticker(TypedDict):


### PR DESCRIPTION
## Summary

The `cover_sticker_id` and `banner_asset_id` fields in the sticker pack data are marked as optional in the [API docs
](https://discord.com/developers/docs/resources/sticker#sticker-pack-object-sticker-pack-structure), but have so far been treated as required.

This was fine in all but the latest "Snowsgiving Surprise Pack", which does not have a banner, breaking `Client.fetch_premium_sticker_packs`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
