### PR TITLE
feat: add integration query parameters

### DIFF
--- a/changelog/917.feature.rst
+++ b/changelog/917.feature.rst
@@ -1,0 +1,1 @@
+Add ``has_commands`` and ``include_role_connections_metadata`` parameters to :meth:`Guild.integrations`.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2990,7 +2990,9 @@ class Guild(Hashable):
         """
         await self._state.http.create_integration(self.id, type, id)
 
-    async def integrations(self) -> List[Integration]:
+    async def integrations(
+        self, *, has_commands: bool = False, include_role_connections_metadata: bool = False
+    ) -> List[Integration]:
         """|coro|
 
         Returns a list of all integrations attached to the guild.
@@ -2999,6 +3001,20 @@ class Guild(Hashable):
         use this.
 
         .. versionadded:: 1.4
+
+        Parameters
+        ----------
+        has_commands: :class:`bool`
+            Whether to only return integrations with registered application commands.
+            Defaults to ``False``.
+
+            .. versionadded:: 2.8
+        include_role_connections_metadata: :class:`bool`
+            Whether to include :attr:`~IntegrationApplication.role_connections_verification_url` in the
+            :attr:`BotIntegration.application` objects of returned integrations.
+            Defaults to ``False``.
+
+            .. versionadded:: 2.8
 
         Raises
         ------
@@ -3012,7 +3028,11 @@ class Guild(Hashable):
         List[:class:`Integration`]
             The list of integrations that are attached to the guild.
         """
-        data = await self._state.http.get_all_integrations(self.id)
+        data = await self._state.http.get_all_integrations(
+            self.id,
+            has_commands=has_commands,
+            include_role_connections_metadata=include_role_connections_metadata,
+        )
 
         def convert(d):
             factory, _ = _integration_factory(d["type"])

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1691,10 +1691,23 @@ class HTTPClient:
         )
         return self.request(r, json=payload, reason=reason)
 
-    def get_all_integrations(self, guild_id: Snowflake) -> Response[List[integration.Integration]]:
-        r = Route("GET", "/guilds/{guild_id}/integrations", guild_id=guild_id)
+    def get_all_integrations(
+        self,
+        guild_id: Snowflake,
+        *,
+        has_commands: Optional[bool] = None,
+        include_role_connections_metadata: Optional[bool] = None,
+    ) -> Response[List[integration.Integration]]:
+        params: Dict[str, Any] = {}
+        if has_commands is not None:
+            params["has_commands"] = int(has_commands)
+        if include_role_connections_metadata is not None:
+            params["include_role_connections_metadata"] = int(include_role_connections_metadata)
 
-        return self.request(r)
+        return self.request(
+            Route("GET", "/guilds/{guild_id}/integrations", guild_id=guild_id),
+            params=params,
+        )
 
     def create_integration(
         self, guild_id: Snowflake, type: integration.IntegrationType, id: int

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -328,6 +328,14 @@ class IntegrationApplication:
         The application's description. Can be an empty string.
     user: Optional[:class:`User`]
         The bot user associated with this application.
+    role_connections_verification_url: Optional[:class:`str`]
+        The application's role connection verification entry point,
+        which when configured will render the app as a verification method
+        in the guild role verification configuration.
+
+        Only available through :meth:`Guild.integrations` with ``include_role_connections_metadata=True``.
+
+        .. versionadded:: 2.8
     """
 
     __slots__ = (
@@ -337,6 +345,7 @@ class IntegrationApplication:
         "description",
         "_summary",
         "user",
+        "role_connections_verification_url",
     )
 
     def __init__(self, *, data: IntegrationApplicationPayload, state) -> None:
@@ -347,6 +356,9 @@ class IntegrationApplication:
         self._summary: str = data.get("summary", "")
         user = data.get("bot")
         self.user: Optional[User] = User(state=state, data=user) if user else None
+        self.role_connections_verification_url: Optional[str] = data.get(
+            "role_connections_verification_url"
+        )
 
     @property
     def summary(self) -> str:

--- a/disnake/types/integration.py
+++ b/disnake/types/integration.py
@@ -17,6 +17,7 @@ class IntegrationApplication(TypedDict):
     description: str
     summary: str
     bot: NotRequired[User]
+    role_connections_verification_url: NotRequired[str]
 
 
 class IntegrationAccount(TypedDict):
@@ -41,11 +42,7 @@ IntegrationType = Literal["twitch", "youtube", "discord"]
 
 class BaseIntegration(PartialIntegration):
     enabled: bool
-    syncing: bool
-    synced_at: str
-    user: User
-    expire_behavior: IntegrationExpireBehavior
-    expire_grace_period: int
+    user: NotRequired[User]
 
 
 class StreamIntegration(BaseIntegration):
@@ -53,6 +50,10 @@ class StreamIntegration(BaseIntegration):
     enable_emoticons: bool
     subscriber_count: int
     revoked: bool
+    syncing: bool
+    synced_at: str
+    expire_behavior: IntegrationExpireBehavior
+    expire_grace_period: int
 
 
 class BotIntegration(BaseIntegration):


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/pull/5857

Adds `has_commands` and `include_role_connections_metadata` parameters to `Guild.integrations`, and the `IntegrationApplication.role_connections_verification_url` prop.

We could also consider setting `include_role_connections_metadata` to `True` by default.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
