### PR TITLE
feat: add `oldest_first` parameter to `Guild.audit_logs`

### DIFF
--- a/changelog/919.feature.rst
+++ b/changelog/919.feature.rst
@@ -1,0 +1,1 @@
+Add ``oldest_first`` parameter to :meth:`Guild.audit_logs`.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3853,6 +3853,8 @@ class Guild(Hashable):
         oldest_first: :class:`bool`
             If set to ``True``, return entries in oldest->newest order. Defaults to ``False``.
 
+            .. versionadded:: 2.9
+
         Raises
         ------
         Forbidden

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3808,13 +3808,14 @@ class Guild(Hashable):
         after: Optional[SnowflakeTime] = None,
         user: Optional[Snowflake] = None,
         action: Optional[AuditLogAction] = None,
+        oldest_first: bool = False,
     ) -> AuditLogIterator:
         """Returns an :class:`AsyncIterator` that enables receiving the guild's audit logs.
 
         You must have :attr:`~Permissions.view_audit_log` permission to use this.
 
-        Entries are always returned in order from newest to oldest, regardless of the
-        ``before`` and ``after`` parameters.
+        Entries are returned in order from newest to oldest by default;
+        pass ``oldest_first=True`` to reverse the iteration order.
 
         Examples
         --------
@@ -3838,18 +3839,20 @@ class Guild(Hashable):
         ----------
         limit: Optional[:class:`int`]
             The number of entries to retrieve. If ``None`` retrieve all entries.
-        before: Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]
+        before: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
             Retrieve entries before this date or entry.
             If a datetime is provided, it is recommended to use a UTC aware datetime.
             If the datetime is naive, it is assumed to be local time.
-        after: Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]
+        after: Optional[Union[:class:`abc.Snowflake`, :class:`datetime.datetime`]]
             Retrieve entries after this date or entry.
             If a datetime is provided, it is recommended to use a UTC aware datetime.
             If the datetime is naive, it is assumed to be local time.
-        user: :class:`abc.Snowflake`
+        user: Optional[:class:`abc.Snowflake`]
             The moderator to filter entries from.
-        action: :class:`AuditLogAction`
+        action: Optional[:class:`AuditLogAction`]
             The action to filter with.
+        oldest_first: :class:`bool`
+            If set to ``True``, return entries in oldest->newest order. Defaults to ``False``.
 
         Raises
         ------
@@ -3875,6 +3878,7 @@ class Guild(Hashable):
             limit=limit,
             user_id=user_id,
             action_type=action.value if action is not None else None,
+            oldest_first=oldest_first,
         )
 
     async def widget(self) -> Widget:

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1745,13 +1745,17 @@ class HTTPClient:
         self,
         guild_id: Snowflake,
         limit: int = 100,
+        # only one of these two may be specified, otherwise `after` gets ignored
         before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
         user_id: Optional[Snowflake] = None,
         action_type: Optional[audit_log.AuditLogEvent] = None,
     ) -> Response[audit_log.AuditLog]:
         params: Dict[str, Any] = {"limit": limit}
-        if before:
+        if before is not None:
             params["before"] = before
+        if after is not None:
+            params["after"] = after
         if user_id:
             params["user_id"] = user_id
         if action_type:

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -496,6 +496,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         after: Optional[Union[Snowflake, datetime.datetime]] = None,
         user_id: Optional[int] = None,
         action_type: Optional[AuditLogEvent] = None,
+        oldest_first: bool = False,
     ) -> None:
         if isinstance(before, datetime.datetime):
             before = Object(id=time_snowflake(before, high=False))
@@ -515,10 +516,16 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         self.entries: asyncio.Queue[AuditLogEntry] = asyncio.Queue()
 
         self._filter: Optional[Callable[[AuditLogEntryPayload], bool]] = None
-        if self.after and self.after != OLDEST_OBJECT:
-            self._filter = lambda e: int(e["id"]) > self.after.id
+        if oldest_first:
+            self._strategy = self._after_strategy
+            if self.before:
+                self._filter = lambda m: int(m["id"]) < self.before.id  # type: ignore
+        else:
+            self._strategy = self._before_strategy
+            if self.after and self.after != OLDEST_OBJECT:
+                self._filter = lambda m: int(m["id"]) > self.after.id
 
-    async def _retrieve_data(self, retrieve: int) -> AuditLogPayload:
+    async def _before_strategy(self, retrieve: int) -> AuditLogPayload:
         before = self.before.id if self.before else None
         data: AuditLogPayload = await self.request(
             self.guild.id,
@@ -533,6 +540,25 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
             if self.limit is not None:
                 self.limit -= retrieve
             self.before = Object(id=int(entries[-1]["id"]))
+        return data
+
+    async def _after_strategy(self, retrieve: int) -> AuditLogPayload:
+        after = self.after.id
+        data: AuditLogPayload = await self.request(
+            self.guild.id,
+            limit=retrieve,
+            user_id=self.user_id,
+            action_type=self.action_type,
+            after=after,
+        )
+
+        entries = data.get("audit_log_entries", [])
+        if entries:
+            if self.limit is not None:
+                self.limit -= retrieve
+            # note: unlike other paginated endpoints, this one returns entries in ascending
+            # order when using `after`; hence `-1` (instead of `0`) is correct here.
+            self.after = Object(id=int(entries[-1]["id"]))
         return data
 
     async def next(self) -> AuditLogEntry:
@@ -555,7 +581,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
 
     async def _fill(self) -> None:
         if self._get_retrieve():
-            log_data = await self._retrieve_data(self.retrieve)
+            log_data = await self._strategy(self.retrieve)
             entries = log_data.get("audit_log_entries")
             if len(entries) < 100:
                 self.limit = 0  # terminate the infinite loop


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/38f01b07531b672880e434692d215233e45eb0db

This was removed in #473, since the `after` parameter wasn't supported on the API side back then. Now that it *is* supported, `oldest_first` can work as expected and doesn't require excessive amounts of memory.

Similar to other endpoints, `before` and `after` are mutually exclusive - `after` is ignored if both are provided, hence the continued need for local filtering.
Notably, using the `after` parameter makes the API return results in ascending order, unlike other endpoints (e.g. the history endpoint, which returns messages in descending order regardless of query parameters).

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
