### PR TITLE
feat: add fallback to `Object` for user property in AuditLogEntry

### DIFF
--- a/changelog/920.feature.rst
+++ b/changelog/920.feature.rst
@@ -1,1 +1,1 @@
-Add :attr:`AuditLogEntry.user_id`
+Add fallback to :class:`Object` for :attr:`AuditLogEntry.user`

--- a/changelog/920.feature.rst
+++ b/changelog/920.feature.rst
@@ -1,0 +1,1 @@
+Add :attr:`AuditLogEntry.user_id`

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -758,7 +758,7 @@ class AuditLogEntry(Hashable):
     def _convert_target_channel(self, target_id: int) -> Union[abc.GuildChannel, Object]:
         return self.guild.get_channel(target_id) or Object(id=target_id)
 
-    def _convert_target_user(self, target_id: int) -> Union[Member, User, Object, None]:
+    def _convert_target_user(self, target_id: int) -> Union[Member, User, Object]:
         return self._get_member(target_id)
 
     def _convert_target_role(self, target_id: int) -> Union[Role, Object]:
@@ -790,7 +790,7 @@ class AuditLogEntry(Hashable):
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id)
 
-    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object, None]:
+    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object]:
         return self._get_member(target_id)
 
     def _convert_target_integration(self, target_id: int) -> Union[PartialIntegration, Object]:

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -535,7 +535,7 @@ class AuditLogEntry(Hashable):
     ----------
     action: :class:`AuditLogAction`
         The action that was done.
-    user: Optional[Union[]:class:`Member`, :class:`User`, :class:`Object`]]
+    user: Optional[Union[:class:`Member`, :class:`User`, :class:`Object`]]
         The user who initiated this action. Usually :class:`Member`\\, unless gone
         then it's a :class:`User`.
     id: :class:`int`

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -535,7 +535,7 @@ class AuditLogEntry(Hashable):
     ----------
     action: :class:`AuditLogAction`
         The action that was done.
-    user: Union[:class:`Member`, :class:`User`, :class:`Object`]
+    user: Optional[Union[]:class:`Member`, :class:`User`, :class:`Object`]]
         The user who initiated this action. Usually :class:`Member`\\, unless gone
         then it's a :class:`User`.
     id: :class:`int`

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -763,7 +763,7 @@ class AuditLogEntry(Hashable):
     def _convert_target_channel(self, target_id: int) -> Union[abc.GuildChannel, Object]:
         return self.guild.get_channel(target_id) or Object(id=target_id)
 
-    def _convert_target_user(self, target_id: int) -> Union[Member, User, Object]:
+    def _convert_target_user(self, target_id: int) -> Union[Member, User, Object, None]:
         return self._get_member(target_id)
 
     def _convert_target_role(self, target_id: int) -> Union[Role, Object]:
@@ -795,7 +795,7 @@ class AuditLogEntry(Hashable):
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id)
 
-    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object]:
+    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object, None]:
         return self._get_member(target_id)
 
     def _convert_target_integration(self, target_id: int) -> Union[PartialIntegration, Object]:

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -532,9 +532,8 @@ class AuditLogEntry(Hashable):
     ----------
     action: :class:`AuditLogAction`
         The action that was done.
-    user: :class:`abc.User`
-        The user who initiated this action. Usually a :class:`Member`\\, unless gone
-        then it's a :class:`User`.
+    user_id: :class:`int`
+        The ID of the user who initiated this action.
     id: :class:`int`
         The entry ID.
     target: Any
@@ -673,7 +672,7 @@ class AuditLogEntry(Hashable):
         # into meaningful data when requested
         self._changes = data.get("changes", [])
 
-        self.user = self._get_member(utils._get_as_snowflake(data, "user_id"))  # type: ignore
+        self.user_id = utils._get_as_snowflake(data, "user_id")
         self._target_id = utils._get_as_snowflake(data, "target_id")
 
     def _get_member(self, user_id: int) -> Union[Member, User, None]:
@@ -697,6 +696,11 @@ class AuditLogEntry(Hashable):
     def created_at(self) -> datetime.datetime:
         """:class:`datetime.datetime`: Returns the entry's creation time in UTC."""
         return utils.snowflake_time(self.id)
+
+    @utils.cached_property
+    def user(self) -> Union[Member, User, None]:
+        """:class:`abc.User`: The user who initiated this action. Usually a :class:`Member`\\, unless gone then it's a :class:`User`."""
+        return self._get_member(self.user_id)  # type: ignore
 
     @utils.cached_property
     def target(

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -699,7 +699,7 @@ class AuditLogEntry(Hashable):
 
     @utils.cached_property
     def user(self) -> Union[Member, User, None]:
-        """:class:`abc.User`: The user who initiated this action. Usually a :class:`Member`\\, unless gone then it's a :class:`User`."""
+        """Optional[:class:`Member`, :class:`User`]: The user who initiated this action. Usually a :class:`Member`\\, unless gone then it's a :class:`User`."""
         return self._get_member(self.user_id)  # type: ignore
 
     @utils.cached_property

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -102,7 +102,7 @@ def _transform_role(
 
 def _transform_member_id(
     entry: AuditLogEntry, data: Optional[Snowflake]
-) -> Union[Member, User, None]:
+) -> Union[Member, User, Object, None]:
     if data is None:
         return None
     return entry._get_member(int(data))
@@ -533,7 +533,7 @@ class AuditLogEntry(Hashable):
     action: :class:`AuditLogAction`
         The action that was done.
     user: Union[:class:`Member`, :class:`User`, :class:`Object`]
-        The user who initiated this action. Usually a :class:`Member`\\, unless gone
+        The user who initiated this action. Usually :class:`Member`\\, unless gone
         then it's a :class:`User`.
     id: :class:`int`
         The entry ID.
@@ -758,7 +758,7 @@ class AuditLogEntry(Hashable):
     def _convert_target_channel(self, target_id: int) -> Union[abc.GuildChannel, Object]:
         return self.guild.get_channel(target_id) or Object(id=target_id)
 
-    def _convert_target_user(self, target_id: int) -> Union[Member, User, None]:
+    def _convert_target_user(self, target_id: int) -> Union[Member, User, Object, None]:
         return self._get_member(target_id)
 
     def _convert_target_role(self, target_id: int) -> Union[Role, Object]:
@@ -790,7 +790,7 @@ class AuditLogEntry(Hashable):
     def _convert_target_emoji(self, target_id: int) -> Union[Emoji, Object]:
         return self._state.get_emoji(target_id) or Object(id=target_id)
 
-    def _convert_target_message(self, target_id: int) -> Union[Member, User, None]:
+    def _convert_target_message(self, target_id: int) -> Union[Member, User, Object, None]:
         return self._get_member(target_id)
 
     def _convert_target_integration(self, target_id: int) -> Union[PartialIntegration, Object]:

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -528,6 +528,9 @@ class AuditLogEntry(Hashable):
     .. versionchanged:: 1.7
         Audit log entries are now comparable and hashable.
 
+    .. versionchanged:: 2.8
+        :attr:`user` can return :class:`Object` if the user is not found.
+
     Attributes
     ----------
     action: :class:`AuditLogAction`
@@ -673,10 +676,12 @@ class AuditLogEntry(Hashable):
         # into meaningful data when requested
         self._changes = data.get("changes", [])
 
-        self.user = self._get_member(utils._get_as_snowflake(data, "user_id"))  # type: ignore
+        self.user = self._get_member(utils._get_as_snowflake(data, "user_id"))
         self._target_id = utils._get_as_snowflake(data, "target_id")
 
-    def _get_member(self, user_id: int) -> Union[Member, User, Object]:
+    def _get_member(self, user_id: Optional[int]) -> Union[Member, User, Object, None]:
+        if not user_id:
+            return None
         return self.guild.get_member(user_id) or self._users.get(user_id) or Object(id=user_id)
 
     def _get_integration_by_application_id(


### PR DESCRIPTION
## Summary

The currently implemented `user` property will try to retrieve the user from the cache. If the user cannot be found, we return `None` with no way to get the user ID. Therefore a new `user_id` property has been introduced.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
