### PR TITLE
ci: update `pre-commit/action` and `isort`

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Run pre-commit
       id: pre-commit
-      uses: pre-commit/action@v2.0.3
+      uses: pre-commit/action@v3.0.0
       env:
         SKIP: 'flake8'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: check-case-conflict
       - id: check-toml
@@ -38,7 +38,7 @@ repos:
         exclude: 'changelog/|py.typed|disnake/bin/COPYING|.github/PULL_REQUEST_TEMPLATE.md|LICENSE|MANIFEST.in|requirements/|requirements.txt'
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--extend-skip", "examples"]


### PR DESCRIPTION
## Summary

Updating `pre-commit/action` resolves the nodejs v12 deprecation warning mentioned in #852.
This also uncovered a [dependency issue](https://github.com/DisnakeDev/disnake/actions/runs/4076273215/jobs/7023783749) with the current isort version, which would've likely come up anyway once the caches expire - see https://github.com/PyCQA/isort/issues/2077.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
