### PR TITLE
fix: use `errno.ECONNRESET` to handle connection resets on Linux properly

### DIFF
--- a/changelog/921.bugfix.rst
+++ b/changelog/921.bugfix.rst
@@ -1,0 +1,1 @@
+Fix handling of ``ECONNRESET`` errors on Linux.

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -9,6 +9,7 @@ import sys
 import traceback
 import warnings
 from datetime import datetime, timedelta
+from errno import ECONNRESET
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -974,7 +975,7 @@ class Client:
                     return
 
                 # If we get connection reset by peer then try to RESUME
-                if isinstance(exc, OSError) and exc.errno in (54, 10054):
+                if isinstance(exc, OSError) and exc.errno == ECONNRESET:
                     ws_params.update(
                         sequence=self.ws.sequence,
                         initial=False,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -7,6 +7,7 @@ import logging
 import re
 import sys
 import weakref
+from errno import ECONNRESET
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -422,7 +423,7 @@ class HTTPClient:
                 # This is handling exceptions from the request
                 except OSError as e:
                     # Connection reset by peer
-                    if tries < 4 and e.errno in (54, 10054):
+                    if tries < 4 and e.errno == ECONNRESET:
                         await asyncio.sleep(1 + tries * 2)
                         continue
                     raise

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from errno import ECONNRESET
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -136,7 +137,7 @@ class Shard:
         if self._client.is_closed():
             return
 
-        if isinstance(e, OSError) and e.errno in (54, 10054):
+        if isinstance(e, OSError) and e.errno == ECONNRESET:
             # If we get Connection reset by peer then always try to RESUME the connection.
             exc = ReconnectWebSocket(self.id, resume=True)
             self._queue_put(EventItem(EventType.resume, self, exc))

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import re
 from contextvars import ContextVar
+from errno import ECONNRESET
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -209,7 +210,7 @@ class AsyncWebhookAdapter:
                             raise HTTPException(response, data)
 
                 except OSError as e:
-                    if attempt < 4 and e.errno in (54, 10054):
+                    if attempt < 4 and e.errno == ECONNRESET:
                         await asyncio.sleep(1 + attempt * 2)
                         continue
                     raise

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -12,6 +12,7 @@ import logging
 import re
 import threading
 import time
+from errno import ECONNRESET
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, Union, overload
 from urllib.parse import quote as urlquote
 
@@ -186,7 +187,7 @@ class WebhookAdapter:
                             raise HTTPException(response, data)
 
                 except OSError as e:
-                    if attempt < 4 and e.errno in (54, 10054):
+                    if attempt < 4 and e.errno == ECONNRESET:
                         time.sleep(1 + attempt * 2)
                         continue
                     raise


### PR DESCRIPTION
## Summary

A couple places in the code attempt to handle connection resets by checking `OSError.errno in (54, 10054)`. This works on Windows (`10054`) and macOS/BSD (`54`), but not on Linux, where `ECONNRESET` is `104`.

Python's `errno` module makes handling this across different platforms much easier.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
