### PR TITLE
docs: fix missing spaces in `ApplicationRoleConnectionMetadataType` enum

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3840,33 +3840,41 @@ of :class:`enum.Enum`.
 
     Represents the type of a role connection metadata value.
 
-    These offer comparison operations which allow guilds to configure role requirements
+    These offer comparison operations, which allow guilds to configure role requirements
     based on the metadata value for each user and a guild-specified configured value.
 
     .. versionadded:: 2.8
 
     .. attribute:: integer_less_than_or_equal
+
         The metadata value (``integer``) is less than or equal to the guild's configured value.
 
     .. attribute:: integer_greater_than_or_equal
+
         The metadata value (``integer``) is greater than or equal to the guild's configured value.
 
     .. attribute:: integer_equal
+
         The metadata value (``integer``) is equal to the guild's configured value.
 
     .. attribute:: integer_not_equal
+
         The metadata value (``integer``) is not equal to the guild's configured value.
 
     .. attribute:: datetime_less_than_or_equal
+
         The metadata value (``ISO8601 string``) is less than or equal to the guild's configured value (``integer``; days before current date).
 
     .. attribute:: datetime_greater_than_or_equal
+
         The metadata value (``ISO8601 string``) is greater than or equal to the guild's configured value (``integer``; days before current date).
 
     .. attribute:: boolean_equal
+
         The metadata value (``integer``) is equal to the guild's configured value.
 
     .. attribute:: boolean_not_equal
+
         The metadata value (``integer``) is not equal to the guild's configured value.
 
 Async Iterator


### PR DESCRIPTION
## Summary

Followup to #906, fixes a documentation formatting issue.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
