### PR TITLE
release: v2.8.0

### DIFF
--- a/changelog/578.feature.rst
+++ b/changelog/578.feature.rst
@@ -1,1 +1,0 @@
-Add :class:`GuildBuilder` and :func:`Client.guild_builder` for full coverage of the guild creation endpoint.

--- a/changelog/794.feature.rst
+++ b/changelog/794.feature.rst
@@ -1,1 +1,0 @@
-Support regex within automod using :attr:`AutoModTriggerMetadata.regex_patterns`.

--- a/changelog/830.misc.rst
+++ b/changelog/830.misc.rst
@@ -1,1 +1,0 @@
-Declare a :pep:`517` build backend in pyproject.toml, and use :pep:`621` to define most package metadata.

--- a/changelog/839.feature.rst
+++ b/changelog/839.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`File.closed` and :attr:`File.bytes_length` properties.

--- a/changelog/849.bugfix.rst
+++ b/changelog/849.bugfix.rst
@@ -1,1 +1,0 @@
-|commands| Fix ``help_command`` parameter annotations to allow ``None`` value.

--- a/changelog/854.feature.rst
+++ b/changelog/854.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`TextChannel.default_thread_slowmode_delay`.

--- a/changelog/858.bugfix.rst
+++ b/changelog/858.bugfix.rst
@@ -1,1 +1,0 @@
-Fix user cache memory leak where unused objects weren't being evicted (provided that :attr:`Intents.members` is enabled).

--- a/changelog/859.doc.rst
+++ b/changelog/859.doc.rst
@@ -1,1 +1,0 @@
-Enable `OpenSearch <https://developer.mozilla.org/en-US/docs/Web/OpenSearch>`_, allowing easy integration of the search functionality into browsers.

--- a/changelog/864.doc.rst
+++ b/changelog/864.doc.rst
@@ -1,1 +1,0 @@
-Clarify types of optional :class:`Invite` attributes.

--- a/changelog/865.feature.rst
+++ b/changelog/865.feature.rst
@@ -1,3 +1,0 @@
-Add support for NSFW application commands.
-- Add :attr:`ApplicationCommand.nsfw`.
-- Add ``nsfw`` parameter to command constructors and decorators.

--- a/changelog/866.feature.rst
+++ b/changelog/866.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`.UserFlags.active_developer` and :attr:`PublicUserFlags.active_developer`.

--- a/changelog/870.bugfix.rst
+++ b/changelog/870.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :attr:`Message.author.public_flags <Member.public_flags>` always being ``0`` when the member cache is disabled.

--- a/changelog/872.doc.rst
+++ b/changelog/872.doc.rst
@@ -1,1 +1,0 @@
-Remove documentation regarding private threads requiring boosts.

--- a/changelog/873.feature.rst
+++ b/changelog/873.feature.rst
@@ -1,1 +1,0 @@
-Adds reasons/descriptions to :exc:`ConnectionClosed` errors.

--- a/changelog/877.doc.rst
+++ b/changelog/877.doc.rst
@@ -1,1 +1,0 @@
-Update :class:`AutoModTriggerMetadata` field limits.

--- a/changelog/877.feature.rst
+++ b/changelog/877.feature.rst
@@ -1,1 +1,0 @@
-Update :class:`AutoModTriggerMetadata` overloads to allow passing ``allow_list`` to keyword-based rules.

--- a/changelog/879.bugfix.rst
+++ b/changelog/879.bugfix.rst
@@ -1,1 +1,0 @@
-Export missing ``ThreadWithMessage`` class.

--- a/changelog/880.bugfix.rst
+++ b/changelog/880.bugfix.rst
@@ -1,1 +1,0 @@
-Add previously missing ``applied_tags`` parameter to all :meth:`ForumChannel.create_thread` overloads.

--- a/changelog/883.feature.rst
+++ b/changelog/883.feature.rst
@@ -1,1 +1,0 @@
-The :attr:`PublicUserFlags.discord_certified_moderator` is now an alias of :attr:`PublicUserFlags.moderator_programs_alumni`.

--- a/changelog/885.feature.rst
+++ b/changelog/885.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`ForumChannel.default_layout`, and ``default_layout`` parameter to channel edit methods.

--- a/changelog/887.bugfix.rst
+++ b/changelog/887.bugfix.rst
@@ -1,1 +1,0 @@
-Fix conversion of custom emoji strings (e.g. ``<:this:934852112221872198>``) in :meth:`Message.add_reaction` and similar methods to more strictly adhere to the API documentation.

--- a/changelog/890.feature.rst
+++ b/changelog/890.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`Locale.id` (Indonesian) locale.

--- a/changelog/895.feature.rst
+++ b/changelog/895.feature.rst
@@ -1,1 +1,0 @@
-Adds :class:`Event` enumeration to use in :meth:`Client.wait_for`, :meth:`disnake.ext.commands.Bot.wait_for` and in :func:`disnake.ext.commands.Bot.listen` decorator.

--- a/changelog/903.feature.rst
+++ b/changelog/903.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`ForumChannel.default_layout`, and ``default_layout`` parameter to channel edit methods.

--- a/changelog/905.feature.rst
+++ b/changelog/905.feature.rst
@@ -1,1 +1,0 @@
-Add new :attr:`MessageType.interaction_premium_upsell` and :attr:`MessageType.guild_application_premium_subscription` message types.

--- a/changelog/906.feature.rst
+++ b/changelog/906.feature.rst
@@ -1,4 +1,0 @@
-Add application role connection features.
-- Add :class:`ApplicationRoleConnectionMetadata` and :class:`ApplicationRoleConnectionMetadataType` types.
-- Add :class:`Client.fetch_role_connection_metadata` and :class:`Client.edit_role_connection_metadata` methods.
-- Add :attr:`RoleTags.is_linked_role` and :attr:`AppInfo.role_connections_verification_url` attributes.

--- a/changelog/907.bugfix.rst
+++ b/changelog/907.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :meth:`Client.delete_guild_command` not updating the local command cache.

--- a/changelog/910.feature.rst
+++ b/changelog/910.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`StickerFormatType.gif`.

--- a/changelog/911.bugfix.rst
+++ b/changelog/911.bugfix.rst
@@ -1,1 +1,0 @@
-Fix errors when trying to deserialize stickers with unknown formats.

--- a/changelog/912.breaking.rst
+++ b/changelog/912.breaking.rst
@@ -1,1 +1,0 @@
-:attr:`StickerPack.cover_sticker_id`, :attr:`.cover_sticker <StickerPack.cover_sticker>` and :attr:`.banner <StickerPack.banner>` are now optional and may return ``None``.

--- a/changelog/912.bugfix.rst
+++ b/changelog/912.bugfix.rst
@@ -1,1 +1,0 @@
-Make :attr:`StickerPack.cover_sticker_id`, :attr:`.cover_sticker <StickerPack.cover_sticker>` and :attr:`.banner <StickerPack.banner>` optional.

--- a/changelog/915.feature.rst
+++ b/changelog/915.feature.rst
@@ -1,1 +1,0 @@
-Add support for the :func:`on_audit_log_entry_create` gateway event, and add :attr:`Intents.moderation` intent. :attr:`Intents.bans` is now an alias of :attr:`Intents.moderation`.

--- a/changelog/918.feature.rst
+++ b/changelog/918.feature.rst
@@ -1,1 +1,0 @@
-Add :attr:`~Member.flags` property to :class:`Member`.

--- a/changelog/920.feature.rst
+++ b/changelog/920.feature.rst
@@ -1,1 +1,0 @@
-Add fallback to :class:`Object` for :attr:`AuditLogEntry.user`

--- a/changelog/921.bugfix.rst
+++ b/changelog/921.bugfix.rst
@@ -1,1 +1,0 @@
-Fix handling of ``ECONNRESET`` errors on Linux.

--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -15,7 +15,7 @@ __title__ = "disnake"
 __author__ = "Rapptz, EQUENOS"
 __license__ = "MIT"
 __copyright__ = "Copyright 2015-present Rapptz, 2021-present EQUENOS"
-__version__ = "2.8.0a"
+__version__ = "2.8.0"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
@@ -81,6 +81,6 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info: VersionInfo = VersionInfo(major=2, minor=8, micro=0, releaselevel="alpha", serial=0)
+version_info: VersionInfo = VersionInfo(major=2, minor=8, micro=0, releaselevel="final", serial=0)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,6 +17,70 @@ in specific versions.
 
 .. towncrier release notes start
 
+.. _vp2p8p0:
+
+v2.8.0
+------
+
+This release comes with support for NSFW application commands,
+the :func:`on_audit_log_entry_create` event,
+and a new :class:`Event` enum for use with methods like :func:`Client.wait_for`.
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+- :attr:`StickerPack.cover_sticker_id`, :attr:`.cover_sticker <StickerPack.cover_sticker>` and :attr:`.banner <StickerPack.banner>` are now optional and may return ``None``. (:issue:`912`)
+- :attr:`AuditLogEntry.user` may now be an :class:`Object` if the user cannot be found, particularly in entries from the :func:`on_audit_log_entry_create` event. (:issue:`920`)
+
+New Features
+~~~~~~~~~~~~
+- Add :class:`GuildBuilder` and :func:`Client.guild_builder` for full coverage of the guild creation endpoint. (:issue:`578`)
+- Support regex within automod using :attr:`AutoModTriggerMetadata.regex_patterns`. (:issue:`794`)
+- Add :attr:`File.closed` and :attr:`File.bytes_length` properties. (:issue:`839`)
+- Add :attr:`TextChannel.default_thread_slowmode_delay`. (:issue:`854`)
+- Add support for NSFW application commands. (:issue:`865`)
+    - Add :attr:`ApplicationCommand.nsfw`.
+    - Add ``nsfw`` parameter to command constructors and decorators.
+- Add :attr:`.UserFlags.active_developer` and :attr:`PublicUserFlags.active_developer`. (:issue:`866`)
+- Adds reasons/descriptions to :exc:`ConnectionClosed` errors. (:issue:`873`)
+- Update :class:`AutoModTriggerMetadata` overloads to allow passing ``allow_list`` to keyword-based rules. (:issue:`877`)
+- The :attr:`PublicUserFlags.discord_certified_moderator` is now an alias of :attr:`PublicUserFlags.moderator_programs_alumni`. (:issue:`883`)
+- Add :attr:`ForumChannel.default_layout`, and ``default_layout`` parameter to channel edit methods. (:issue:`885`, :issue:`903`)
+- Add :attr:`Locale.id` (Indonesian) locale. (:issue:`890`)
+- Adds :class:`Event` enumeration to use in :meth:`Client.wait_for`, :meth:`disnake.ext.commands.Bot.wait_for` and in :func:`disnake.ext.commands.Bot.listen` decorator. (:issue:`895`)
+- Add new :attr:`MessageType.interaction_premium_upsell` and :attr:`MessageType.guild_application_premium_subscription` message types. (:issue:`905`)
+- Add application role connection features. (:issue:`906`)
+    - Add :class:`ApplicationRoleConnectionMetadata` and :class:`ApplicationRoleConnectionMetadataType` types.
+    - Add :class:`Client.fetch_role_connection_metadata` and :class:`Client.edit_role_connection_metadata` methods.
+    - Add :attr:`RoleTags.is_linked_role` and :attr:`AppInfo.role_connections_verification_url` attributes.
+- Add :attr:`StickerFormatType.gif`. (:issue:`910`)
+- Add support for the :func:`on_audit_log_entry_create` gateway event, and add :attr:`Intents.moderation` intent. :attr:`Intents.bans` is now an alias of :attr:`Intents.moderation`. (:issue:`915`)
+- Add :attr:`~Member.flags` property to :class:`Member`. (:issue:`918`)
+- Add fallback to :class:`Object` for :attr:`AuditLogEntry.user` (:issue:`920`)
+
+Bug Fixes
+~~~~~~~~~
+- |commands| Fix ``help_command`` parameter annotations to allow ``None`` value. (:issue:`849`)
+- Fix user cache memory leak where unused objects weren't being evicted (provided that :attr:`Intents.members` is enabled). (:issue:`858`)
+- Fix :attr:`Message.author.public_flags <Member.public_flags>` always being ``0`` when the member cache is disabled. (:issue:`870`)
+- Export missing ``ThreadWithMessage`` class. (:issue:`879`)
+- Add previously missing ``applied_tags`` parameter to all :meth:`ForumChannel.create_thread` overloads. (:issue:`880`)
+- Fix conversion of custom emoji strings (e.g. ``<:this:934852112221872198>``) in :meth:`Message.add_reaction` and similar methods to more strictly adhere to the API documentation. (:issue:`887`)
+- Fix :meth:`Client.delete_guild_command` not updating the local command cache. (:issue:`907`)
+- Fix errors when trying to deserialize stickers with unknown formats. (:issue:`911`)
+- Make :attr:`StickerPack.cover_sticker_id`, :attr:`.cover_sticker <StickerPack.cover_sticker>` and :attr:`.banner <StickerPack.banner>` optional. (:issue:`912`)
+- Fix handling of ``ECONNRESET`` errors on Linux. (:issue:`921`)
+
+Documentation
+~~~~~~~~~~~~~
+- Enable `OpenSearch <https://developer.mozilla.org/en-US/docs/Web/OpenSearch>`_, allowing easy integration of the search functionality into browsers. (:issue:`859`)
+- Clarify types of optional :class:`Invite` attributes. (:issue:`864`)
+- Remove documentation regarding private threads requiring boosts. (:issue:`872`)
+- Update :class:`AutoModTriggerMetadata` field limits. (:issue:`877`)
+
+Miscellaneous
+~~~~~~~~~~~~~
+- Declare a :pep:`517` build backend in pyproject.toml, and use :pep:`621` to define most package metadata. (:issue:`830`)
+
 .. _vp2p7p1:
 
 v2.7.1

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,6 +17,18 @@ in specific versions.
 
 .. towncrier release notes start
 
+.. _vp2p7p1:
+
+v2.7.1
+------
+
+Bug Fixes
+~~~~~~~~~
+- Fix :attr:`Message.author.public_flags <Member.public_flags>` always being ``0`` when the member cache is disabled. (:issue:`870`)
+- Export missing ``ThreadWithMessage`` class. (:issue:`879`)
+- Fix :meth:`Client.delete_guild_command` not updating the local command cache. (:issue:`907`)
+- Fix errors when trying to deserialize stickers with unknown formats. (:issue:`911`)
+
 .. _vp2p7p0:
 
 v2.7.0
@@ -85,6 +97,20 @@ Miscellaneous
 - Use ``importlib.metadata`` instead of the deprecated ``pkg_resources`` in the cli for displaying the version. (:issue:`791`)
 - |commands| Add missing ``py.typed`` marker. (:issue:`784`)
 - |tasks| Add missing ``py.typed`` marker. (:issue:`784`)
+
+.. _vp2p6p3:
+
+v2.6.3
+------
+
+This maintainence release contains backports from v2.8.0.
+
+Bug Fixes
+~~~~~~~~~
+- Fix :attr:`Message.author.public_flags <Member.public_flags>` always being ``0`` when the member cache is disabled. (:issue:`870`)
+- Export missing ``ThreadWithMessage`` class. (:issue:`879`)
+- Fix :meth:`Client.delete_guild_command` not updating the local command cache. (:issue:`907`)
+- Fix errors when trying to deserialize stickers with unknown formats. (:issue:`911`)
 
 .. _vp2p6p2:
 


### PR DESCRIPTION
changelog (including backport versions) + version bump