### PR TITLE
docs: update path to favicon after sphinx 6.0.1 update

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -35,7 +35,7 @@
         href="{{ pathto('_static/opensearch.xml', 1) }}"/>
   {%- endif %}
   {%- if favicon_url %}
-  <link rel="icon" href="{{ pathto('_static/' + favicon_url, 1)|e }}"/>
+  <link rel="icon" href="{{ pathto( favicon_url, 1)|e }}"/>
   {%- endif %}
   {%- block linktags %}
   {%- if hasdoc('about') %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -35,7 +35,7 @@
         href="{{ pathto('_static/opensearch.xml', 1) }}"/>
   {%- endif %}
   {%- if favicon_url %}
-  <link rel="icon" href="{{ pathto( favicon_url, 1)|e }}"/>
+  <link rel="icon" href="{{ favicon_url|e }}"/>
   {%- endif %}
   {%- block linktags %}
   {%- if hasdoc('about') %}


### PR DESCRIPTION
## Summary

sphinx 6 changed the path provided to the favicon slightly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
