### PR TITLE
refactor(lint): add flake8-return rules

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1634,7 +1634,7 @@ class Messageable:
         if view is not None and components is not None:
             raise TypeError("cannot pass both view and components parameter to send()")
 
-        elif view:
+        if view:
             if not hasattr(view, "__discord_ui_view__"):
                 raise TypeError(f"view parameter must be View not {view.__class__!r}")
 
@@ -1656,7 +1656,7 @@ class Messageable:
         if files is not None:
             if len(files) > 10:
                 raise ValueError("files parameter must be a list of up to 10 elements")
-            elif not all(isinstance(file, File) for file in files):
+            if not all(isinstance(file, File) for file in files):
                 raise TypeError("files parameter must be a list of File")
 
             try:

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -454,6 +454,7 @@ class GuildChannel(ABC):
 
         if options:
             return await self._state.http.edit_channel(self.id, reason=reason, **options)
+        return None
 
     def _fill_overwrites(self, data: GuildChannelPayload) -> None:
         self._overwrites = []

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -831,8 +831,7 @@ class CustomActivity(BaseActivity):
             if self.name:
                 return f"{self.emoji} {self.name}"
             return str(self.emoji)
-        else:
-            return str(self.name)
+        return str(self.name)
 
     def __repr__(self) -> str:
         return f"<CustomActivity name={self.name!r} emoji={self.emoji!r}>"

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -103,6 +103,7 @@ class _BaseActivity:
             return datetime.datetime.fromtimestamp(
                 self._created_at / 1000, tz=datetime.timezone.utc
             )
+        return None
 
     @property
     def start(self) -> Optional[datetime.datetime]:

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -100,9 +100,8 @@ class AssetMixin:
             if seek_begin:
                 fp.seek(0)
             return written
-        else:
-            with open(fp, "wb") as f:
-                return f.write(data)
+        with open(fp, "wb") as f:
+            return f.write(data)
 
     async def to_file(
         self,

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -231,13 +231,12 @@ def _transform_type(
     action_name = entry.action.name
     if action_name.startswith("sticker_"):
         return enums.try_enum(enums.StickerType, data)
-    elif action_name.startswith("webhook_"):
+    if action_name.startswith("webhook_"):
         return enums.try_enum(enums.WebhookType, data)
-    elif action_name.startswith("integration_") or action_name.startswith("overwrite_"):
+    if action_name.startswith("integration_") or action_name.startswith("overwrite_"):
         # integration: str, overwrite: int
         return data
-    else:
-        return enums.try_enum(enums.ChannelType, data)
+    return enums.try_enum(enums.ChannelType, data)
 
 
 def _transform_datetime(entry: AuditLogEntry, data: Optional[str]) -> Optional[datetime.datetime]:

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -377,7 +377,7 @@ class AuditLogChanges:
             if attr == "$add":
                 self._handle_role(self.before, self.after, entry, elem["new_value"])  # type: ignore
                 continue
-            elif attr == "$remove":
+            if attr == "$remove":
                 self._handle_role(self.after, self.before, entry, elem["new_value"])  # type: ignore
                 continue
 

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -477,6 +477,8 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             # the payload will always be the proper channel payload
             return self.__class__(state=self._state, guild=self.guild, data=payload)  # type: ignore
 
+        return None
+
     @utils.copy_doc(disnake.abc.GuildChannel.clone)
     async def clone(
         self, *, name: Optional[str] = None, reason: Optional[str] = None
@@ -1447,6 +1449,8 @@ class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
             # the payload will always be the proper channel payload
             return self.__class__(state=self._state, guild=self.guild, data=payload)  # type: ignore
 
+        return None
+
     async def delete_messages(self, messages: Iterable[Snowflake]) -> None:
         """|coro|
 
@@ -2196,6 +2200,8 @@ class StageChannel(disnake.abc.Messageable, VocalGuildChannel):
             # the payload will always be the proper channel payload
             return self.__class__(state=self._state, guild=self.guild, data=payload)  # type: ignore
 
+        return None
+
     async def delete_messages(self, messages: Iterable[Snowflake]) -> None:
         """|coro|
 
@@ -2625,6 +2631,8 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         if payload is not None:
             # the payload will always be the proper channel payload
             return self.__class__(state=self._state, guild=self.guild, data=payload)  # type: ignore
+
+        return None
 
     @overload
     async def move(
@@ -3297,6 +3305,8 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
         if payload is not None:
             # the payload will always be the proper channel payload
             return self.__class__(state=self._state, guild=self.guild, data=payload)  # type: ignore
+
+        return None
 
     @utils.copy_doc(disnake.abc.GuildChannel.clone)
     async def clone(

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -4122,28 +4122,26 @@ def _guild_channel_factory(channel_type: int):
     value = try_enum(ChannelType, channel_type)
     if value is ChannelType.text:
         return TextChannel, value
-    elif value is ChannelType.voice:
+    if value is ChannelType.voice:
         return VoiceChannel, value
-    elif value is ChannelType.category:
+    if value is ChannelType.category:
         return CategoryChannel, value
-    elif value is ChannelType.news:
+    if value is ChannelType.news:
         return TextChannel, value
-    elif value is ChannelType.stage_voice:
+    if value is ChannelType.stage_voice:
         return StageChannel, value
-    elif value is ChannelType.forum:
+    if value is ChannelType.forum:
         return ForumChannel, value
-    else:
-        return None, value
+    return None, value
 
 
 def _channel_factory(channel_type: int):
     cls, value = _guild_channel_factory(channel_type)
     if value is ChannelType.private:
         return DMChannel, value
-    elif value is ChannelType.group:
+    if value is ChannelType.group:
         return GroupChannel, value
-    else:
-        return cls, value
+    return cls, value
 
 
 def _threaded_channel_factory(channel_type: int):

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -3564,7 +3564,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
 
         if params.files and len(params.files) > 10:
             raise ValueError("files parameter must be a list of up to 10 elements")
-        elif params.files and not all(isinstance(file, File) for file in params.files):
+        if params.files and not all(isinstance(file, File) for file in params.files):
             raise TypeError("files parameter must be a list of File")
 
         channel_data = {

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1127,6 +1127,7 @@ class Client:
             except KeyboardInterrupt:
                 # I am unsure why this gets raised here but suppress it anyway
                 return None
+        return None
 
     # properties
 
@@ -1261,6 +1262,7 @@ class Client:
 
         if isinstance(channel, StageChannel):
             return channel.instance
+        return None
 
     def get_guild(self, id: int, /) -> Optional[Guild]:
         """Returns a guild with the given ID.

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -684,21 +684,20 @@ def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> 
     component_type = data["type"]
     if component_type == 1:
         return ActionRow(data)  # type: ignore
-    elif component_type == 2:
+    if component_type == 2:
         return Button(data)  # type: ignore
-    elif component_type == 3:
+    if component_type == 3:
         return StringSelectMenu(data)  # type: ignore
-    elif component_type == 4:
+    if component_type == 4:
         return TextInput(data)  # type: ignore
-    elif component_type == 5:
+    if component_type == 5:
         return UserSelectMenu(data)  # type: ignore
-    elif component_type == 6:
+    if component_type == 6:
         return RoleSelectMenu(data)  # type: ignore
-    elif component_type == 7:
+    if component_type == 7:
         return MentionableSelectMenu(data)  # type: ignore
-    elif component_type == 8:
+    if component_type == 8:
         return ChannelSelectMenu(data)  # type: ignore
-    else:
-        assert_never(component_type)
-        as_enum = try_enum(ComponentType, component_type)
-        return Component._raw_construct(type=as_enum)  # type: ignore
+    assert_never(component_type)
+    as_enum = try_enum(ComponentType, component_type)
+    return Component._raw_construct(type=as_enum)  # type: ignore

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -830,9 +830,8 @@ class Embed:
                 raise TypeError("File must have a filename")
             self._files[key] = file
             return f"attachment://{file.filename}"
-        else:
-            self._files.pop(key, None)
-            return str(url) if url is not None else None
+        self._files.pop(key, None)
+        return str(url) if url is not None else None
 
     def check_limits(self) -> None:
         """Checks if this embed fits within the limits dictated by Discord.

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -461,44 +461,43 @@ class AuditLogAction(Enum):
         v = self.value
         if v == -1:
             return "all"
-        elif v < 10:
+        if v < 10:
             return "guild"
-        elif v < 20:
+        if v < 20:
             return "channel"
-        elif v < 30:
+        if v < 30:
             return "user"
-        elif v < 40:
+        if v < 40:
             return "role"
-        elif v < 50:
+        if v < 50:
             return "invite"
-        elif v < 60:
+        if v < 60:
             return "webhook"
-        elif v < 70:
+        if v < 70:
             return "emoji"
-        elif v == 73:
+        if v == 73:
             return "channel"
-        elif v < 80:
+        if v < 80:
             return "message"
-        elif v < 83:
+        if v < 83:
             return "integration"
-        elif v < 90:
+        if v < 90:
             return "stage_instance"
-        elif v < 93:
+        if v < 93:
             return "sticker"
-        elif v < 103:
+        if v < 103:
             return "guild_scheduled_event"
-        elif v < 113:
+        if v < 113:
             return "thread"
-        elif v < 122:
+        if v < 122:
             return "application_command_or_integration"
-        elif v < 140:
+        if v < 140:
             return None
-        elif v < 143:
+        if v < 143:
             return "automod_rule"
-        elif v < 146:
+        if v < 146:
             return "user"
-        else:
-            return None
+        return None
 
 
 class UserFlags(Enum):

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -71,7 +71,7 @@ def wrap_callback(coro):
         except CommandError:
             raise
         except asyncio.CancelledError:
-            return
+            return None
         except Exception as exc:
             raise CommandInvokeError(exc) from exc
         return ret
@@ -430,7 +430,7 @@ class InvokableApplicationCommand(ABC):
         self, inter: ApplicationCommandInteraction, error: CommandError
     ) -> Any:
         if not self.has_error_handler():
-            return
+            return None
 
         injected = wrap_callback(self.on_error)
         if self.cog is not None:

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -220,13 +220,12 @@ class InvokableApplicationCommand(ABC):
         return self._ensure_assignment_on_copy(copy)
 
     def _update_copy(self: AppCommandT, kwargs: Dict[str, Any]) -> AppCommandT:
-        if kwargs:
-            kw = kwargs.copy()
-            kw.update(self.__original_kwargs__)
-            copy = type(self)(self.callback, **kw)
-            return self._ensure_assignment_on_copy(copy)
-        else:
+        if not kwargs:
             return self.copy()
+        kw = kwargs.copy()
+        kw.update(self.__original_kwargs__)
+        copy = type(self)(self.callback, **kw)
+        return self._ensure_assignment_on_copy(copy)
 
     @property
     def dm_permission(self) -> bool:
@@ -295,8 +294,7 @@ class InvokableApplicationCommand(ABC):
         """
         if self.cog is not None:
             return await self.callback(self.cog, interaction, *args, **kwargs)
-        else:
-            return await self.callback(interaction, *args, **kwargs)
+        return await self.callback(interaction, *args, **kwargs)
 
     def _prepare_cooldowns(self, inter: ApplicationCommandInteraction) -> None:
         if self._buckets.valid:
@@ -435,8 +433,7 @@ class InvokableApplicationCommand(ABC):
         injected = wrap_callback(self.on_error)
         if self.cog is not None:
             return await injected(self.cog, inter, error)
-        else:
-            return await injected(inter, error)
+        return await injected(inter, error)
 
     async def _call_external_error_handlers(
         self, inter: ApplicationCommandInteraction, error: CommandError

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -523,7 +523,7 @@ class BotBase(CommonBotBase, GroupMixin):
 
         if prefix is None:
             return ctx
-        elif isinstance(prefix, str):
+        if isinstance(prefix, str):
             if not view.skip_string(prefix):
                 return ctx
         else:

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -154,18 +154,16 @@ class CommonBotBase(Generic[CogT]):
         """
         if self.owner_id:
             return user.id == self.owner_id
-        elif self.owner_ids:
+        if self.owner_ids:
             return user.id in self.owner_ids
-        else:
-            app = await self.application_info()  # type: ignore
-            if app.team:
-                self.owners = set(app.team.members)
-                self.owner_ids = ids = {m.id for m in app.team.members}
-                return user.id in ids
-            else:
-                self.owner = app.owner
-                self.owner_id = owner_id = app.owner.id
-                return user.id == owner_id
+        app = await self.application_info()  # type: ignore
+        if app.team:
+            self.owners = set(app.team.members)
+            self.owner_ids = ids = {m.id for m in app.team.members}
+            return user.id in ids
+        self.owner = app.owner
+        self.owner_id = owner_id = app.owner.id
+        return user.id == owner_id
 
     # listener registration
 

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -379,7 +379,7 @@ class CommonBotBase(Generic[CogT]):
         """
         cog = self.__cogs.pop(name, None)
         if cog is None:
-            return
+            return None
 
         help_command: Optional[HelpCommand] = getattr(self, "_help_command", None)
         if help_command and help_command.cog is cog:

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -357,16 +357,15 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
             if hasattr(entity, "__cog_commands__"):
                 injected = wrap_callback(cmd.send_cog_help)
                 return await injected(entity)
-            elif isinstance(entity, Group):
+            if isinstance(entity, Group):
                 injected = wrap_callback(cmd.send_group_help)
                 return await injected(entity)
-            elif isinstance(entity, Command):
+            if isinstance(entity, Command):
                 injected = wrap_callback(cmd.send_command_help)
                 return await injected(entity)
-            else:
-                return None
         except CommandError as e:
             await cmd.on_help_command_error(self, e)
+        return None
 
     @disnake.utils.copy_doc(Message.reply)
     async def reply(self, content: Optional[str] = None, **kwargs: Any) -> Message:

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -208,9 +208,9 @@ class MemberConverter(IDConverter[disnake.Member]):
             username, _, discriminator = argument.rpartition("#")
             members = await guild.query_members(username, limit=100, cache=cache)
             return _utils_get(members, name=username, discriminator=discriminator)
-        else:
-            members = await guild.query_members(argument, limit=100, cache=cache)
-            return disnake.utils.find(lambda m: m.name == argument or m.nick == argument, members)
+
+        members = await guild.query_members(argument, limit=100, cache=cache)
+        return disnake.utils.find(lambda m: m.name == argument or m.nick == argument, members)
 
     async def query_member_by_id(
         self, bot: disnake.Client, guild: disnake.Guild, user_id: int
@@ -945,8 +945,7 @@ class PermissionsConverter(Converter[disnake.Permissions]):
 
         if callable(attr):
             return attr()
-        else:
-            return disnake.Permissions(**{name: True})
+        return disnake.Permissions(**{name: True})
 
 
 class GuildScheduledEventConverter(IDConverter[disnake.GuildScheduledEvent]):
@@ -1124,10 +1123,9 @@ def _convert_to_bool(argument: str) -> bool:
     lowered = argument.lower()
     if lowered in ("yes", "y", "true", "t", "1", "enable", "on"):
         return True
-    elif lowered in ("no", "n", "false", "f", "0", "disable", "off"):
+    if lowered in ("no", "n", "false", "f", "0", "disable", "off"):
         return False
-    else:
-        raise BadBoolArgument(lowered)
+    raise BadBoolArgument(lowered)
 
 
 def get_converter(param: inspect.Parameter) -> Any:
@@ -1191,9 +1189,8 @@ async def _actual_conversion(
         if isinstance(converter, type) and issubclass(converter, Converter):
             if inspect.ismethod(converter.convert):
                 return await converter.convert(ctx, argument)
-            else:
-                return await converter().convert(ctx, argument)
-        elif isinstance(converter, Converter):
+            return await converter().convert(ctx, argument)
+        if isinstance(converter, Converter):
             return await converter.convert(ctx, argument)  # type: ignore
     except CommandError:
         raise

--- a/disnake/ext/commands/cooldowns.py
+++ b/disnake/ext/commands/cooldowns.py
@@ -38,15 +38,15 @@ class BucketType(Enum):
     def get_key(self, msg: Message) -> Any:
         if self is BucketType.user:
             return msg.author.id
-        elif self is BucketType.guild:
+        if self is BucketType.guild:
             return (msg.guild or msg.author).id
-        elif self is BucketType.channel:
+        if self is BucketType.channel:
             return msg.channel.id
-        elif self is BucketType.member:
+        if self is BucketType.member:
             return ((msg.guild and msg.guild.id), msg.author.id)
-        elif self is BucketType.category:
+        if self is BucketType.category:
             return (msg.channel.category or msg.channel).id  # type: ignore
-        elif self is BucketType.role:
+        if self is BucketType.role:
             # we return the channel id of a private-channel as there are only roles in guilds
             # and that yields the same result as for a guild with only the @everyone role
             # NOTE: PrivateChannel doesn't actually have an id attribute but we assume we are

--- a/disnake/ext/commands/cooldowns.py
+++ b/disnake/ext/commands/cooldowns.py
@@ -52,6 +52,7 @@ class BucketType(Enum):
             # NOTE: PrivateChannel doesn't actually have an id attribute but we assume we are
             # recieving a DMChannel or GroupChannel which inherit from PrivateChannel and do
             return (msg.channel if isinstance(msg.channel, PrivateChannel) else msg.author.top_role).id  # type: ignore
+        return None
 
     def __call__(self, msg: Message) -> Any:
         return self.get_key(msg)
@@ -151,6 +152,7 @@ class Cooldown:
 
         # we're not so decrement our tokens
         self._tokens -= 1
+        return None
 
     def reset(self) -> None:
         """Reset the cooldown to its initial state."""

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -468,8 +468,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         """
         if self.cog is not None:
             return await self.callback(self.cog, context, *args, **kwargs)  # type: ignore
-        else:
-            return await self.callback(context, *args, **kwargs)  # type: ignore
+        return await self.callback(context, *args, **kwargs)  # type: ignore
 
     def _ensure_assignment_on_copy(self, other: CommandT) -> CommandT:
         other._before_invoke = self._before_invoke
@@ -505,8 +504,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             kw.update(self.__original_kwargs__)
             copy = self.__class__(self.callback, **kw)
             return self._ensure_assignment_on_copy(copy)
-        else:
-            return self.copy()
+        return self.copy()
 
     async def dispatch_error(self, ctx: Context, error: Exception) -> None:
         stop_propagation = False
@@ -549,13 +547,12 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         if isinstance(converter, Greedy):
             if param.kind in (param.POSITIONAL_OR_KEYWORD, param.POSITIONAL_ONLY):
                 return await self._transform_greedy_pos(ctx, param, required, converter.converter)
-            elif param.kind == param.VAR_POSITIONAL:
+            if param.kind == param.VAR_POSITIONAL:
                 return await self._transform_greedy_var_pos(ctx, param, converter.converter)
-            else:
-                # if we're here, then it's a KEYWORD_ONLY param type
-                # since this is mostly useless, we'll helpfully transform Greedy[X]
-                # into just X and do the parsing that way.
-                converter = converter.converter
+            # if we're here, then it's a KEYWORD_ONLY param type
+            # since this is mostly useless, we'll helpfully transform Greedy[X]
+            # into just X and do the parsing that way.
+            converter = converter.converter
 
         if view.eof:
             if param.kind == param.VAR_POSITIONAL:
@@ -581,8 +578,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                 ):
                     view.index = previous
                     return None
-                else:
-                    raise
+                raise
         view.previous = previous
 
         # type-checker fails to narrow argument
@@ -705,8 +701,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         parent = self.full_parent_name
         if parent:
             return f"{parent} {self.name}"
-        else:
-            return self.name
+        return self.name
 
     def __str__(self) -> str:
         return self.qualified_name

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -1075,8 +1075,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                         else f"[{name}={param.default}]..."
                     )
                     continue
-                else:
-                    result.append(f"[{name}]")
+                result.append(f"[{name}]")
 
             elif param.kind == param.VAR_POSITIONAL:
                 if self.require_var_positional:

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -158,7 +158,7 @@ def wrap_callback(coro):
         except CommandError:
             raise
         except asyncio.CancelledError:
-            return
+            return None
         except Exception as exc:
             raise CommandInvokeError(exc) from exc
         return ret
@@ -176,7 +176,7 @@ def hooked_wrapped_callback(command, ctx, coro):
             raise
         except asyncio.CancelledError:
             ctx.command_failed = True
-            return
+            return None
         except Exception as exc:
             ctx.command_failed = True
             raise CommandInvokeError(exc) from exc

--- a/disnake/ext/commands/flag_converter.py
+++ b/disnake/ext/commands/flag_converter.py
@@ -405,17 +405,16 @@ async def convert_flag(ctx: Context, argument: str, flag: Flag, annotation: Any 
         if origin is tuple:
             if args[-1] is Ellipsis:
                 return await tuple_convert_all(ctx, argument, flag, args[0])
-            else:
-                return await tuple_convert_flag(ctx, argument, flag, args)
-        elif origin is list:
+            return await tuple_convert_flag(ctx, argument, flag, args)
+        if origin is list:
             # typing.List[x]
             annotation = args[0]
             return await convert_flag(ctx, argument, flag, annotation)
-        elif origin is Union and args[-1] is type(None):
+        if origin is Union and args[-1] is type(None):
             # typing.Optional[x]
             annotation = Union[args[:-1]]  # type: ignore
             return await run_converters(ctx, annotation, argument, param)
-        elif origin is dict:
+        if origin is dict:
             # typing.Dict[K, V] -> typing.Tuple[K, V]
             return await tuple_convert_flag(ctx, argument, flag, args)
 

--- a/disnake/ext/commands/flag_converter.py
+++ b/disnake/ext/commands/flag_converter.py
@@ -224,8 +224,7 @@ def get_flags(
         name = flag.name.casefold() if case_insensitive else flag.name
         if name in names:
             raise TypeError(f"{flag.name!r} flag conflicts with previous flag or alias.")
-        else:
-            names.add(name)
+        names.add(name)
 
         for alias in flag.aliases:
             # Validate alias is unique
@@ -234,8 +233,7 @@ def get_flags(
                 raise TypeError(
                     f"{flag.name!r} flag alias {alias!r} conflicts with previous flag or alias."
                 )
-            else:
-                names.add(alias)
+            names.add(alias)
 
         flags[flag.name] = flag
 
@@ -579,13 +577,12 @@ class FlagConverter(metaclass=FlagsMeta):
             except KeyError:
                 if flag.required:
                     raise MissingRequiredFlag(flag) from None
+                if callable(flag.default):
+                    default = await maybe_coroutine(flag.default, ctx)
+                    setattr(self, flag.attribute, default)
                 else:
-                    if callable(flag.default):
-                        default = await maybe_coroutine(flag.default, ctx)
-                        setattr(self, flag.attribute, default)
-                    else:
-                        setattr(self, flag.attribute, flag.default)
-                    continue
+                    setattr(self, flag.attribute, flag.default)
+                continue
 
             if flag.max_args > 0 and len(values) > flag.max_args:
                 if flag.override:

--- a/disnake/ext/commands/help.py
+++ b/disnake/ext/commands/help.py
@@ -854,8 +854,7 @@ class HelpCommand:
 
         if isinstance(cmd, Group):
             return await self.send_group_help(cmd)
-        else:
-            return await self.send_command_help(cmd)
+        return await self.send_command_help(cmd)
 
 
 class DefaultHelpCommand(HelpCommand):
@@ -993,10 +992,9 @@ class DefaultHelpCommand(HelpCommand):
         ctx = self.context
         if self.dm_help is True:
             return ctx.author
-        elif self.dm_help is None and len(self.paginator) > self.dm_help_threshold:
+        if self.dm_help is None and len(self.paginator) > self.dm_help_threshold:
             return ctx.author
-        else:
-            return ctx.channel
+        return ctx.channel
 
     async def prepare_help_command(self, ctx, command) -> None:
         self.paginator.clear()
@@ -1237,10 +1235,9 @@ class MinimalHelpCommand(HelpCommand):
         ctx = self.context
         if self.dm_help is True:
             return ctx.author
-        elif self.dm_help is None and len(self.paginator) > self.dm_help_threshold:
+        if self.dm_help is None and len(self.paginator) > self.dm_help_threshold:
             return ctx.author
-        else:
-            return ctx.channel
+        return ctx.channel
 
     async def prepare_help_command(self, ctx, command) -> None:
         self.paginator.clear()

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -448,6 +448,7 @@ class InteractionBotBase(CommonBotBase):
             group = slash.children.get(chain[1])
             if isinstance(group, SubCommandGroup):
                 return group.children.get(chain[2])
+        return None
 
     def get_user_command(self, name: str) -> Optional[InvokableUserCommand]:
         """Gets an :class:`InvokableUserCommand` from the internal list

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -442,9 +442,9 @@ class InteractionBotBase(CommonBotBase):
 
         if len(chain) == 1:
             return slash
-        elif len(chain) == 2:
+        if len(chain) == 2:
             return slash.children.get(chain[1])
-        elif len(chain) == 3:
+        if len(chain) == 3:
             group = slash.children.get(chain[1])
             if isinstance(group, SubCommandGroup):
                 return group.children.get(chain[2])

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -109,14 +109,13 @@ __all__ = (
 def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[TypeT]:
     if not isinstance(tp, (type, tuple)):
         return False
-    elif not isinstance(obj, type):
+    if not isinstance(obj, type):
         # Assume we have a type hint
         if get_origin(obj) in (Union, UnionType, Optional):
             obj = get_args(obj)
             return any(isinstance(o, type) and issubclass(o, tp) for o in obj)
-        else:
-            # Other type hint specializations are not supported
-            return False
+        # Other type hint specializations are not supported
+        return False
     return issubclass(obj, tp)
 
 
@@ -173,11 +172,10 @@ def _xt_to_xe(xe: Optional[float], xt: Optional[float], direction: float = 1) ->
         if xt is not None:
             raise TypeError("Cannot combine lt and le or gt and le")
         return xe
-    elif xt is not None:
+    if xt is not None:
         epsilon = math.ldexp(1.0, -1024)
         return xt + (epsilon * direction)
-    else:
-        return None
+    return None
 
 
 class Injection(Generic[P, T_]):
@@ -231,8 +229,7 @@ class Injection(Generic[P, T_]):
         """
         if self._injected is not None:
             return self.function(self._injected, *args, **kwargs)  # type: ignore
-        else:
-            return self.function(*args, **kwargs)  # type: ignore
+        return self.function(*args, **kwargs)  # type: ignore
 
     @classmethod
     def register(

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -995,7 +995,7 @@ def format_kwargs(
         raise TypeError(
             "When calling a slash command only self and the interaction should be positional"
         )
-    elif first and not isinstance(first, commands.Cog):
+    if first and not isinstance(first, commands.Cog):
         raise TypeError("Method slash commands may be created only in cog subclasses")
 
     cog: Optional[commands.Cog] = first

--- a/disnake/ext/commands/view.py
+++ b/disnake/ext/commands/view.py
@@ -165,6 +165,7 @@ class StringView:
                 return "".join(result)
 
             result.append(current)
+        return None
 
     def __repr__(self) -> str:
         return (

--- a/disnake/ext/mypy_plugin/__init__.py
+++ b/disnake/ext/mypy_plugin/__init__.py
@@ -36,7 +36,7 @@ def range_type_analyze_callback(ctx: AnalyzeTypeContext) -> Type:
         if name == "float":
             return ctx.api.named_type("builtins.float", [])
         # otherwise it should be an int; fail if it isn't
-        elif name != "int":
+        if name != "int":
             ctx.api.fail(f'"Range" parameters must be int or float, not {name}', ctx.context)
             return AnyType(TypeOfAny.from_error)
 

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -231,6 +231,7 @@ class Loop(Generic[LF]):
         """
         if self._seconds is not MISSING:
             return self._seconds
+        return None
 
     @property
     def minutes(self) -> Optional[float]:
@@ -241,6 +242,7 @@ class Loop(Generic[LF]):
         """
         if self._minutes is not MISSING:
             return self._minutes
+        return None
 
     @property
     def hours(self) -> Optional[float]:
@@ -251,6 +253,7 @@ class Loop(Generic[LF]):
         """
         if self._hours is not MISSING:
             return self._hours
+        return None
 
     @property
     def time(self) -> Optional[List[datetime.time]]:
@@ -261,6 +264,7 @@ class Loop(Generic[LF]):
         """
         if self._time is not MISSING:
             return self._time.copy()
+        return None
 
     @property
     def current_loop(self) -> int:

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -279,7 +279,7 @@ class Loop(Generic[LF]):
         """
         if self._task is MISSING:
             return None
-        elif self._task and self._task.done() or self._stop_next_iteration:
+        if self._task and self._task.done() or self._stop_next_iteration:
             return None
         return self._next_iteration
 
@@ -581,11 +581,10 @@ class Loop(Generic[LF]):
             self._time_index += 1
             if next_time > utcnow().timetz():
                 return datetime.datetime.combine(utcnow(), next_time)
-            else:
-                return datetime.datetime.combine(
-                    utcnow() + datetime.timedelta(days=1),
-                    next_time,
-                )
+            return datetime.datetime.combine(
+                utcnow() + datetime.timedelta(days=1),
+                next_time,
+            )
 
         next_date = self._last_iteration
         if next_time < next_date.timetz():

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -728,9 +728,8 @@ class DiscordWebSocket:
             if self._can_handle_close():
                 _log.info("Websocket closed with %s, attempting a reconnect.", code)
                 raise ReconnectWebSocket(self.shard_id) from None
-            else:
-                _log.info("Websocket closed with %s, cannot reconnect.", code)
-                raise ConnectionClosed(self.socket, shard_id=self.shard_id, code=code) from None
+            _log.info("Websocket closed with %s, cannot reconnect.", code)
+            raise ConnectionClosed(self.socket, shard_id=self.shard_id, code=code) from None
 
     async def debug_send(self, data: str, /) -> None:
         await self._rate_limiter.block()

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4111,6 +4111,7 @@ class Guild(Hashable):
 
         if not self._state.is_guild_evicted(self):
             return await self._state.chunk_guild(self, cache=cache)
+        return None
 
     async def query_members(
         self,

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -761,7 +761,7 @@ class Guild(Hashable):
 
     def _resolve_channel(self, id: Optional[int], /) -> Optional[Union[GuildChannel, Thread]]:
         if id is None:
-            return
+            return None
 
         return self._channels.get(id) or self._threads.get(id)
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -406,12 +406,11 @@ class HTTPClient:
                         # the usual error cases
                         if response.status == 403:
                             raise Forbidden(response, data)
-                        elif response.status == 404:
+                        if response.status == 404:
                             raise NotFound(response, data)
-                        elif response.status >= 500:
+                        if response.status >= 500:
                             raise DiscordServerError(response, data)
-                        else:
-                            raise HTTPException(response, data)
+                        raise HTTPException(response, data)
 
                 # This is handling exceptions from the request
                 except OSError as e:

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -434,12 +434,11 @@ class HTTPClient:
         async with self.__session.get(url) as resp:
             if resp.status == 200:
                 return await resp.read()
-            elif resp.status == 404:
+            if resp.status == 404:
                 raise NotFound(resp, "asset not found")
-            elif resp.status == 403:
+            if resp.status == 403:
                 raise Forbidden(resp, "cannot retrieve asset")
-            else:
-                raise HTTPException(resp, "failed to get asset")
+            raise HTTPException(resp, "failed to get asset")
 
     # state management
 

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -411,7 +411,6 @@ class BotIntegration(Integration):
 def _integration_factory(value: str) -> Tuple[Type[Integration], str]:
     if value == "discord":
         return BotIntegration, value
-    elif value in ("twitch", "youtube"):
+    if value in ("twitch", "youtube"):
         return StreamIntegration, value
-    else:
-        return Integration, value
+    return Integration, value

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1712,6 +1712,7 @@ class InteractionMessage(Message):
             asyncio.create_task(inner_call())
         else:
             await self._state._interaction.delete_original_response()
+        return None
 
 
 class InteractionDataResolved(Dict[str, Any]):

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -290,7 +290,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
                 raise ValueError("history does not support around with limit=None")
             if self.limit > 101:
                 raise ValueError("history max limit 101 when specifying around parameter")
-            elif self.limit == 101:
+            if self.limit == 101:
                 self.limit = 100  # Thanks Discord
 
             self._retrieve_messages = self._retrieve_messages_around_strategy

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -964,8 +964,7 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
             return guild.get_member(int(user_data["id"])) or Member(
                 data=member_data, user_data=user_data, guild=guild, state=self.state
             )
-        else:
-            return self.state.store_user(data["user"])
+        return self.state.store_user(data["user"])
 
     async def fill_users(self) -> None:
         if not self._get_retrieve():

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -462,6 +462,7 @@ class Member(disnake.abc.Messageable, _UserTag):
             u.name, u._avatar, u.discriminator, u._public_flags = modified
             # Signal to dispatch on_user_update
             return to_return, u
+        return None
 
     @property
     def status(self) -> Status:
@@ -612,6 +613,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         """
         if self.activities:
             return self.activities[0]
+        return None
 
     def mentioned_in(self, message: Message) -> bool:
         """Whether the member is mentioned in the specified message.
@@ -930,6 +932,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         if payload:
             data = await http.edit_member(guild_id, self.id, reason=reason, **payload)
             return Member(data=data, guild=self.guild, state=self._state)
+        return None
 
     async def request_to_speak(self) -> None:
         """|coro|

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -1157,5 +1157,4 @@ class Member(disnake.abc.Messageable, _UserTag):
         """
         if duration is not MISSING:
             return await self.guild.timeout(self, duration=duration, reason=reason)
-        else:
-            return await self.guild.timeout(self, until=until, reason=reason)
+        return await self.guild.timeout(self, until=until, reason=reason)

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1064,7 +1064,7 @@ class Message(Hashable):
                 break
         else:
             # didn't find anything so just return
-            return
+            return None
 
         del self.reactions[index]
         return reaction
@@ -1451,7 +1451,7 @@ class Message(Hashable):
 
         if self.type is MessageType.role_subscription_purchase:
             if not (data := self.role_subscription_data):
-                return
+                return None
 
             guild_name = f"**{self.guild.name}**" if self.guild else None
             if data.total_months_subscribed > 0:

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -361,9 +361,8 @@ class Attachment(Hashable):
             if seek_begin:
                 fp.seek(0)
             return written
-        else:
-            with open(fp, "wb") as f:
-                return f.write(data)
+        with open(fp, "wb") as f:
+            return f.write(data)
 
     async def read(self, *, use_cached: bool = False) -> bytes:
         """|coro|
@@ -1335,14 +1334,12 @@ class Message(Hashable):
         if self.type is MessageType.recipient_add:
             if self.channel.type is ChannelType.group:
                 return f"{self.author.name} added {self.mentions[0].name} to the group."
-            else:
-                return f"{self.author.name} added {self.mentions[0].name} to the thread."
+            return f"{self.author.name} added {self.mentions[0].name} to the thread."
 
         if self.type is MessageType.recipient_remove:
             if self.channel.type is ChannelType.group:
                 return f"{self.author.name} removed {self.mentions[0].name} from the group."
-            else:
-                return f"{self.author.name} removed {self.mentions[0].name} from the thread."
+            return f"{self.author.name} removed {self.mentions[0].name} from the thread."
 
         # MessageType.call cannot be read by bots.
 
@@ -1384,26 +1381,22 @@ class Message(Hashable):
         if self.type is MessageType.premium_guild_subscription:
             if not self.content:
                 return f"{self.author.name} just boosted the server!"
-            else:
-                return f"{self.author.name} just boosted the server **{self.content}** times!"
+            return f"{self.author.name} just boosted the server **{self.content}** times!"
 
         if self.type is MessageType.premium_guild_tier_1:
             if not self.content:
                 return f"{self.author.name} just boosted the server! {self.guild} has achieved **Level 1!**"
-            else:
-                return f"{self.author.name} just boosted the server **{self.content}** times! {self.guild} has achieved **Level 1!**"
+            return f"{self.author.name} just boosted the server **{self.content}** times! {self.guild} has achieved **Level 1!**"
 
         if self.type is MessageType.premium_guild_tier_2:
             if not self.content:
                 return f"{self.author.name} just boosted the server! {self.guild} has achieved **Level 2!**"
-            else:
-                return f"{self.author.name} just boosted the server **{self.content}** times! {self.guild} has achieved **Level 2!**"
+            return f"{self.author.name} just boosted the server **{self.content}** times! {self.guild} has achieved **Level 2!**"
 
         if self.type is MessageType.premium_guild_tier_3:
             if not self.content:
                 return f"{self.author.name} just boosted the server! {self.guild} has achieved **Level 3!**"
-            else:
-                return f"{self.author.name} just boosted the server **{self.content}** times! {self.guild} has achieved **Level 3!**"
+            return f"{self.author.name} just boosted the server **{self.content}** times! {self.guild} has achieved **Level 3!**"
 
         if self.type is MessageType.channel_follow_add:
             return f"{self.author.name} has added {self.content} to this channel. Its most important updates will show up here."
@@ -1461,10 +1454,11 @@ class Message(Hashable):
                     f"of {guild_name} for {data.total_months_subscribed} "
                     f"{'month' if data.total_months_subscribed == 1 else 'months'}!"
                 )
-            elif data.is_renewal:
+            if data.is_renewal:
                 return f"{self.author.name} renewed **{data.tier_name}** in their {guild_name} membership!"
-            else:
-                return f"{self.author.name} joined **{data.tier_name}** as a subscriber of {guild_name}!"
+            return (
+                f"{self.author.name} joined **{data.tier_name}** as a subscriber of {guild_name}!"
+            )
 
         if self.type is MessageType.interaction_premium_upsell:
             return self.content

--- a/disnake/oggparse.py
+++ b/disnake/oggparse.py
@@ -80,10 +80,9 @@ class OggStream:
         head = self.stream.read(4)
         if head == b"OggS":
             return OggPage(self.stream)
-        elif not head:
+        if not head:
             return None
-        else:
-            raise OggError("invalid header magic")
+        raise OggError("invalid header magic")
 
     def _iter_pages(self) -> Generator[OggPage, None, None]:
         page = self._next_page()

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -265,5 +265,4 @@ class PartialEmoji(_EmojiTag, AssetMixin):
         # note: API only supports exactly one of `name` and `id` being set
         if emoji.id:
             return None, emoji.id
-        else:
-            return emoji.name, None
+        return emoji.name, None

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -238,19 +238,13 @@ class Permissions(BaseFlags):
         """Returns ``True`` if self has the same or fewer permissions as other."""
         if isinstance(other, Permissions):
             return (self.value & other.value) == self.value
-        else:
-            raise TypeError(
-                f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}"
-            )
+        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
 
     def is_superset(self, other: Permissions) -> bool:
         """Returns ``True`` if self has the same or more permissions as other."""
         if isinstance(other, Permissions):
             return (self.value | other.value) == self.value
-        else:
-            raise TypeError(
-                f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}"
-            )
+        raise TypeError(f"cannot compare {self.__class__.__name__} with {other.__class__.__name__}")
 
     def is_strict_subset(self, other: Permissions) -> bool:
         """Returns ``True`` if the permissions on self are a strict subset of those on other."""

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -542,7 +542,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         except Exception:
             if not fallback:
                 _log.exception("Probe '%s' using '%s' failed", method, executable)
-                return  # type: ignore
+                return None  # type: ignore
 
             _log.exception("Probe '%s' using '%s' failed, trying fallback", method, executable)
             try:

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -367,7 +367,7 @@ class AutoShardedClient(Client):
                 raise ClientException(
                     "When passing manual shard_ids, you must provide a shard_count."
                 )
-            elif not isinstance(self.shard_ids, (list, tuple)):
+            if not isinstance(self.shard_ids, (list, tuple)):
                 raise ClientException("shard_ids parameter must be a list or a tuple.")
 
         # instead of a single websocket, we have multiple

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -493,7 +493,10 @@ class AutoShardedClient(Client):
                     if item.error.code != 1000:
                         raise item.error
                 return
-            elif item.type in (EventType.identify, EventType.resume):
+            elif item.type in (  # noqa: RET505 # needs to be refactored
+                EventType.identify,
+                EventType.resume,
+            ):
                 await item.shard.reidentify(item.error)
             elif item.type == EventType.reconnect:
                 await item.shard.reconnect()

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -449,6 +449,7 @@ class AutoShardedClient(Client):
         # keep reading the shard while others connect
         self.__shards[shard_id] = ret = Shard(ws, self, self.__queue.put_nowait)
         ret.launch()
+        return None
 
     async def launch_shards(self, *, ignore_session_start_limit: bool = False) -> None:
         shard_count, gateway, session_start_limit = await self.http.get_bot_gateway(

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -466,6 +466,7 @@ class ConnectionState:
         granula = self._guild_application_commands.get(guild_id)
         if granula is not None:
             return granula.get(application_command_id)
+        return None
 
     def _add_guild_application_command(
         self, guild_id: int, application_command: APIApplicationCommand
@@ -496,6 +497,7 @@ class ConnectionState:
         for cmd in self._global_application_commands.values():
             if cmd.name == name and (cmd_type is None or cmd.type is cmd_type):
                 return cmd
+        return None
 
     def _get_guild_command_named(
         self, guild_id: int, name: str, cmd_type: Optional[ApplicationCommandType] = None
@@ -504,6 +506,7 @@ class ConnectionState:
         for cmd in granula.values():
             if cmd.name == name and (cmd_type is None or cmd.type is cmd_type):
                 return cmd
+        return None
 
     @property
     def emojis(self) -> List[Emoji]:
@@ -1993,6 +1996,7 @@ class ConnectionState:
             channel = guild._resolve_channel(id)
             if channel is not None:
                 return channel
+        return None
 
     def create_message(
         self,

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -944,7 +944,7 @@ class ConnectionState:
             # PING interaction should never be received
             return
 
-        elif data["type"] == 2:
+        if data["type"] == 2:
             interaction = ApplicationCommandInteraction(data=data, state=self)
             self.dispatch("application_command", interaction)
 

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -511,7 +511,6 @@ def _sticker_factory(
     value = try_enum(StickerType, sticker_type)
     if value == StickerType.standard:
         return StandardSticker, value
-    elif value == StickerType.guild:
+    if value == StickerType.guild:
         return GuildSticker, value
-    else:
-        return Sticker, value
+    return Sticker, value

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -192,7 +192,7 @@ class View:
         while True:
             # Guard just in case someone changes the value of the timeout at runtime
             if self.timeout is None:
-                return
+                return None
 
             if self.__timeout_expiry is None:
                 return self._dispatch_timeout()
@@ -380,7 +380,7 @@ class View:
 
             allow = await self.interaction_check(interaction)
             if not allow:
-                return
+                return None
 
             await item.callback(interaction)
         except Exception as e:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -490,14 +490,13 @@ _mime_type_extensions = {
 def _get_mime_type_for_image(data: bytes) -> str:
     if data[0:8] == b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A":
         return "image/png"
-    elif data[0:3] == b"\xff\xd8\xff" or data[6:10] in (b"JFIF", b"Exif"):
+    if data[0:3] == b"\xff\xd8\xff" or data[6:10] in (b"JFIF", b"Exif"):
         return "image/jpeg"
-    elif data[0:6] in (b"\x47\x49\x46\x38\x37\x61", b"\x47\x49\x46\x38\x39\x61"):
+    if data[0:6] in (b"\x47\x49\x46\x38\x37\x61", b"\x47\x49\x46\x38\x39\x61"):
         return "image/gif"
-    elif data[0:4] == b"RIFF" and data[8:12] == b"WEBP":
+    if data[0:4] == b"RIFF" and data[8:12] == b"WEBP":
         return "image/webp"
-    else:
-        raise ValueError("Unsupported image type given")
+    raise ValueError("Unsupported image type given")
 
 
 def _bytes_to_base64_data(data: bytes) -> str:
@@ -555,8 +554,7 @@ def _parse_ratelimit_header(request: Any, *, use_clock: bool = False) -> float:
         now = datetime.datetime.now(utc)
         reset = datetime.datetime.fromtimestamp(float(request.headers["X-Ratelimit-Reset"]), utc)
         return (reset - now).total_seconds()
-    else:
-        return float(reset_after)
+    return float(reset_after)
 
 
 async def maybe_coroutine(
@@ -565,8 +563,7 @@ async def maybe_coroutine(
     value = f(*args, **kwargs)
     if _isawaitable(value):
         return await value
-    else:
-        return value  # type: ignore  # typeguard doesn't narrow in the negative case
+    return value  # type: ignore  # typeguard doesn't narrow in the negative case
 
 
 async def async_all(gen: Iterable[Union[Awaitable[bool], bool]], *, check=_isawaitable) -> bool:
@@ -764,11 +761,10 @@ def resolve_template(code: Union[Template, str]) -> str:
 
     if isinstance(code, Template):
         return code.code
-    else:
-        rx = r"(?:https?\:\/\/)?discord(?:\.new|(?:app)?\.com\/template)\/(.+)"
-        m = re.match(rx, code)
-        if m:
-            return m.group(1)
+    rx = r"(?:https?\:\/\/)?discord(?:\.new|(?:app)?\.com\/template)\/(.+)"
+    m = re.match(rx, code)
+    if m:
+        return m.group(1)
     return code
 
 
@@ -858,9 +854,9 @@ def escape_markdown(text: str, *, as_needed: bool = False, ignore_links: bool = 
         if ignore_links:
             regex = f"(?:{_URL_REGEX}|{regex})"
         return re.sub(regex, replacement, text, 0, re.MULTILINE)
-    else:
-        text = re.sub(r"\\", r"\\\\", text)
-        return _MARKDOWN_ESCAPE_REGEX.sub(r"\\\1", text)
+
+    text = re.sub(r"\\", r"\\\\", text)
+    return _MARKDOWN_ESCAPE_REGEX.sub(r"\\\1", text)
 
 
 def escape_mentions(text: str) -> str:
@@ -1319,10 +1315,9 @@ def as_valid_locale(locale: str) -> Optional[str]:
 def humanize_list(values: List[str], combine: str) -> str:
     if len(values) > 2:
         return f"{', '.join(values[:-1])}, {combine} {values[-1]}"
-    elif len(values) == 0:
+    if len(values) == 0:
         return "<none>"
-    else:
-        return f" {combine} ".join(values)
+    return f" {combine} ".join(values)
 
 
 # Similar to typing.assert_never, but returns instead of raising (i.e. has no runtime effect).

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -444,8 +444,7 @@ class VoiceClient(VoiceProtocol):
                             )
                             await self.disconnect()
                             break
-                        else:
-                            continue
+                        continue
 
                 if not reconnect:
                     await self.disconnect()

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -372,8 +372,7 @@ class VoiceClient(VoiceProtocol):
                     await asyncio.sleep(1 + i * 2.0)
                     await self.voice_disconnect()
                     continue
-                else:
-                    raise
+                raise
 
         if self._runner is MISSING:
             self._runner = self.loop.create_task(self.poll_voice_ws(reconnect))

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -204,10 +204,9 @@ class AsyncWebhookAdapter:
 
                         if response.status == 403:
                             raise Forbidden(response, data)
-                        elif response.status == 404:
+                        if response.status == 404:
                             raise NotFound(response, data)
-                        else:
-                            raise HTTPException(response, data)
+                        raise HTTPException(response, data)
 
                 except OSError as e:
                     if attempt < 4 and e.errno == ECONNRESET:
@@ -1667,7 +1666,7 @@ class Webhook(BaseWebhook):
         thread_id: Optional[int] = None
         if thread is not MISSING and thread_name is not None:
             raise TypeError("only one of thread and thread_name can be provided.")
-        elif thread is not MISSING:
+        if thread is not MISSING:
             thread_id = thread.id
 
         params = handle_message_parameters(

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -182,10 +182,9 @@ class WebhookAdapter:
 
                         if response.status_code == 403:
                             raise Forbidden(response, data)
-                        elif response.status_code == 404:
+                        if response.status_code == 404:
                             raise NotFound(response, data)
-                        else:
-                            raise HTTPException(response, data)
+                        raise HTTPException(response, data)
 
                 except OSError as e:
                     if attempt < 4 and e.errno == ECONNRESET:
@@ -1023,7 +1022,7 @@ class SyncWebhook(BaseWebhook):
         thread_id: Optional[int] = None
         if thread is not MISSING and thread_name is not None:
             raise TypeError("only one of thread and thread_name can be provided.")
-        elif thread is not MISSING:
+        if thread is not MISSING:
             thread_id = thread.id
 
         params = handle_message_parameters(

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -1061,6 +1061,7 @@ class SyncWebhook(BaseWebhook):
                     f.close()
         if wait:
             return self._create_message(data)
+        return None
 
     def fetch_message(self, id: int, /) -> SyncWebhookMessage:
         """Retrieves a single :class:`SyncWebhookMessage` owned by this webhook.

--- a/examples/basic_voice.py
+++ b/examples/basic_voice.py
@@ -70,7 +70,8 @@ class Music(commands.Cog):
     async def join(self, ctx, *, channel: disnake.VoiceChannel):
         """Joins a voice channel"""
         if ctx.voice_client is not None:
-            return await ctx.voice_client.move_to(channel)
+            await ctx.voice_client.move_to(channel)
+            return
 
         await channel.connect()
 
@@ -111,6 +112,7 @@ class Music(commands.Cog):
 
         ctx.voice_client.source.volume = volume / 100
         await ctx.send(f"Changed volume to {volume}%")
+        return None
 
     @commands.command()
     async def stop(self, ctx):

--- a/examples/converters.py
+++ b/examples/converters.py
@@ -40,6 +40,7 @@ async def userinfo_error(ctx: commands.Context, error: commands.CommandError):
     # so we handle this in this error handler:
     if isinstance(error, commands.UserNotFound):
         return await ctx.send("Couldn't find that user.")
+    return None
 
 
 @bot.command()
@@ -68,7 +69,8 @@ async def multiply(ctx: commands.Context, number: int, maybe: bool):
     # See: https://docs.disnake.dev/en/stable/ext/commands/commands.html#bool
 
     if maybe is True:
-        return await ctx.send(str(number * 2))
+        await ctx.send(str(number * 2))
+        return
 
     await ctx.send(str(number * 5))
 

--- a/examples/guessing_game.py
+++ b/examples/guessing_game.py
@@ -27,7 +27,8 @@ async def guess(ctx: commands.Context):
     try:
         guess = await ctx.bot.wait_for("message", check=is_guess_message, timeout=10)
     except asyncio.TimeoutError:
-        return await ctx.send(f"Sorry, you took too long. The answer was {answer}.")
+        await ctx.send(f"Sorry, you took too long. The answer was {answer}.")
+        return
 
     if int(guess.content) == answer:
         await ctx.send("You guessed correctly!")

--- a/examples/views/tic_tac_toe.py
+++ b/examples/views/tic_tac_toe.py
@@ -101,7 +101,7 @@ class TicTacToe(disnake.ui.View):
         def check_winner(value: int) -> Optional[Player]:
             if value == Player.O * 3:
                 return Player.O
-            elif value == Player.X * 3:
+            if value == Player.X * 3:
                 return Player.X
             return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,9 @@ ignore = [
     # we do explicitly return None even when its the only possible value as we are not fully typehinted
     "RET501",
 
+    # ruff bug, too many false positives
+    "RET504", # unnecessary variaible assignment before return statement
+
     # provide specific codes on type: ignore
     "PGH003",
 
@@ -192,7 +195,7 @@ ignore = [
 
     # outer loop variables are overwritten by inner assignment target, these are mostly intentional
     "PLW2901",
-    
+
     # temporary disables, to fix later
     "D205",   # blank line required between summary and description
     "D401",   # first line of docstring should be in imperative mood

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ select = [
     "DTZ", # flake8-datetimez
     # "EM", # flake8-errmsg
     "G", # flake8-logging-format
-    # "RET", # flake8-return
+    "RET", # flake8-return
     # "SIM", # flake8-simplify
     "TID251", # flake8-tidy-imports, replaces S404
     # "TCH", # flake8-type-checking
@@ -180,6 +180,9 @@ ignore = [
     # ignore try-except-pass. Bare excepts are caught with E722
     "S110",
 
+    # we do explicitly return None even when its the only possible value as we are not fully typehinted
+    "RET501",
+
     # provide specific codes on type: ignore
     "PGH003",
 
@@ -189,7 +192,7 @@ ignore = [
 
     # outer loop variables are overwritten by inner assignment target, these are mostly intentional
     "PLW2901",
-
+    
     # temporary disables, to fix later
     "D205",   # blank line required between summary and description
     "D401",   # first line of docstring should be in imperative mood

--- a/scripts/codemods/typed_permissions.py
+++ b/scripts/codemods/typed_permissions.py
@@ -140,7 +140,7 @@ class PermissionTypings(codemod.VisitorBasedCodemodCommand):
                 'a function cannot be decorated with "_overload_with_permissions" and not take any kwargs unless it is an overload.'
             )
         # always true if this isn't an overload
-        elif node.params.star_kwarg:
+        if node.params.star_kwarg:
             # use the existing annotation if one exists
             annotation = node.params.star_kwarg.annotation
             if annotation is None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -60,7 +60,7 @@ class freeze_time(ContextManager):
 
             return wrap_async  # type: ignore
 
-        else:
+        else:  # noqa: RET505
 
             @functools.wraps(func)
             def wrap_sync(*args, **kwargs):


### PR DESCRIPTION
## Summary

Enable all `RET` errors on ruff. 

As some of these error codes might not be desired, I seperated each of them into an individual commit (except for RET506, I fixed some of that in RET505 inadvertently).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm run pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
