### PR TITLE
refactor(lint): add pylint rules

### DIFF
--- a/disnake/opus.py
+++ b/disnake/opus.py
@@ -296,7 +296,6 @@ def is_loaded() -> bool:
     :class:`bool`
         Indicates if the opus library has been loaded.
     """
-    global _lib
     return _lib is not MISSING
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,9 @@ ignore = [
     # import aliases are fixed by isort
     "PLC0414",
 
+    # outer loop variables are overwritten by inner assignment target, these are mostly intentional
+    "PLW2901",
+
     # temporary disables, to fix later
     "B904",   # within an except clause raise from error or from none
     "B026",   # backwards star-arg unpacking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,10 @@ select = [
     "Q",      # flake8-quotes
     "T20",    # flake8-print
     "PGH",    # pygrep-hooks
+    "PLC",    # pylint convention
+    "PLE",    # pylint error
+    # "PLR",    # pylint refactor
+    "PLW",    # pylint warnings
     "TRY002", "TRY004", # tryceratops
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,9 @@ ignore = [
     # provide specific codes on type: ignore
     "PGH003",
 
+    # import aliases are fixed by isort
+    "PLC0414",
+
     # temporary disables, to fix later
     "B904",   # within an except clause raise from error or from none
     "B026",   # backwards star-arg unpacking


### PR DESCRIPTION
## Summary

add some more ruff rules, these pertaining to the pylint plugin. 

Disabled some rules for now that require too much refactoring to add.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
