### PR TITLE
refactor(lint): add flake8-raises

### DIFF
--- a/changelog/950.feature.rst
+++ b/changelog/950.feature.rst
@@ -1,0 +1,2 @@
+Cleanup general error raising to be less confusing.
+- Overall, most errors about incorrect types no longer include the internal error in their traceback.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -967,8 +967,8 @@ class GuildChannel(ABC):
                 raise TypeError("No overwrite provided.")
             try:
                 overwrite = PermissionOverwrite(**permissions)
-            except (ValueError, TypeError):
-                raise TypeError("Invalid permissions given to keyword arguments.")
+            except (ValueError, TypeError) as e:
+                raise TypeError("Invalid permissions given to keyword arguments.") from e
         else:
             if len(permissions) > 0:
                 raise TypeError("Cannot mix overwrite and keyword arguments.")

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -731,7 +731,7 @@ class Embed:
         try:
             self._fields[index]
         except IndexError:
-            raise IndexError("field index out of range")
+            raise IndexError("field index out of range") from None
 
         field: EmbedFieldPayload = {
             "inline": inline,

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -161,7 +161,7 @@ class EnumMeta(type):
         try:
             return cls._enum_value_map_[value]
         except (KeyError, TypeError):
-            raise ValueError(f"{value!r} is not a valid {cls.__name__}")
+            raise ValueError(f"{value!r} is not a valid {cls.__name__}") from None
 
     def __getitem__(cls, key):
         return cls._enum_member_map_[key]

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -479,7 +479,7 @@ class BotBase(CommonBotBase, GroupMixin):
                 raise TypeError(
                     "command_prefix must be plain string, iterable of strings, or callable "
                     f"returning either of these, not {ret.__class__.__name__}"
-                )
+                ) from None
 
             if not ret:
                 raise ValueError("Iterable command_prefix must contain at least one prefix")
@@ -543,7 +543,7 @@ class BotBase(CommonBotBase, GroupMixin):
                     raise TypeError(
                         "get_prefix must return either a string or a list of string, "
                         f"not {prefix.__class__.__name__}"
-                    )
+                    ) from None
 
                 # It's possible a bad command_prefix got us here.
                 for value in prefix:
@@ -551,7 +551,7 @@ class BotBase(CommonBotBase, GroupMixin):
                         raise TypeError(
                             "Iterable command_prefix or list returned from get_prefix must "
                             f"contain only strings, not {value.__class__.__name__}"
-                        )
+                        ) from None
 
                 # Getting here shouldn't happen
                 raise

--- a/disnake/ext/commands/cog.py
+++ b/disnake/ext/commands/cog.py
@@ -734,12 +734,12 @@ class Cog(metaclass=CogMeta):
             if command.parent is None:
                 try:
                     bot.add_command(command)  # type: ignore
-                except Exception as e:
+                except Exception:
                     # undo our additions
                     for to_undo in self.__cog_commands__[:index]:
                         if to_undo.parent is None:
                             bot.remove_command(to_undo.name)  # type: ignore
-                    raise e
+                    raise
 
         for index, command in enumerate(self.__cog_app_commands__):
             command.cog = self
@@ -750,7 +750,7 @@ class Cog(metaclass=CogMeta):
                     bot.add_user_command(command)
                 elif isinstance(command, InvokableMessageCommand):
                     bot.add_message_command(command)
-            except Exception as e:
+            except Exception:
                 # undo our additions
                 for to_undo in self.__cog_app_commands__[:index]:
                     if isinstance(to_undo, InvokableSlashCommand):
@@ -759,7 +759,7 @@ class Cog(metaclass=CogMeta):
                         bot.remove_user_command(to_undo.name)
                     elif isinstance(to_undo, InvokableMessageCommand):
                         bot.remove_message_command(to_undo.name)
-                raise e
+                raise
 
         if not hasattr(self.cog_load.__func__, "__cog_special_method__"):
             bot.loop.create_task(disnake.utils.maybe_coroutine(self.cog_load))

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -462,8 +462,8 @@ class CommonBotBase(Generic[CogT]):
     def _resolve_name(self, name: str, package: Optional[str]) -> str:
         try:
             return importlib.util.resolve_name(name, package)
-        except ImportError:
-            raise errors.ExtensionNotFound(name) from None
+        except ImportError as e:
+            raise errors.ExtensionNotFound(name) from e
 
     def load_extension(self, name: str, *, package: Optional[str] = None) -> None:
         """Loads an extension.

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -447,7 +447,7 @@ class CommonBotBase(Generic[CogT]):
             setup = lib.setup
         except AttributeError:
             del sys.modules[key]
-            raise errors.NoEntryPointError(key)
+            raise errors.NoEntryPointError(key) from None
 
         try:
             setup(self)
@@ -463,7 +463,7 @@ class CommonBotBase(Generic[CogT]):
         try:
             return importlib.util.resolve_name(name, package)
         except ImportError:
-            raise errors.ExtensionNotFound(name)
+            raise errors.ExtensionNotFound(name) from None
 
     def load_extension(self, name: str, *, package: Optional[str] = None) -> None:
         """Loads an extension.

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -738,7 +738,7 @@ class RoleConverter(IDConverter[disnake.Role]):
     async def convert(self, ctx: AnyContext, argument: str) -> disnake.Role:
         guild = ctx.guild
         if not guild:
-            raise NoPrivateMessage()
+            raise NoPrivateMessage
 
         match = self._get_id_match(argument) or re.match(r"<@&([0-9]{17,19})>$", argument)
         if match:

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -431,9 +431,9 @@ class MessageConverter(IDConverter[disnake.Message]):
         try:
             return await channel.fetch_message(message_id)
         except disnake.NotFound:
-            raise MessageNotFound(argument)
+            raise MessageNotFound(argument) from None
         except disnake.Forbidden:
-            raise ChannelNotReadable(channel)  # type: ignore
+            raise ChannelNotReadable(channel) from None  # type: ignore
 
 
 class GuildChannelConverter(IDConverter[disnake.abc.GuildChannel]):
@@ -668,7 +668,7 @@ class ColourConverter(Converter[disnake.Colour]):
             if not (0 <= value <= 0xFFFFFF):
                 raise BadColourArgument(argument)
         except ValueError:
-            raise BadColourArgument(argument)
+            raise BadColourArgument(argument) from None
         else:
             return disnake.Color(value=value)
 

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -559,7 +559,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         if view.eof:
             if param.kind == param.VAR_POSITIONAL:
-                raise RuntimeError()  # break the loop
+                raise RuntimeError  # break the loop
             if required:
                 if self._is_typing_optional(param.annotation):
                     return None
@@ -621,7 +621,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             value = await run_converters(ctx, converter, argument, param)  # type: ignore
         except (CommandError, ArgumentParsingError):
             view.index = previous
-            raise RuntimeError() from None  # break loop
+            raise RuntimeError from None  # break loop
         else:
             return value
 
@@ -1881,7 +1881,7 @@ def has_role(item: Union[int, str]) -> Callable[[T], T]:
 
     def predicate(ctx: AnyContext) -> bool:
         if ctx.guild is None:
-            raise NoPrivateMessage()
+            raise NoPrivateMessage
 
         # ctx.guild is None doesn't narrow ctx.author to Member
         if isinstance(item, int):
@@ -1929,7 +1929,7 @@ def has_any_role(*items: Union[int, str]) -> Callable[[T], T]:
 
     def predicate(ctx: AnyContext) -> bool:
         if ctx.guild is None:
-            raise NoPrivateMessage()
+            raise NoPrivateMessage
 
         # ctx.guild is None doesn't narrow ctx.author to Member
         getter = functools.partial(disnake.utils.get, ctx.author.roles)  # type: ignore
@@ -1960,7 +1960,7 @@ def bot_has_role(item: int) -> Callable[[T], T]:
 
     def predicate(ctx: AnyContext) -> bool:
         if ctx.guild is None:
-            raise NoPrivateMessage()
+            raise NoPrivateMessage
 
         me = cast(disnake.Member, ctx.me)
         if isinstance(item, int):
@@ -1990,7 +1990,7 @@ def bot_has_any_role(*items: int) -> Callable[[T], T]:
 
     def predicate(ctx: AnyContext) -> bool:
         if ctx.guild is None:
-            raise NoPrivateMessage()
+            raise NoPrivateMessage
 
         me = cast(disnake.Member, ctx.me)
         getter = functools.partial(disnake.utils.get, me.roles)
@@ -2410,7 +2410,7 @@ def dm_only() -> Callable[[T], T]:
 
     def predicate(ctx: AnyContext) -> bool:
         if ctx.guild is not None:
-            raise PrivateMessageOnly()
+            raise PrivateMessageOnly
         return True
 
     return check(predicate)
@@ -2427,7 +2427,7 @@ def guild_only() -> Callable[[T], T]:
 
     def predicate(ctx: AnyContext) -> bool:
         if ctx.guild is None:
-            raise NoPrivateMessage()
+            raise NoPrivateMessage
         return True
 
     return check(predicate)

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -574,7 +574,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         else:
             try:
                 argument = view.get_quoted_word()
-            except ArgumentParsingError as exc:
+            except ArgumentParsingError:
                 if (
                     self._is_typing_optional(param.annotation)
                     and not param.kind == param.VAR_POSITIONAL
@@ -582,7 +582,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
                     view.index = previous
                     return None
                 else:
-                    raise exc
+                    raise
         view.previous = previous
 
         # type-checker fails to narrow argument

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -728,7 +728,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             except StopIteration:
                 raise disnake.ClientException(
                     f'Callback for {self.name} command is missing "self" parameter.'
-                )
+                ) from None
 
         # next we have the 'ctx' as the next parameter
         try:
@@ -736,7 +736,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         except StopIteration:
             raise disnake.ClientException(
                 f'Callback for {self.name} command is missing "ctx" parameter.'
-            )
+            ) from None
 
         for name, param in iterator:
             ctx.current_parameter = param

--- a/disnake/ext/commands/flag_converter.py
+++ b/disnake/ext/commands/flag_converter.py
@@ -579,7 +579,7 @@ class FlagConverter(metaclass=FlagsMeta):
                 values = arguments[name]
             except KeyError:
                 if flag.required:
-                    raise MissingRequiredFlag(flag)
+                    raise MissingRequiredFlag(flag) from None
                 else:
                     if callable(flag.default):
                         default = await maybe_coroutine(flag.default, ctx)

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -188,7 +188,7 @@ class Loop(Generic[LF]):
         except Exception as exc:
             self._has_failed = True
             await self._call_loop_function("error", exc)
-            raise exc
+            raise
         finally:
             await self._call_loop_function("after_loop")
             self._handle.cancel()

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2650,7 +2650,7 @@ class HTTPClient:
         try:
             data: gateway.Gateway = await self.request(Route("GET", "/gateway"))
         except HTTPException as exc:
-            raise GatewayNotFound() from exc
+            raise GatewayNotFound from exc
 
         return self._format_gateway_url(data["url"], encoding=encoding, zlib=zlib)
 
@@ -2660,7 +2660,7 @@ class HTTPClient:
         try:
             data: gateway.GatewayBot = await self.request(Route("GET", "/gateway/bot"))
         except HTTPException as exc:
-            raise GatewayNotFound() from exc
+            raise GatewayNotFound from exc
 
         return (
             data["shards"],

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -116,7 +116,7 @@ class _AsyncIterator(AsyncIterator[T]):
         try:
             return await self.next()
         except NoMoreItems:
-            raise StopAsyncIteration()
+            raise StopAsyncIteration
 
 
 class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
@@ -191,7 +191,7 @@ class ReactionIterator(_AsyncIterator[Union["User", "Member"]]):
         try:
             return self.users.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     async def fill_users(self) -> None:
         if self.limit > 0:
@@ -317,7 +317,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         try:
             return self.messages.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     def _get_retrieve(self):
         limit = self.limit
@@ -442,7 +442,7 @@ class BanIterator(_AsyncIterator["BanEntry"]):
         try:
             return self.bans.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     def _get_retrieve(self) -> bool:
         self.retrieve = min(self.limit, 1000) if self.limit is not None else 1000
@@ -567,7 +567,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         try:
             return self.entries.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     def _get_retrieve(self):
         limit = self.limit
@@ -707,7 +707,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         try:
             return self.guilds.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     def _get_retrieve(self):
         limit = self.limit
@@ -782,7 +782,7 @@ class MemberIterator(_AsyncIterator["Member"]):
         try:
             return self.members.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     def _get_retrieve(self):
         limit = self.limit
@@ -869,7 +869,7 @@ class ArchivedThreadIterator(_AsyncIterator["Thread"]):
         try:
             return self.queue.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     @staticmethod
     def get_archive_timestamp(data: ThreadPayload) -> str:
@@ -881,7 +881,7 @@ class ArchivedThreadIterator(_AsyncIterator["Thread"]):
 
     async def fill_queue(self) -> None:
         if not self.has_more:
-            raise NoMoreItems()
+            raise NoMoreItems
 
         limit = 50 if self.limit is None else max(self.limit, 50)
         data = await self.endpoint(self.channel_id, before=self.before, limit=limit)
@@ -944,7 +944,7 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
         try:
             return self.users.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems()
+            raise NoMoreItems
 
     def _get_retrieve(self) -> bool:
         limit = self.limit

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -116,7 +116,7 @@ class _AsyncIterator(AsyncIterator[T]):
         try:
             return await self.next()
         except NoMoreItems:
-            raise StopAsyncIteration
+            raise StopAsyncIteration from None
 
 
 class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
@@ -191,7 +191,7 @@ class ReactionIterator(_AsyncIterator[Union["User", "Member"]]):
         try:
             return self.users.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     async def fill_users(self) -> None:
         if self.limit > 0:
@@ -317,7 +317,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         try:
             return self.messages.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     def _get_retrieve(self):
         limit = self.limit
@@ -442,7 +442,7 @@ class BanIterator(_AsyncIterator["BanEntry"]):
         try:
             return self.bans.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     def _get_retrieve(self) -> bool:
         self.retrieve = min(self.limit, 1000) if self.limit is not None else 1000
@@ -567,7 +567,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         try:
             return self.entries.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     def _get_retrieve(self):
         limit = self.limit
@@ -707,7 +707,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         try:
             return self.guilds.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     def _get_retrieve(self):
         limit = self.limit
@@ -782,7 +782,7 @@ class MemberIterator(_AsyncIterator["Member"]):
         try:
             return self.members.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     def _get_retrieve(self):
         limit = self.limit
@@ -869,7 +869,7 @@ class ArchivedThreadIterator(_AsyncIterator["Thread"]):
         try:
             return self.queue.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     @staticmethod
     def get_archive_timestamp(data: ThreadPayload) -> str:
@@ -944,7 +944,7 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
         try:
             return self.users.get_nowait()
         except asyncio.QueueEmpty:
-            raise NoMoreItems
+            raise NoMoreItems from None
 
     def _get_retrieve(self) -> bool:
         limit = self.limit

--- a/disnake/opus.py
+++ b/disnake/opus.py
@@ -333,7 +333,7 @@ class _OpusStruct:
     @staticmethod
     def get_opus_version() -> str:
         if not is_loaded() and not _load_default():
-            raise OpusNotLoaded()
+            raise OpusNotLoaded
 
         return _lib.opus_get_version_string().decode("utf-8")
 

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -1046,9 +1046,9 @@ class ThreadMember(Hashable):
     def _from_data(self, data: ThreadMemberPayload) -> None:
         try:
             self.id = int(data["user_id"])
-        except KeyError:
+        except KeyError as err:
             if (self_id := self._state.self_id) is None:
-                raise AssertionError("self_id is None when updating our own ThreadMember.")
+                raise AssertionError("self_id is None when updating our own ThreadMember.") from err
             self.id = self_id
 
         try:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -612,7 +612,7 @@ async def sane_wait_for(futures: Iterable[Awaitable[T]], *, timeout: float) -> S
     done, pending = await asyncio.wait(ensured, timeout=timeout, return_when=asyncio.ALL_COMPLETED)
 
     if len(pending) != 0:
-        raise asyncio.TimeoutError()
+        raise asyncio.TimeoutError
 
     return done
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ select = [
     "PLE",    # pylint error
     # "PLR",    # pylint refactor
     "PLW",    # pylint warnings
-    "TRY002", "TRY004", # tryceratops
+    "TRY002", "TRY004", "TRY201", # tryceratops
 ]
 ignore = [
     # star imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ select = [
     "RUF",    # ruff specific exceptions
     "PT",     # flake8-pytest-style
     "Q",      # flake8-quotes
+    "RSE",    # flake8-raise
     "T20",    # flake8-print
     "PGH",    # pygrep-hooks
     "PLC",    # pylint convention


### PR DESCRIPTION
## Summary

Enables RSE102, TRY201, and B904 in ruff which correspond to the three errors that flake8-raises provides.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `task lint`
    - [x] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
