### PR TITLE
chore(contrib): install nox into the local development environment rather than global

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@
 
 - [ ] If code changes were made, then they have been tested
     - [ ] I have updated the documentation to reflect the changes
-    - [ ] I have formatted the code properly by running `task lint`
-    - [ ] I have type-checked the code by running `task pyright`
+    - [ ] I have formatted the code properly by running `pdm lint`
+    - [ ] I have type-checked the code by running `pdm pyright`
 - [ ] This PR fixes an issue
 - [ ] This PR adds something new (e.g. new method or parameters)
 - [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,13 @@ Creating a pull request is fairly simple, just make sure it focuses on a single 
 
 We would greatly appreciate the code submitted to be of a consistent style with other code in disnake. This project follows PEP-8 guidelines (mostly) with a column limit of 100 characters.
 
-Run these commands to install [`nox`](https://nox.thea.codes/) and [`pdm`](https://pdm.fming.dev/), as well as the required dependencies in your environment, and to set up [`pre-commit`](https://pre-commit.com/#quick-start) hooks.
+Run these commands to install [`PDM`](https://pdm.fming.dev/), as well as the required dependencies in your environment, and to set up [`pre-commit`](https://pre-commit.com/#quick-start) hooks.
 ```
-pip install nox pdm
+pip install pdm
 pdm run setup_env
 ```
 
+> PDM should be globally installed, if possible. There may be issues with putting PDM in the same environment as the rest of the dependencies for disnake.
 > If you have [pipx](https://pypa.github.io/pipx/) installed on your system, we recommend installing the above tools with pipx instead.
 
 The installed `pre-commit` hooks will automatically run before every commit, which will format/lint the code
@@ -67,9 +68,9 @@ documented at [https://spdx.dev/ids/](https://spdx.dev/ids/).
 
 ### Scripts
 
-To run all important checks and tests, use `nox`:
+To run all important checks and tests, use `pdm run nox`:
 ```sh
-nox -R
+pdm run nox -R
 ```
 
 You can also choose to only run a single task; run `pdm run --list` to view all available scripts and use `pdm run <name>` to run them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Creating a pull request is fairly simple, just make sure it focuses on a single 
 We would greatly appreciate the code submitted to be of a consistent style with other code in disnake. This project follows PEP-8 guidelines (mostly) with a column limit of 100 characters.
 
 
-We require [`PDM`](https://pdm.fming.dev/) for development. If PDM is not already installed on your system, you can follow their [installation steps here](https://github.com/pdm-project/pdm#installation) to get started.
+We use [`PDM`](https://pdm.fming.dev/) for development. If PDM is not already installed on your system, you can follow their [installation steps here](https://pdm.fming.dev/latest/#installation) to get started.
 
 Once PDM is installed and avaliable, use the following command to initialise a virtual environment, install the necessary development dependencies, and install the [`pre-commit`](https://pre-commit.com/#quick-start) hooks.
 .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,14 +47,14 @@ Creating a pull request is fairly simple, just make sure it focuses on a single 
 
 We would greatly appreciate the code submitted to be of a consistent style with other code in disnake. This project follows PEP-8 guidelines (mostly) with a column limit of 100 characters.
 
-Run these commands to install [`PDM`](https://pdm.fming.dev/), as well as the required dependencies in your environment, and to set up [`pre-commit`](https://pre-commit.com/#quick-start) hooks.
+
+We require [`PDM`](https://pdm.fming.dev/) for development. If PDM is not already installed on your system, you can follow their [installation steps here](https://github.com/pdm-project/pdm#installation) to get started.
+
+Once PDM is installed and avaliable, use the following command to initialise a virtual environment, install the necessary development dependencies, and install the [`pre-commit`](https://pre-commit.com/#quick-start) hooks.
+.
 ```
-pip install pdm
 pdm run setup_env
 ```
-
-> PDM should be globally installed, if possible. There may be issues with putting PDM in the same environment as the rest of the dependencies for disnake.
-> If you have [pipx](https://pypa.github.io/pipx/) installed on your system, we recommend installing the above tools with pipx instead.
 
 The installed `pre-commit` hooks will automatically run before every commit, which will format/lint the code
 to match the project's style. Note that you will have to stage and commit again if anything was updated!
@@ -75,7 +75,7 @@ pdm run nox -R
 
 You can also choose to only run a single task; run `pdm run --list` to view all available scripts and use `pdm run <name>` to run them.
 
-Some notes (all of the mentioned scripts are automatically run by `nox -R`, see above):
+Some notes (all of the mentioned scripts are automatically run by `pdm run nox -R`, see above):
 - If `pre-commit` hooks aren't installed, run `pdm run lint` manually to check and fix the formatting in all files.  
   **Note**: If the code is formatted incorrectly, `pre-commit` will apply fixes and exit without committing the changes - just stage and commit again.
 - For type-checking, run `pdm run pyright`. You can use `pdm run pyright -w` to automatically re-check on every file change.  

--- a/changelog/953.misc.rst
+++ b/changelog/953.misc.rst
@@ -1,0 +1,2 @@
+Change dependency and environment management to use `pdm <https://pdm.fming.dev/>`__.
+Please check `CONTRIBUTING.md <https://github.com/DisnakeDev/disnake/tree/master/CONTRIBUTING.md>`__ for more details.

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -34,7 +34,7 @@ If you are not sure what issue type to use, don't hesitate to ask in your PR.
 ``towncrier`` preserves multiple paragraphs and formatting (code blocks, lists, and so on), but for entries
 other than ``features`` it is usually better to stick to a single paragraph to keep it concise.
 
-You can also run ``nox -s docs`` to build the documentation
+You can also run ``pdm run docs`` to build the documentation
 with the draft changelog (http://127.0.0.1:8009/whats_new.html) if you want to get a preview of how your change will look in the final release notes.
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -99,7 +99,7 @@ def codemod(session: nox.Session):
     if session.posargs and session.posargs[0] == "run-all" or not session.interactive:
         # run all of the transformers on disnake
         session.log("Running all transformers.")
-        res: str = session.run("python", "-m", "libcst.tool", "list", silent=True)
+        res: str = session.run("python", "-m", "libcst.tool", "list", silent=True)  # type: ignore
         transformers = [line.split("-")[0].strip() for line in res.splitlines()]
         session.log("Transformers: " + ", ".join(transformers))
 
@@ -126,7 +126,9 @@ def codemod(session: nox.Session):
 @nox.session()
 def pyright(session: nox.Session):
     """Run pyright."""
-    session.run_always("pdm", "install", "-d", "-Gspeed", "-Gdocs", "-Gvoice", external=True)
+    session.run_always(
+        "pdm", "install", "-d", "-Gspeed", "-Gdocs", "-Gvoice", "-Gnox", external=True
+    )
     env = {
         "PYRIGHT_PYTHON_IGNORE_WARNINGS": "1",
     }
@@ -149,7 +151,7 @@ def pyright(session: nox.Session):
 def test(session: nox.Session, extras: List[str]):
     """Run tests."""
     # shell splitting is not done by nox
-    extras = chain(*(["-G", extra] for extra in extras))
+    extras = list(chain(*(["-G", extra] for extra in extras)))
 
     session.run_always("pdm", "install", "-dG", "test", "-dG", "typing", *extras, external=True)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -126,9 +126,7 @@ def codemod(session: nox.Session):
 @nox.session()
 def pyright(session: nox.Session):
     """Run pyright."""
-    session.run_always(
-        "pdm", "install", "-d", "-Gspeed", "-Gdocs", "-Gvoice", "-Gnox", external=True
-    )
+    session.run_always("pdm", "install", "-d", "-Gspeed", "-Gdocs", "-Gvoice", external=True)
     env = {
         "PYRIGHT_PYTHON_IGNORE_WARNINGS": "1",
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ discord = ["discord-disnake"]
 
 [tool.pdm.dev-dependencies]
 nox = [
-    "nox>=2022.11.21",
+    "nox==2022.11.21",
 ]
 tools = [
     "pre-commit~=2.19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ discord = ["discord-disnake"]
 [tool.pdm.dev-dependencies]
 tools = [
     "pre-commit~=2.19.0",
-    "taskipy~=1.10.1",
     "slotscheck~=0.15.0",
     "python-dotenv~=0.20.0",
     "towncrier==22.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,7 +269,6 @@ include = [
 ]
 ignore = [
     "disnake/ext/mypy_plugin",
-    "noxfile.py",  # this is ignored because nox is not installed in the environment when running pyright
 ]
 
 # this is one of the diagnostics that aren't enabled by default, even in strict mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ docs = { cmd = "nox -Rs docs --", help = "Build the documentation for developmen
 isort = { composite = ["lint isort"], help = "Run isort" }
 lint = { cmd = "nox -Rs lint --", help = "Check all files for linting errors" }
 pyright = { cmd = "nox -Rs pyright --", help = "Run pyright" }
-setup_env = { cmd = "pdm install -d -G speed -G docs -G voice -G nox", help = "Set up the local environment and all dependencies" }
+setup_env = { cmd = "pdm install -d -G speed -G docs -G voice", help = "Set up the local environment and all dependencies" }
 post_setup_env = { composite = ["python -m ensurepip --default-pip", "pre-commit install --install-hooks"] }
 test = { cmd = "nox -Rs test --", help = "Run pytest" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ docs = [
 discord = ["discord-disnake"]
 
 [tool.pdm.dev-dependencies]
+nox = [
+    "nox>=2022.11.21",
+]
 tools = [
     "pre-commit~=2.19.0",
     "slotscheck~=0.15.0",
@@ -95,7 +98,7 @@ docs = { cmd = "nox -Rs docs --", help = "Build the documentation for developmen
 isort = { composite = ["lint isort"], help = "Run isort" }
 lint = { cmd = "nox -Rs lint --", help = "Check all files for linting errors" }
 pyright = { cmd = "nox -Rs pyright --", help = "Run pyright" }
-setup_env = { cmd = "pdm install -d -G speed -G docs -G voice", help = "Set up the local environment and all dependencies" }
+setup_env = { cmd = "pdm install -d -G speed -G docs -G voice -G nox", help = "Set up the local environment and all dependencies" }
 post_setup_env = { composite = ["python -m ensurepip --default-pip", "pre-commit install --install-hooks"] }
 test = { cmd = "nox -Rs test --", help = "Run pytest" }
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Install nox in the virtual environment created by pdm.

This was suggested on Discord around [here](https://canary.discord.com/channels/808030843078836254/913779868985090089/1078451344135954693). 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `task lint`
    - [ ] I have type-checked the code by running `task pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
