### PR TITLE
lint: enable datetime rules

### DIFF
--- a/changelog/945.bugfix.rst
+++ b/changelog/945.bugfix.rst
@@ -1,0 +1,1 @@
+:attr:`RawTypingEvent.timestamp` is now a timezone-aware :class:`~datetime.datetime` instead of a naive one.

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -899,9 +899,7 @@ class Member(disnake.abc.Messageable, _UserTag):
                 await http.edit_my_voice_state(guild_id, voice_state_payload)
             else:
                 if not suppress:
-                    voice_state_payload[
-                        "request_to_speak_timestamp"
-                    ] = datetime.datetime.utcnow().isoformat()
+                    voice_state_payload["request_to_speak_timestamp"] = utils.utcnow().isoformat()
                 await http.edit_voice_state(guild_id, self.id, voice_state_payload)
 
         if voice_channel is not MISSING:
@@ -960,7 +958,7 @@ class Member(disnake.abc.Messageable, _UserTag):
 
         payload = {
             "channel_id": self.voice.channel.id,
-            "request_to_speak_timestamp": datetime.datetime.utcnow().isoformat(),
+            "request_to_speak_timestamp": utils.utcnow().isoformat(),
         }
 
         if self._state.self_id != self.id:

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -389,7 +389,9 @@ class RawTypingEvent(_RawReprMixin):
         self.user_id: int = int(data["user_id"])
         self.channel_id: int = int(data["channel_id"])
         self.member: Optional[Member] = None
-        self.timestamp: datetime.datetime = datetime.datetime.utcfromtimestamp(data["timestamp"])
+        self.timestamp: datetime.datetime = datetime.datetime.fromtimestamp(
+            data["timestamp"], tz=datetime.timezone.utc
+        )
         try:
             self.guild_id: Optional[int] = int(data["guild_id"])
         except KeyError:

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -381,6 +381,9 @@ class RawTypingEvent(_RawReprMixin):
         The member object of the user who started typing or ``None`` if it was in a DM.
     timestamp: :class:`datetime.datetime`
         The UTC datetime when the user started typing.
+
+        .. versionchanged:: 2.9
+            Changed from naive to aware datetime.
     """
 
     __slots__ = ("user_id", "channel_id", "guild_id", "member", "timestamp")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ select = [
     "S", # flake8-bandit
     "B", # flake8-bugbear
     "C", # flake8-comprehensions
-    # "DTZ", # flake8-datetimez
+    "DTZ", # flake8-datetimez
     # "EM", # flake8-errmsg
     "G", # flake8-logging-format
     # "RET", # flake8-return

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -64,7 +64,7 @@ def test_type_default() -> None:
 
 
 def test_timestamp_naive(embed: Embed) -> None:
-    embed.timestamp = datetime.now()
+    embed.timestamp = datetime.now()  # noqa: DTZ005  # the point of this is to test naive dts
     assert embed.timestamp.tzinfo is not None
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -407,7 +407,7 @@ def test_get_slots():
 @pytest.mark.parametrize(("delta", "expected"), [(7, 7), (-100, 0)])
 @helpers.freeze_time()
 def test_compute_timedelta(tz, delta, expected):
-    dt = datetime.datetime.now()
+    dt = datetime.datetime.now()  # noqa: DTZ005
     if tz is not utils.MISSING:
         dt = dt.astimezone(tz)
     assert utils.compute_timedelta(dt + timedelta(seconds=delta)) == expected
@@ -793,7 +793,7 @@ def test_resolve_annotation_literal():
     with pytest.raises(
         TypeError, match=r"Literal arguments must be of type str, int, bool, or NoneType."
     ):
-        utils.resolve_annotation(Literal[datetime.datetime.now(), 3], globals(), locals(), {})  # type: ignore
+        utils.resolve_annotation(Literal[timezone.utc, 3], globals(), locals(), {})  # type: ignore
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

https://beta.ruff.rs/docs/rules/#flake8-datetimez-dtz

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
