### PR TITLE
chore(lint): add autotyping for automatic typing of known types

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -133,7 +133,7 @@ jobs:
         LIBCST_PARSER_TYPE: "native"
       run: |
         nox -s codemod -- run-all
-        if [ -n "$(git status --porcelain disnake/)" ]; then
+        if [ -n "$(git status --porcelain disnake/ tests/ test_bot/ scripts/ examples/ noxfile.py)" ]; then
           echo "::error::Please run 'nox -s codemod -- run-all' locally and commit the changes." >&2;
           exit 1;
         else

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -133,7 +133,7 @@ jobs:
         LIBCST_PARSER_TYPE: "native"
       run: |
         nox -s codemod -- run-all
-        if [ -n "$(git status --porcelain disnake/ tests/ test_bot/ scripts/ examples/ noxfile.py)" ]; then
+        if [ -n "$(git status --porcelain)" ]; then
           echo "::error::Please run 'nox -s codemod -- run-all' locally and commit the changes." >&2;
           exit 1;
         else

--- a/.libcst.codemod.yaml
+++ b/.libcst.codemod.yaml
@@ -13,6 +13,7 @@ blacklist_patterns: []
 # List of modules that contain codemods inside of them.
 modules:
 - 'scripts.codemods'
+- 'autotyping'
 # - 'libcst.codemod.commands'
 # Absolute or relative path of the repository root, used for providing
 # full-repo metadata. Relative paths should be specified with this file

--- a/disnake/__main__.py
+++ b/disnake/__main__.py
@@ -163,7 +163,7 @@ _base_table = {**_ascii_table, **_byte_table}
 _translation_table = str.maketrans(_base_table)
 
 
-def to_path(parser, name, *, replace_spaces=False):
+def to_path(parser, name: str, *, replace_spaces: bool = False):
     if isinstance(name, Path):
         return name
 

--- a/disnake/__main__.py
+++ b/disnake/__main__.py
@@ -5,6 +5,7 @@ import importlib.metadata
 import platform
 import sys
 from pathlib import Path
+from typing import Union
 
 import aiohttp
 
@@ -163,7 +164,7 @@ _base_table = {**_ascii_table, **_byte_table}
 _translation_table = str.maketrans(_base_table)
 
 
-def to_path(parser, name: str, *, replace_spaces: bool = False):
+def to_path(parser, name: Union[str, Path], *, replace_spaces: bool = False):
     if isinstance(name, Path):
         return name
 

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -879,7 +879,12 @@ class GuildChannel(ABC):
         ...
 
     async def set_permissions(
-        self, target, *, overwrite=MISSING, reason=None, **permissions
+        self,
+        target,
+        *,
+        overwrite: Optional[PermissionOverwrite] = MISSING,
+        reason: Optional[str] = None,
+        **permissions,
     ) -> None:
         """
         |coro|

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -16,6 +16,9 @@ from typing import (
     TypeVar,
 )
 
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
 __all__ = (
     "Enum",
     "ChannelType",
@@ -142,10 +145,10 @@ class EnumMeta(type):
         value_cls._actual_enum_cls_ = actual_cls  # type: ignore
         return actual_cls
 
-    def __iter__(cls) -> Iterator:
+    def __iter__(cls) -> Iterator[Self]:
         return (cls._enum_member_map_[name] for name in cls._enum_member_names_)
 
-    def __reversed__(cls) -> Iterator:
+    def __reversed__(cls) -> Iterator[Self]:
         return (cls._enum_member_map_[name] for name in reversed(cls._enum_member_names_))
 
     def __len__(cls) -> int:

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    Iterator,
     List,
     NamedTuple,
     NoReturn,
@@ -103,7 +104,7 @@ class EnumMeta(type):
         _enum_member_map_: ClassVar[Dict[str, Any]]
         _enum_value_map_: ClassVar[Dict[Any, Any]]
 
-    def __new__(cls, name, bases, attrs, *, comparable: bool = False):
+    def __new__(cls, name: str, bases, attrs, *, comparable: bool = False):
         value_mapping = {}
         member_mapping = {}
         member_names = []
@@ -141,10 +142,10 @@ class EnumMeta(type):
         value_cls._actual_enum_cls_ = actual_cls  # type: ignore
         return actual_cls
 
-    def __iter__(cls):
+    def __iter__(cls) -> Iterator:
         return (cls._enum_member_map_[name] for name in cls._enum_member_names_)
 
-    def __reversed__(cls):
+    def __reversed__(cls) -> Iterator:
         return (cls._enum_member_map_[name] for name in reversed(cls._enum_member_names_))
 
     def __len__(cls) -> int:
@@ -166,7 +167,7 @@ class EnumMeta(type):
     def __getitem__(cls, key):
         return cls._enum_member_map_[key]
 
-    def __setattr__(cls, name, value) -> NoReturn:
+    def __setattr__(cls, name: str, value) -> NoReturn:
         raise TypeError("Enums are immutable.")
 
     def __delattr__(cls, attr) -> NoReturn:

--- a/disnake/ext/commands/cooldowns.py
+++ b/disnake/ext/commands/cooldowns.py
@@ -198,7 +198,7 @@ class CooldownMapping:
         return self._type
 
     @classmethod
-    def from_cooldown(cls, rate: float, per, type) -> Self:
+    def from_cooldown(cls, rate: float, per: float, type) -> Self:
         return cls(Cooldown(rate, per), type)
 
     def _bucket_key(self, msg: Message) -> Any:

--- a/disnake/ext/commands/cooldowns.py
+++ b/disnake/ext/commands/cooldowns.py
@@ -198,7 +198,7 @@ class CooldownMapping:
         return self._type
 
     @classmethod
-    def from_cooldown(cls, rate, per, type) -> Self:
+    def from_cooldown(cls, rate: float, per, type) -> Self:
         return cls(Cooldown(rate, per), type)
 
     def _bucket_key(self, msg: Message) -> Any:

--- a/disnake/ext/commands/help.py
+++ b/disnake/ext/commands/help.py
@@ -12,6 +12,7 @@ from .core import Command, Group
 from .errors import CommandError
 
 if TYPE_CHECKING:
+    from ._types import MaybeCoro
     from .context import Context
 
 __all__ = (
@@ -459,7 +460,7 @@ class HelpCommand:
         if cog is not None:
             self._command_impl._inject_into_cog(cog)
 
-    def command_not_found(self, string: str) -> str:
+    def command_not_found(self, string: str) -> MaybeCoro[str]:
         """|maybecoro|
 
         A method called when a command is not found in the help command.
@@ -480,7 +481,7 @@ class HelpCommand:
         """
         return f'No command called "{string}" found.'
 
-    def subcommand_not_found(self, command, string: str) -> str:
+    def subcommand_not_found(self, command, string: str) -> MaybeCoro[str]:
         """|maybecoro|
 
         A method called when a command did not have a subcommand requested in the help command.
@@ -917,7 +918,7 @@ class DefaultHelpCommand(HelpCommand):
             return text[: self.width - 3].rstrip() + "..."
         return text
 
-    def get_ending_note(self) -> str:
+    def get_ending_note(self) -> Optional[str]:
         """Returns help command's ending note. This is mainly useful to override for i18n purposes.
 
         :return type: :class:`str`
@@ -1119,7 +1120,7 @@ class MinimalHelpCommand(HelpCommand):
         for page in self.paginator.pages:
             await destination.send(page)
 
-    def get_opening_note(self) -> str:
+    def get_opening_note(self) -> Optional[str]:
         """Returns help command's opening note. This is mainly useful to override for i18n purposes.
 
         The default implementation returns ::
@@ -1141,7 +1142,7 @@ class MinimalHelpCommand(HelpCommand):
     def get_command_signature(self, command) -> str:
         return f"{self.context.clean_prefix}{command.qualified_name} {command.signature}"
 
-    def get_ending_note(self):
+    def get_ending_note(self) -> Optional[str]:
         """Return the help command's ending note. This is mainly useful to override for i18n purposes.
 
         The default implementation does nothing.

--- a/disnake/ext/commands/help.py
+++ b/disnake/ext/commands/help.py
@@ -71,14 +71,14 @@ class Paginator:
         suffix: Optional[str] = "```",
         max_size: int = 2000,
         linesep: str = "\n",
-    ):
+    ) -> None:
         self.prefix = prefix
         self.suffix = suffix
         self.max_size = max_size
         self.linesep = linesep
         self.clear()
 
-    def clear(self):
+    def clear(self) -> None:
         """Clears the paginator to have no pages."""
         if self.prefix is not None:
             self._current_page = [self.prefix]
@@ -100,7 +100,7 @@ class Paginator:
     def _linesep_len(self):
         return len(self.linesep)
 
-    def add_line(self, line="", *, empty=False):
+    def add_line(self, line: str = "", *, empty: bool = False):
         """Adds a line to the current page.
 
         If the line exceeds the :attr:`max_size` then an exception
@@ -132,7 +132,7 @@ class Paginator:
             self._current_page.append("")
             self._count += self._linesep_len
 
-    def close_page(self):
+    def close_page(self) -> None:
         """Prematurely terminate a page."""
         if self.suffix is not None:
             self._current_page.append(self.suffix)
@@ -145,7 +145,7 @@ class Paginator:
             self._current_page = []
             self._count = 0
 
-    def __len__(self):
+    def __len__(self) -> int:
         total = sum(len(p) for p in self._pages)
         return total + self._count
 
@@ -157,7 +157,7 @@ class Paginator:
             self.close_page()
         return self._pages
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         fmt = "<Paginator prefix: {0.prefix!r} suffix: {0.suffix!r} linesep: {0.linesep!r} max_size: {0.max_size} count: {0._count}>"
         return fmt.format(self)
 
@@ -168,12 +168,12 @@ def _not_overriden(f):
 
 
 class _HelpCommandImpl(Command):
-    def __init__(self, inject, *args, **kwargs):
+    def __init__(self, inject, *args, **kwargs) -> None:
         super().__init__(inject.command_callback, *args, **kwargs)
         self._original = inject
         self._injected = inject
 
-    async def prepare(self, ctx):
+    async def prepare(self, ctx) -> None:
         self._injected = injected = self._original.copy()
         injected.context = ctx
         self.callback = injected.command_callback
@@ -187,7 +187,7 @@ class _HelpCommandImpl(Command):
 
         await super().prepare(ctx)
 
-    async def _parse_arguments(self, ctx):
+    async def _parse_arguments(self, ctx) -> None:
         # Make the parser think we don't have a cog so it doesn't
         # inject the parameter into `ctx.args`.
         original_cog = self.cog
@@ -197,7 +197,7 @@ class _HelpCommandImpl(Command):
         finally:
             self.cog = original_cog
 
-    async def _on_error_cog_implementation(self, dummy, ctx, error):
+    async def _on_error_cog_implementation(self, dummy, ctx, error) -> None:
         await self._injected.on_help_command_error(ctx, error)
 
     @property
@@ -210,7 +210,7 @@ class _HelpCommandImpl(Command):
         else:
             return result
 
-    def _inject_into_cog(self, cog):
+    def _inject_into_cog(self, cog) -> None:
         # Warning: hacky
 
         # Make the cog think that get_commands returns this command
@@ -232,7 +232,7 @@ class _HelpCommandImpl(Command):
         cog.walk_commands = wrapped_walk_commands
         self.cog = cog
 
-    def _eject_cog(self):
+    def _eject_cog(self) -> None:
         if self.cog is None:
             return
 
@@ -303,7 +303,7 @@ class HelpCommand:
         self.__original_args__ = deepcopy(args)  # type: ignore
         return self
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         self.show_hidden = options.pop("show_hidden", False)
         self.verify_checks = options.pop("verify_checks", True)
         self.command_attrs = attrs = options.pop("command_attrs", {})
@@ -317,16 +317,16 @@ class HelpCommand:
         obj._command_impl = self._command_impl
         return obj
 
-    def _add_to_bot(self, bot):
+    def _add_to_bot(self, bot) -> None:
         command = _HelpCommandImpl(self, **self.command_attrs)
         bot.add_command(command)
         self._command_impl = command
 
-    def _remove_from_bot(self, bot):
+    def _remove_from_bot(self, bot) -> None:
         bot.remove_command(self._command_impl.name)
         self._command_impl._eject_cog()
 
-    def add_check(self, func):
+    def add_check(self, func) -> None:
         """
         Adds a check to the help command.
 
@@ -339,7 +339,7 @@ class HelpCommand:
         """
         self._command_impl.add_check(func)
 
-    def remove_check(self, func):
+    def remove_check(self, func) -> None:
         """
         Removes a check from the help command.
 
@@ -383,7 +383,7 @@ class HelpCommand:
             return command_name
         return ctx.invoked_with
 
-    def get_command_signature(self, command):
+    def get_command_signature(self, command) -> str:
         """Retrieves the signature portion of the help page.
 
         Parameters
@@ -417,7 +417,7 @@ class HelpCommand:
 
         return f"{self.context.clean_prefix}{alias} {command.signature}"
 
-    def remove_mentions(self, string):
+    def remove_mentions(self, string: str):
         """Removes mentions from the string to prevent abuse.
 
         This includes ``@everyone``, ``@here``, member mentions and role mentions.
@@ -451,7 +451,7 @@ class HelpCommand:
         return self._command_impl.cog
 
     @cog.setter
-    def cog(self, cog):
+    def cog(self, cog) -> None:
         # Remove whatever cog is currently valid, if any
         self._command_impl._eject_cog()
 
@@ -459,7 +459,7 @@ class HelpCommand:
         if cog is not None:
             self._command_impl._inject_into_cog(cog)
 
-    def command_not_found(self, string):
+    def command_not_found(self, string: str) -> str:
         """|maybecoro|
 
         A method called when a command is not found in the help command.
@@ -480,7 +480,7 @@ class HelpCommand:
         """
         return f'No command called "{string}" found.'
 
-    def subcommand_not_found(self, command, string):
+    def subcommand_not_found(self, command, string: str) -> str:
         """|maybecoro|
 
         A method called when a command did not have a subcommand requested in the help command.
@@ -605,7 +605,7 @@ class HelpCommand:
         """
         return self.context.channel
 
-    async def send_error_message(self, error):
+    async def send_error_message(self, error) -> None:
         """|coro|
 
         Handles the implementation when an error happens in the help command.
@@ -630,7 +630,7 @@ class HelpCommand:
         await destination.send(error)
 
     @_not_overriden
-    async def on_help_command_error(self, ctx, error):
+    async def on_help_command_error(self, ctx, error) -> None:
         """|coro|
 
         The help command's error handler, as specified by :ref:`ext_commands_error_handler`.
@@ -773,7 +773,7 @@ class HelpCommand:
         """
         return None
 
-    async def prepare_help_command(self, ctx, command=None):
+    async def prepare_help_command(self, ctx, command=None) -> None:
         """|coro|
 
         A low level method that can be used to prepare the help command
@@ -896,7 +896,7 @@ class DefaultHelpCommand(HelpCommand):
         The paginator used to paginate the help command output.
     """
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         self.width = options.pop("width", 80)
         self.indent = options.pop("indent", 2)
         self.sort_commands = options.pop("sort_commands", True)
@@ -908,7 +908,7 @@ class DefaultHelpCommand(HelpCommand):
 
         super().__init__(**options)
 
-    def shorten_text(self, text):
+    def shorten_text(self, text: str):
         """Shortens text to fit into the :attr:`width`.
 
         :return type: :class:`str`
@@ -917,7 +917,7 @@ class DefaultHelpCommand(HelpCommand):
             return text[: self.width - 3].rstrip() + "..."
         return text
 
-    def get_ending_note(self):
+    def get_ending_note(self) -> str:
         """Returns help command's ending note. This is mainly useful to override for i18n purposes.
 
         :return type: :class:`str`
@@ -928,7 +928,7 @@ class DefaultHelpCommand(HelpCommand):
             f"You can also type {self.context.clean_prefix}{command_name} category for more info on a category."
         )
 
-    def add_indented_commands(self, commands, *, heading, max_size=None):
+    def add_indented_commands(self, commands, *, heading, max_size: Optional[int] = None) -> None:
         """Indents a list of commands after the specified heading.
 
         The formatting is added to the :attr:`paginator`.
@@ -963,13 +963,13 @@ class DefaultHelpCommand(HelpCommand):
             entry = f'{self.indent * " "}{name:<{width}} {command.short_doc}'
             self.paginator.add_line(self.shorten_text(entry))
 
-    async def send_pages(self):
+    async def send_pages(self) -> None:
         """A helper utility to send the page output from :attr:`paginator` to the destination."""
         destination = self.get_destination()
         for page in self.paginator.pages:
             await destination.send(page)
 
-    def add_command_formatting(self, command):
+    def add_command_formatting(self, command) -> None:
         """A utility function to format the non-indented block of commands and groups.
 
         Parameters
@@ -1000,11 +1000,11 @@ class DefaultHelpCommand(HelpCommand):
         else:
             return ctx.channel
 
-    async def prepare_help_command(self, ctx, command):
+    async def prepare_help_command(self, ctx, command) -> None:
         self.paginator.clear()
         await super().prepare_help_command(ctx, command)
 
-    async def send_bot_help(self, mapping):
+    async def send_bot_help(self, mapping) -> None:
         ctx = self.context
         bot = ctx.bot
 
@@ -1036,12 +1036,12 @@ class DefaultHelpCommand(HelpCommand):
 
         await self.send_pages()
 
-    async def send_command_help(self, command):
+    async def send_command_help(self, command) -> None:
         self.add_command_formatting(command)
         self.paginator.close_page()
         await self.send_pages()
 
-    async def send_group_help(self, group):
+    async def send_group_help(self, group) -> None:
         self.add_command_formatting(group)
 
         filtered = await self.filter_commands(group.commands, sort=self.sort_commands)
@@ -1055,7 +1055,7 @@ class DefaultHelpCommand(HelpCommand):
 
         await self.send_pages()
 
-    async def send_cog_help(self, cog):
+    async def send_cog_help(self, cog) -> None:
         if cog.description:
             self.paginator.add_line(cog.description, empty=True)
 
@@ -1102,7 +1102,7 @@ class MinimalHelpCommand(HelpCommand):
         The paginator used to paginate the help command output.
     """
 
-    def __init__(self, **options):
+    def __init__(self, **options) -> None:
         self.sort_commands = options.pop("sort_commands", True)
         self.commands_heading = options.pop("commands_heading", "Commands")
         self.dm_help = options.pop("dm_help", False)
@@ -1113,13 +1113,13 @@ class MinimalHelpCommand(HelpCommand):
 
         super().__init__(**options)
 
-    async def send_pages(self):
+    async def send_pages(self) -> None:
         """A helper utility to send the page output from :attr:`paginator` to the destination."""
         destination = self.get_destination()
         for page in self.paginator.pages:
             await destination.send(page)
 
-    def get_opening_note(self):
+    def get_opening_note(self) -> str:
         """Returns help command's opening note. This is mainly useful to override for i18n purposes.
 
         The default implementation returns ::
@@ -1138,7 +1138,7 @@ class MinimalHelpCommand(HelpCommand):
             f"You can also use `{self.context.clean_prefix}{command_name} [category]` for more info on a category."
         )
 
-    def get_command_signature(self, command):
+    def get_command_signature(self, command) -> str:
         return f"{self.context.clean_prefix}{command.qualified_name} {command.signature}"
 
     def get_ending_note(self):
@@ -1153,7 +1153,7 @@ class MinimalHelpCommand(HelpCommand):
         """
         return None
 
-    def add_bot_commands_formatting(self, commands, heading):
+    def add_bot_commands_formatting(self, commands, heading) -> None:
         """Adds the minified bot heading with commands to the output.
 
         The formatting should be added to the :attr:`paginator`.
@@ -1174,7 +1174,7 @@ class MinimalHelpCommand(HelpCommand):
             self.paginator.add_line(f"__**{heading}**__")
             self.paginator.add_line(joined)
 
-    def add_subcommand_formatting(self, command):
+    def add_subcommand_formatting(self, command) -> None:
         """Adds formatting information on a subcommand.
 
         The formatting should be added to the :attr:`paginator`.
@@ -1192,7 +1192,7 @@ class MinimalHelpCommand(HelpCommand):
             fmt.format(self.context.clean_prefix, command.qualified_name, command.short_doc)
         )
 
-    def add_aliases_formatting(self, aliases):
+    def add_aliases_formatting(self, aliases) -> None:
         """Adds the formatting information on a command's aliases.
 
         The formatting should be added to the :attr:`paginator`.
@@ -1209,7 +1209,7 @@ class MinimalHelpCommand(HelpCommand):
         """
         self.paginator.add_line(f'**{self.aliases_heading}** {", ".join(aliases)}', empty=True)
 
-    def add_command_formatting(self, command):
+    def add_command_formatting(self, command) -> None:
         """A utility function to format commands and groups.
 
         Parameters
@@ -1244,11 +1244,11 @@ class MinimalHelpCommand(HelpCommand):
         else:
             return ctx.channel
 
-    async def prepare_help_command(self, ctx, command):
+    async def prepare_help_command(self, ctx, command) -> None:
         self.paginator.clear()
         await super().prepare_help_command(ctx, command)
 
-    async def send_bot_help(self, mapping):
+    async def send_bot_help(self, mapping) -> None:
         ctx = self.context
         bot = ctx.bot
 
@@ -1281,7 +1281,7 @@ class MinimalHelpCommand(HelpCommand):
 
         await self.send_pages()
 
-    async def send_cog_help(self, cog):
+    async def send_cog_help(self, cog) -> None:
         bot = self.context.bot
         if bot.description:
             self.paginator.add_line(bot.description, empty=True)
@@ -1306,7 +1306,7 @@ class MinimalHelpCommand(HelpCommand):
 
         await self.send_pages()
 
-    async def send_group_help(self, group):
+    async def send_group_help(self, group) -> None:
         self.add_command_formatting(group)
 
         filtered = await self.filter_commands(group.commands, sort=self.sort_commands)
@@ -1326,7 +1326,7 @@ class MinimalHelpCommand(HelpCommand):
 
         await self.send_pages()
 
-    async def send_command_help(self, command):
+    async def send_command_help(self, command) -> None:
         self.add_command_formatting(command)
         self.paginator.close_page()
         await self.send_pages()

--- a/disnake/ext/commands/view.py
+++ b/disnake/ext/commands/view.py
@@ -58,7 +58,7 @@ class StringView:
         self.index += pos
         return self.previous != self.index
 
-    def skip_string(self, string) -> bool:
+    def skip_string(self, string: str) -> bool:
         strlen = len(string)
         if self.buffer[self.index : self.index + strlen] == string:
             self.previous = self.index

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -439,17 +439,17 @@ class SystemChannelFlags(BaseFlags, inverted=True):
             raise TypeError("Value to set for SystemChannelFlags must be a bool.")
 
     @flag_value
-    def join_notifications(self):
+    def join_notifications(self) -> int:
         """:class:`bool`: Returns ``True`` if the system channel is used for member join notifications."""
         return 1
 
     @flag_value
-    def premium_subscriptions(self):
+    def premium_subscriptions(self) -> int:
         """:class:`bool`: Returns ``True`` if the system channel is used for "Nitro boosting" notifications."""
         return 2
 
     @flag_value
-    def guild_reminder_notifications(self):
+    def guild_reminder_notifications(self) -> int:
         """:class:`bool`: Returns ``True`` if the system channel is used for server setup helpful tips notifications.
 
         .. versionadded:: 2.0
@@ -457,7 +457,7 @@ class SystemChannelFlags(BaseFlags, inverted=True):
         return 4
 
     @flag_value
-    def join_notification_replies(self):
+    def join_notification_replies(self) -> int:
         """:class:`bool`: Returns ``True`` if the system channel shows sticker reply
         buttons for member join notifications.
 
@@ -1706,7 +1706,7 @@ class MemberCacheFlags(BaseFlags):
         return self.value == self.DEFAULT_VALUE
 
     @flag_value
-    def voice(self):
+    def voice(self) -> int:
         """:class:`bool`: Whether to cache members that are in voice.
 
         This requires :attr:`Intents.voice_states`.
@@ -1716,7 +1716,7 @@ class MemberCacheFlags(BaseFlags):
         return 1
 
     @flag_value
-    def joined(self):
+    def joined(self) -> int:
         """:class:`bool`: Whether to cache members that joined the guild
         or are chunked as part of the initial log in flow.
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2545,7 +2545,7 @@ class Guild(Hashable):
 
     # TODO: Remove Optional typing here when async iterators are refactored
     def fetch_members(
-        self, *, limit: int = 1000, after: Optional[SnowflakeTime] = None
+        self, *, limit: Optional[int] = 1000, after: Optional[SnowflakeTime] = None
     ) -> MemberIterator:
         """Retrieves an :class:`.AsyncIterator` that enables receiving the guild's members. In order to use this,
         :meth:`Intents.members` must be enabled.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4719,7 +4719,7 @@ class GuildBuilder:
         The settings to use with the system channel.
     """
 
-    def __init__(self, *, state: ConnectionState, name: str):
+    def __init__(self, *, state: ConnectionState, name: str) -> None:
         self._state = state
         self.name: str = name
 

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -763,7 +763,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
 
 
 class MemberIterator(_AsyncIterator["Member"]):
-    def __init__(self, guild, limit: int = 1000, after=None) -> None:
+    def __init__(self, guild, limit: Optional[int] = 1000, after=None) -> None:
         if isinstance(after, datetime.datetime):
             after = Object(id=time_snowflake(after, high=True))
 

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -120,7 +120,7 @@ class _AsyncIterator(AsyncIterator[T]):
 
 
 class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
-    def __init__(self, iterator, max_size) -> None:
+    def __init__(self, iterator, max_size: int) -> None:
         self.iterator = iterator
         self.max_size = max_size
 
@@ -172,7 +172,7 @@ class _FilteredAsyncIterator(_AsyncIterator[T]):
 
 
 class ReactionIterator(_AsyncIterator[Union["User", "Member"]]):
-    def __init__(self, message, emoji, limit=100, after=None) -> None:
+    def __init__(self, message, emoji, limit: int = 100, after=None) -> None:
         self.message = message
         self.limit = limit
         self.after = after
@@ -674,7 +674,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         Object after which all guilds must be.
     """
 
-    def __init__(self, bot, limit, before=None, after=None) -> None:
+    def __init__(self, bot, limit: Optional[int], before=None, after=None) -> None:
         if isinstance(before, datetime.datetime):
             before = Object(id=time_snowflake(before, high=False))
         if isinstance(after, datetime.datetime):
@@ -763,7 +763,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
 
 
 class MemberIterator(_AsyncIterator["Member"]):
-    def __init__(self, guild, limit=1000, after=None) -> None:
+    def __init__(self, guild, limit: int = 1000, after=None) -> None:
         if isinstance(after, datetime.datetime):
             after = Object(id=time_snowflake(after, high=True))
 

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -120,7 +120,7 @@ class _AsyncIterator(AsyncIterator[T]):
 
 
 class _ChunkedAsyncIterator(_AsyncIterator[List[T]]):
-    def __init__(self, iterator, max_size: int) -> None:
+    def __init__(self, iterator: _AsyncIterator[T], max_size: int) -> None:
         self.iterator = iterator
         self.max_size = max_size
 

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -366,7 +366,7 @@ class FFmpegOpusAudio(FFmpegAudio):
         bitrate: int = 128,
         codec: Optional[str] = None,
         executable: str = "ffmpeg",
-        pipe=False,
+        pipe: bool = False,
         stderr=None,
         before_options=None,
         options=None,

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -243,7 +243,7 @@ class VoiceClient(VoiceProtocol):
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user
 
-    def checked_add(self, attr, value, limit: int) -> None:
+    def checked_add(self, attr: str, value: int, limit: int) -> None:
         val = getattr(self, attr)
         if val + value > limit:
             setattr(self, attr, 0)

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -243,7 +243,7 @@ class VoiceClient(VoiceProtocol):
         """:class:`ClientUser`: The user connected to voice (i.e. ourselves)."""
         return self._state.user
 
-    def checked_add(self, attr, value, limit) -> None:
+    def checked_add(self, attr, value, limit: int) -> None:
         val = getattr(self, attr)
         if val + value > limit:
             setattr(self, attr, 0)

--- a/noxfile.py
+++ b/noxfile.py
@@ -144,16 +144,8 @@ def autotyping(session: nox.Session) -> None:
         return
 
     # run the custom fixers
-    any_change_made = False
     for module, options in dir_options.items():
-        try:
-            session.run(*base_command, *module, *options, env=env)
-        except Exception as e:
-            session.log(e)
-            any_change_made = True
-
-    if any_change_made:
-        session.error("Typings were added")
+        session.run(*base_command, *module, *options, env=env)
 
 
 @nox.session(name="codemod")

--- a/noxfile.py
+++ b/noxfile.py
@@ -105,13 +105,7 @@ def autotyping(session: nox.Session):
     base_command = ["python", "-m", "libcst.tool", "codemod", "autotyping.AutotypeCommand"]
     commands = {
         "disnake": [
-            "--safe",
-            "--bool-param",
-            "--int-param",
-            "--float-param",
-            "--str-param",
-            "--bytes-param",
-            "--annotate-imprecise-magics",
+            "--aggressive",
         ],
         "examples": [
             "--scalar-return",

--- a/noxfile.py
+++ b/noxfile.py
@@ -187,7 +187,7 @@ def codemod(session: nox.Session):
         else:
             session.run("python", "-m", "libcst.tool", "list")
     if not session.interactive:
-        session.notify("autotyping")
+        session.notify("autotyping", posargs=[])
 
 
 @nox.session()

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,7 @@ reset_coverage = True
 
 
 @nox.session
-def docs(session: nox.Session):
+def docs(session: nox.Session) -> None:
     """Build and generate the documentation.
 
     If running locally, will build automatic reloading docs.
@@ -70,7 +70,7 @@ def docs(session: nox.Session):
 
 
 @nox.session
-def lint(session: nox.Session):
+def lint(session: nox.Session) -> None:
     """Check all files for linting errors"""
     session.run_always("pdm", "install", "-G", "tools", external=True)
 
@@ -78,7 +78,7 @@ def lint(session: nox.Session):
 
 
 @nox.session(name="check-manifest")
-def check_manifest(session: nox.Session):
+def check_manifest(session: nox.Session) -> None:
     """Run check-manifest."""
     # --no-self is provided here because check-manifest builds disnake. There's no reason to build twice, so we don't.
     session.run_always("pdm", "install", "--no-self", "-dG", "tools", external=True)
@@ -86,14 +86,14 @@ def check_manifest(session: nox.Session):
 
 
 @nox.session()
-def slotscheck(session: nox.Session):
+def slotscheck(session: nox.Session) -> None:
     """Run slotscheck."""
     session.run_always("pdm", "install", "-dG", "tools", external=True)
     session.run("python", "-m", "slotscheck", "--verbose", "-m", "disnake")
 
 
 @nox.session
-def autotyping(session: nox.Session):
+def autotyping(session: nox.Session) -> None:
     """Run autotyping.
 
     Because of the nature of changes that autotyping makes, and the goal design of examples,
@@ -125,6 +125,10 @@ def autotyping(session: nox.Session):
         "test_bot": [
             "--aggressive",
         ],
+        # also autotype this file
+        "noxfile.py": [
+            "--aggressive",
+        ],
     }
 
     if session.posargs:
@@ -154,7 +158,7 @@ def autotyping(session: nox.Session):
 
 
 @nox.session(name="codemod")
-def codemod(session: nox.Session):
+def codemod(session: nox.Session) -> None:
     """Run libcst codemods."""
     session.run_always("pdm", "install", "-dG", "codemod", external=True)
     if session.posargs and session.posargs[0] == "run-all" or not session.interactive:
@@ -191,7 +195,7 @@ def codemod(session: nox.Session):
 
 
 @nox.session()
-def pyright(session: nox.Session):
+def pyright(session: nox.Session) -> None:
     """Run pyright."""
     session.run_always("pdm", "install", "-d", "-Gspeed", "-Gdocs", "-Gvoice", external=True)
     env = {
@@ -213,7 +217,7 @@ def pyright(session: nox.Session):
         # ["voice"],
     ],
 )
-def test(session: nox.Session, extras: List[str]):
+def test(session: nox.Session, extras: List[str]) -> None:
     """Run tests."""
     # shell splitting is not done by nox
     extras = list(chain(*(["-G", extra] for extra in extras)))
@@ -238,7 +242,7 @@ def test(session: nox.Session, extras: List[str]):
 
 
 @nox.session()
-def coverage(session: nox.Session):
+def coverage(session: nox.Session) -> None:
     """Display coverage information from the tests."""
     session.run_always("pdm", "install", "-dG", "test", external=True)
     if "html" in session.posargs or "serve" in session.posargs:

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import pathlib
 from itertools import chain
 from typing import TYPE_CHECKING, Callable, List, TypeVar
 
@@ -135,9 +136,15 @@ def autotyping(session: nox.Session) -> None:
         # short circuit with the provided arguments
         # if there's just one file argument, give it the defaults that we normally use
         posargs = session.posargs.copy()
-        if len(posargs) == 1 and not posargs[0].startswith("--"):
-            module = posargs[0].split("/")[0]
-            posargs += commands.get(module, [])
+        if len(posargs) == 1 and not (path := posargs[0]).startswith("--"):
+            path = pathlib.Path(path).absolute()
+            try:
+                path = path.relative_to(pathlib.Path.cwd())
+            except ValueError:
+                pass
+            else:
+                module = path.parts[0]
+                posargs += commands.get(module, [])
         session.run(*base_command, *posargs, env=env)
         return
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -169,11 +169,17 @@ def codemod(session: nox.Session) -> None:
 
         for trans in transformers:
             # remove autotyping transformers
-            if trans.startswith("autotyping"):
+            if trans.startswith("autotyping."):
                 session.log("Skipping autotyping transformer.")
                 continue
             session.run(
-                "python", "-m", "libcst.tool", "codemod", trans, "disnake", "--hide-progress"
+                "python",
+                "-m",
+                "libcst.tool",
+                "codemod",
+                trans,
+                "disnake",
+                "--hide-progress",
             )
         session.log("Finished running all transformers.")
     else:

--- a/noxfile.py
+++ b/noxfile.py
@@ -102,7 +102,6 @@ def autotyping(session: nox.Session) -> None:
     """
     session.run_always("pdm", "install", "-dG", "codemod", external=True)
 
-    env = {"LIBCST_PARSER_TYPE": "native"}
     base_command = ["python", "-m", "libcst.tool", "codemod", "autotyping.AutotypeCommand"]
     dir_options: Dict[Tuple[str, ...], Tuple[str, ...]] = {
         (
@@ -140,12 +139,12 @@ def autotyping(session: nox.Session) -> None:
                         posargs += options
                         break
 
-        session.run(*base_command, *posargs, env=env)
+        session.run(*base_command, *posargs)
         return
 
     # run the custom fixers
     for module, options in dir_options.items():
-        session.run(*base_command, *module, *options, env=env)
+        session.run(*base_command, *module, *options)
 
 
 @nox.session(name="codemod")

--- a/noxfile.py
+++ b/noxfile.py
@@ -137,10 +137,7 @@ def autotyping(session: nox.Session) -> None:
         posargs = session.posargs.copy()
         if len(posargs) == 1 and not posargs[0].startswith("--"):
             module = posargs[0].split("/")[0]
-            try:
-                posargs += commands[module]
-            except KeyError:
-                pass
+            posargs += commands.get(module, [])
         session.run(*base_command, *posargs, env=env)
         return
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -134,7 +134,7 @@ def autotyping(session: nox.Session) -> None:
     if session.posargs:
         # short circuit with the provided arguments
         # if there's just one file argument, give it the defaults that we normally use
-        posargs = session.posargs
+        posargs = session.posargs.copy()
         if len(posargs) == 1 and not posargs[0].startswith("--"):
             module = posargs[0].split("/")[0]
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ codemod = [
     # run codemods on the respository (mostly automated typing)
     "libcst~=0.4.7",
     "black==23.1.0",
+    "autotyping==23.2.0",
 ]
 typing = [
     "typing-extensions~=4.2.0",

--- a/test_bot/__init__.py
+++ b/test_bot/__init__.py
@@ -14,7 +14,7 @@ logging.basicConfig(
 )
 
 
-def _log_to_file():
+def _log_to_file() -> None:
     log_format = logging.Formatter(_LOG_FORMAT)
 
     # Set up file logging

--- a/test_bot/__main__.py
+++ b/test_bot/__main__.py
@@ -27,7 +27,7 @@ def fancy_traceback(exc: Exception) -> str:
 
 
 class TestBot(commands.Bot):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             command_prefix=Config.prefix,
             intents=disnake.Intents.all(),
@@ -41,7 +41,7 @@ class TestBot(commands.Bot):
 
         self.i18n.load("test_bot/locale")
 
-    async def on_ready(self):
+    async def on_ready(self) -> None:
         # fmt: off
         print(
             f"\n"

--- a/test_bot/cogs/events.py
+++ b/test_bot/cogs/events.py
@@ -4,29 +4,29 @@ from disnake.ext import commands
 
 
 class EventListeners(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot) -> None:
         self.bot: commands.Bot = bot
 
     @commands.Cog.listener()
-    async def on_guild_scheduled_event_create(self, event):
+    async def on_guild_scheduled_event_create(self, event) -> None:
         print("Scheduled event create", repr(event), sep="\n", end="\n\n")
 
     @commands.Cog.listener()
-    async def on_guild_scheduled_event_update(self, before, after):
+    async def on_guild_scheduled_event_update(self, before, after) -> None:
         print("Scheduled event update", repr(before), repr(after), sep="\n", end="\n\n")
 
     @commands.Cog.listener()
-    async def on_guild_scheduled_event_delete(self, event):
+    async def on_guild_scheduled_event_delete(self, event) -> None:
         print("Scheduled event delete", repr(event), sep="\n", end="\n\n")
 
     @commands.Cog.listener()
-    async def on_guild_scheduled_event_subscribe(self, event, user):
+    async def on_guild_scheduled_event_subscribe(self, event, user) -> None:
         print("Scheduled event subscribe", event, user, sep="\n", end="\n\n")
 
     @commands.Cog.listener()
-    async def on_guild_scheduled_event_unsubscribe(self, event, user):
+    async def on_guild_scheduled_event_unsubscribe(self, event, user) -> None:
         print("Scheduled event unsubscribe", event, user, sep="\n", end="\n\n")
 
 
-def setup(bot):
+def setup(bot) -> None:
     bot.add_cog(EventListeners(bot))

--- a/test_bot/cogs/guild_scheduled_events.py
+++ b/test_bot/cogs/guild_scheduled_events.py
@@ -8,18 +8,20 @@ from disnake.ext import commands
 
 
 class GuildScheduledEvents(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     @commands.slash_command()
-    async def fetch_event(self, inter: disnake.GuildCommandInteraction, id: commands.LargeInt):
+    async def fetch_event(
+        self, inter: disnake.GuildCommandInteraction, id: commands.LargeInt
+    ) -> None:
         gse = await inter.guild.fetch_scheduled_event(id)
         await inter.response.send_message(str(gse.image))
 
     @commands.slash_command()
     async def edit_event(
         self, inter: disnake.GuildCommandInteraction, id: commands.LargeInt, new_image: bool
-    ):
+    ) -> None:
         await inter.response.defer()
         gse = await inter.guild.fetch_scheduled_event(id)
         image = disnake.File("./assets/banner.png")
@@ -32,7 +34,7 @@ class GuildScheduledEvents(commands.Cog):
     @commands.slash_command()
     async def create_event(
         self, inter: disnake.GuildCommandInteraction, name: str, channel: disnake.VoiceChannel
-    ):
+    ) -> None:
         image = disnake.File("./assets/banner.png")
         gse = await inter.guild.create_scheduled_event(
             name=name,
@@ -45,5 +47,5 @@ class GuildScheduledEvents(commands.Cog):
         await inter.response.send_message(str(gse.image))
 
 
-def setup(bot: commands.Bot):
+def setup(bot: commands.Bot) -> None:
     bot.add_cog(GuildScheduledEvents(bot))

--- a/test_bot/cogs/injections.py
+++ b/test_bot/cogs/injections.py
@@ -73,7 +73,7 @@ async def perhaps_this_is_it(
 
 
 class InjectionSlashCommands(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot) -> None:
         self.bot: commands.Bot = bot
         self.exponent = 2
 
@@ -94,7 +94,7 @@ class InjectionSlashCommands(commands.Cog):
         prefixed: str = commands.Param(converter=PrefixConverter("__", "__")),
         other: Tuple[int, str] = commands.inject(injected),
         some: int = commands.inject(injected_method),
-    ):
+    ) -> None:
         """A command gotten from explicit converts and injections
 
         Parameters
@@ -112,7 +112,7 @@ class InjectionSlashCommands(commands.Cog):
         inter: disnake.CommandInteraction,
         perhaps: PerhapsThis,
         god: Optional[HopeToGod] = None,
-    ):
+    ) -> None:
         """A command gotten just with annotations
 
         Parameters
@@ -123,5 +123,5 @@ class InjectionSlashCommands(commands.Cog):
         await inter.response.send_message(f"```py\n{pformat(locals())}\n```")
 
 
-def setup(bot):
+def setup(bot) -> None:
     bot.add_cog(InjectionSlashCommands(bot))

--- a/test_bot/cogs/localization.py
+++ b/test_bot/cogs/localization.py
@@ -10,7 +10,7 @@ from disnake.ext import commands
 
 
 class Localizations(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot) -> None:
         self.bot: commands.Bot = bot
 
     @commands.slash_command()
@@ -80,5 +80,5 @@ class Localizations(commands.Cog):
         await inter.response.send_message(msg.content[::-1])
 
 
-def setup(bot):
+def setup(bot) -> None:
     bot.add_cog(Localizations(bot))

--- a/test_bot/cogs/message_commands.py
+++ b/test_bot/cogs/message_commands.py
@@ -5,13 +5,13 @@ from disnake.ext import commands
 
 
 class MessageCommands(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot) -> None:
         self.bot: commands.Bot = bot
 
     @commands.message_command(name="Reverse")
-    async def reverse(self, inter: disnake.MessageCommandInteraction):
+    async def reverse(self, inter: disnake.MessageCommandInteraction) -> None:
         await inter.response.send_message(inter.target.content[::-1])
 
 
-def setup(bot):
+def setup(bot) -> None:
     bot.add_cog(MessageCommands(bot))

--- a/test_bot/cogs/misc.py
+++ b/test_bot/cogs/misc.py
@@ -8,7 +8,7 @@ from disnake.ext import commands
 
 
 class Misc(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot) -> None:
         self.bot: commands.Bot = bot
 
     def _get_file(self, description: str) -> disnake.File:
@@ -48,5 +48,5 @@ class Misc(commands.Cog):
         await inter.response.send_message(".", view=view)
 
 
-def setup(bot):
+def setup(bot) -> None:
     bot.add_cog(Misc(bot))

--- a/test_bot/cogs/slash_commands.py
+++ b/test_bot/cogs/slash_commands.py
@@ -6,20 +6,20 @@ import disnake
 from disnake.ext import commands
 
 
-async def test_autocomp(inter, string):
+async def test_autocomp(inter, string: str):
     return ["XD", ":D", ":)", ":|", ":("]
 
 
 class SlashCommands(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot) -> None:
         self.bot: commands.Bot = bot
 
     @commands.slash_command()
-    async def hello(self, inter: disnake.CommandInteraction):
+    async def hello(self, inter: disnake.CommandInteraction) -> None:
         await inter.response.send_message("Hello world!")
 
     @commands.slash_command()
-    async def auto(self, inter: disnake.CommandInteraction, mood: str):
+    async def auto(self, inter: disnake.CommandInteraction, mood: str) -> None:
         """
         Has an autocomplete option.
 
@@ -38,13 +38,13 @@ class SlashCommands(commands.Cog):
         self,
         inter: disnake.AppCmdInter,
         mood: str = commands.Param(autocomplete=test_autocomp),
-    ):
+    ) -> None:
         await inter.send(mood)
 
     @commands.slash_command()
     async def guild_only(
         self, inter: disnake.GuildCommandInteraction, option: Optional[str] = None
-    ):
+    ) -> None:
         await inter.send(f"guild: {inter.guild} | option: {option!r}")
 
     @commands.slash_command()
@@ -55,7 +55,7 @@ class SlashCommands(commands.Cog):
         b: Optional[commands.Range[1, ...]] = None,
         c: Optional[commands.Range[0, 10]] = None,
         d: Optional[commands.Range[0, 10.0]] = None,
-    ):
+    ) -> None:
         """limit slash command options to a range of values
 
         Parameters
@@ -68,9 +68,11 @@ class SlashCommands(commands.Cog):
         await inter.send(f"{inter.options}")
 
     @commands.slash_command()
-    async def largenumber(self, inter: disnake.CommandInteraction, largenum: commands.LargeInt):
+    async def largenumber(
+        self, inter: disnake.CommandInteraction, largenum: commands.LargeInt
+    ) -> None:
         await inter.send(f"Is int: {isinstance(largenum, int)}")
 
 
-def setup(bot):
+def setup(bot) -> None:
     bot.add_cog(SlashCommands(bot))

--- a/test_bot/cogs/user_commands.py
+++ b/test_bot/cogs/user_commands.py
@@ -5,13 +5,13 @@ from disnake.ext import commands
 
 
 class UserCommands(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot) -> None:
         self.bot: commands.Bot = bot
 
     @commands.user_command(name="Avatar")
-    async def avatar(self, inter: disnake.UserCommandInteraction, user: disnake.User):
+    async def avatar(self, inter: disnake.UserCommandInteraction, user: disnake.User) -> None:
         await inter.response.send_message(user.display_avatar.url, ephemeral=True)
 
 
-def setup(bot):
+def setup(bot) -> None:
     bot.add_cog(UserCommands(bot))

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -7,20 +7,20 @@ from disnake.ext import commands
 
 
 class TestDefaultPermissions:
-    def test_decorator(self):
+    def test_decorator(self) -> None:
         class Cog(commands.Cog):
             @commands.slash_command(default_member_permissions=64)
-            async def cmd(self, _):
+            async def cmd(self, _) -> None:
                 ...
 
             @commands.default_member_permissions(64)
             @commands.slash_command()
-            async def above(self, _):
+            async def above(self, _) -> None:
                 ...
 
             @commands.slash_command()
             @commands.default_member_permissions(64)
-            async def below(self, _):
+            async def below(self, _) -> None:
                 ...
 
         for c in (Cog, Cog()):
@@ -28,14 +28,14 @@ class TestDefaultPermissions:
             assert c.above.default_member_permissions == Permissions(64)
             assert c.below.default_member_permissions == Permissions(64)
 
-    def test_decorator_overwrite(self):
+    def test_decorator_overwrite(self) -> None:
         # putting the decorator above should fail
         with pytest.raises(ValueError, match="Cannot set `default_member_permissions`"):
 
             class Cog(commands.Cog):
                 @commands.default_member_permissions(32)
                 @commands.slash_command(default_member_permissions=64)
-                async def above(self, _):
+                async def above(self, _) -> None:
                     ...
 
         # putting the decorator below shouldn't fail
@@ -45,30 +45,30 @@ class TestDefaultPermissions:
         class Cog2(commands.Cog):
             @commands.slash_command(default_member_permissions=64)
             @commands.default_member_permissions(32)
-            async def below(self, _):
+            async def below(self, _) -> None:
                 ...
 
         for c in (Cog2, Cog2()):
             assert c.below.default_member_permissions == Permissions(32)
 
-    def test_attrs(self):
+    def test_attrs(self) -> None:
         class Cog(commands.Cog, slash_command_attrs={"default_member_permissions": 32}):
             @commands.slash_command()
-            async def no_overwrite(self, _):
+            async def no_overwrite(self, _) -> None:
                 ...
 
             @commands.slash_command(default_member_permissions=64)
-            async def overwrite(self, _):
+            async def overwrite(self, _) -> None:
                 ...
 
             @commands.default_member_permissions(64)
             @commands.slash_command()
-            async def overwrite_decorator_above(self, _):
+            async def overwrite_decorator_above(self, _) -> None:
                 ...
 
             @commands.slash_command()
             @commands.default_member_permissions(64)
-            async def overwrite_decorator_below(self, _):
+            async def overwrite_decorator_below(self, _) -> None:
                 ...
 
         assert Cog.no_overwrite.default_member_permissions is None

--- a/tests/ext/commands/test_core.py
+++ b/tests/ext/commands/test_core.py
@@ -25,7 +25,7 @@ class CustomCog(commands.Cog):
 
 
 class TestDecorators:
-    def _test_typing_defaults(self):
+    def _test_typing_defaults(self) -> None:
         base = commands.GroupMixin[None]()
 
         # no cog
@@ -63,7 +63,7 @@ class TestDecorators:
                 expected_text="Group[CustomCog, (a: int, b: str), bool]",
             )
 
-    def _test_typing_cls(self):
+    def _test_typing_cls(self) -> None:
         class CustomCommand(commands.Command):
             ...
 

--- a/tests/ext/commands/test_slash_core.py
+++ b/tests/ext/commands/test_slash_core.py
@@ -8,45 +8,45 @@ class TestParents:
     def _create_cog(self):
         class Cog(commands.Cog):
             @commands.slash_command()
-            async def a(self, _):
+            async def a(self, _) -> None:
                 ...
 
             @a.sub_command()
-            async def sub(self, _):
+            async def sub(self, _) -> None:
                 ...
 
             @a.sub_command_group()
-            async def group(self, _):
+            async def group(self, _) -> None:
                 ...
 
             @group.sub_command()
-            async def subsub(self, _):
+            async def subsub(self, _) -> None:
                 ...
 
         return Cog()
 
-    def test_parent(self):
+    def test_parent(self) -> None:
         cog = self._create_cog()
         assert cog.a.parent is None
         assert cog.sub.parent is cog.a
         assert cog.group.parent is cog.a
         assert cog.subsub.parent is cog.group
 
-    def test_qualified_name(self):
+    def test_qualified_name(self) -> None:
         cog = self._create_cog()
         assert cog.a.qualified_name == "a"
         assert cog.sub.qualified_name == "a sub"
         assert cog.group.qualified_name == "a group"
         assert cog.subsub.qualified_name == "a group subsub"
 
-    def test_root_parent(self):
+    def test_root_parent(self) -> None:
         cog = self._create_cog()
         assert cog.a.root_parent is None
         assert cog.sub.root_parent is cog.a
         assert cog.group.root_parent is cog.a
         assert cog.subsub.root_parent is cog.a
 
-    def test_parents(self):
+    def test_parents(self) -> None:
         cog = self._create_cog()
         assert cog.a.parents == ()
         assert cog.sub.parents == (cog.a,)

--- a/tests/ext/commands/test_view.py
+++ b/tests/ext/commands/test_view.py
@@ -22,7 +22,7 @@ class TestStringView:
             ('hone"stl"y, quotes.', 'hone"stl"y,'),
         ],
     )
-    def test_get_word(self, text, expected_word):
+    def test_get_word(self, text: str, expected_word) -> None:
         view = StringView(text)
 
         word = view.get_word()
@@ -39,7 +39,7 @@ class TestStringView:
             ("''", "''"),
         ],
     )
-    def test_get_quoted_word(self, text, expected_word):
+    def test_get_quoted_word(self, text: str, expected_word) -> None:
         view = StringView(text)
 
         word = view.get_quoted_word()
@@ -55,7 +55,7 @@ class TestStringView:
             ('"test\\', ExpectedClosingQuoteError),
         ],
     )
-    def test_get_quoted_word_raises(self, text, exception):
+    def test_get_quoted_word_raises(self, text: str, exception) -> None:
         view = StringView(text)
 
         with pytest.raises(exception):

--- a/tests/ext/tasks/test_loops.py
+++ b/tests/ext/tasks/test_loops.py
@@ -10,7 +10,7 @@ from disnake.ext.tasks import LF, Loop, loop
 
 
 class TestLoops:
-    def test_decorator(self):
+    def test_decorator(self) -> None:
         class Cog(commands.Cog):
             @loop(seconds=30, minutes=0, hours=0)
             async def task(self) -> None:
@@ -25,8 +25,8 @@ class TestLoops:
             def task() -> None:
                 ...
 
-    def test_mixing_time(self):
-        async def callback():
+    def test_mixing_time(self) -> None:
+        async def callback() -> None:
             pass
 
         with pytest.raises(TypeError):
@@ -38,7 +38,7 @@ class TestLoops:
             async def task() -> None:
                 ...
 
-    def test_inheritance(self):
+    def test_inheritance(self) -> None:
         class HyperLoop(Loop[LF]):
             def __init__(self, coro: LF, time_tup: Tuple[float, float, float]) -> None:
                 s, m, h = time_tup
@@ -60,7 +60,7 @@ class TestLoops:
             def __init__(self, coro: Any) -> None:
                 ...
 
-        async def callback():
+        async def callback() -> None:
             pass
 
         HyperLoop(callback, (1, 2, 3))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,7 +29,7 @@ class freeze_time(ContextManager):
     # i know `freezegun` exists, but it's rather complex and does much more than
     # we really need here, and I'm unsure if it would interfere with `looptime`
 
-    def __init__(self, dt: Optional[datetime.datetime] = None):
+    def __init__(self, dt: Optional[datetime.datetime] = None) -> None:
         dt = dt or datetime.datetime.now(datetime.timezone.utc)
         assert dt.tzinfo
 

--- a/tests/interactions/test_base.py
+++ b/tests/interactions/test_base.py
@@ -86,7 +86,7 @@ class TestInteractionResponse:
     )
     async def test_defer(
         self, response: disnake.InteractionResponse, adapter, parent_type, with_message, expected
-    ):
+    ) -> None:
         response._parent.type = parent_type
 
         await response.defer(with_message=with_message)
@@ -106,7 +106,7 @@ class TestInteractionResponse:
     )
     async def test_defer_ephemeral(
         self, response: disnake.InteractionResponse, adapter, with_message, expected_data
-    ):
+    ) -> None:
         response._parent.type = disnake.InteractionType.component
 
         await response.defer(with_message=with_message, ephemeral=True)
@@ -118,7 +118,9 @@ class TestInteractionResponse:
             data=expected_data,
         )
 
-    async def test_defer_invalid_parent(self, response: disnake.InteractionResponse, adapter):
+    async def test_defer_invalid_parent(
+        self, response: disnake.InteractionResponse, adapter
+    ) -> None:
         # autocomplete can't be deferred
         response._parent.type = disnake.InteractionType.application_command_autocomplete
 
@@ -135,7 +137,7 @@ class TestInteractionDataResolved:
         s._get_guild.return_value = None
         return s
 
-    def test_init_member(self, state):
+    def test_init_member(self, state) -> None:
         member_payload: MemberPayload = {
             "roles": [],
             "joined_at": "2022-09-02T22:00:55.069000+00:00",
@@ -179,7 +181,7 @@ class TestInteractionDataResolved:
         assert len(resolved.users) == 0
 
     @pytest.mark.parametrize("channel_type", [t.value for t in disnake.ChannelType])
-    def test_channel(self, state, channel_type):
+    def test_channel(self, state, channel_type) -> None:
         channel_data: ResolvedPartialChannelPayload = {
             "id": "42",
             "type": channel_type,

--- a/tests/test_colour.py
+++ b/tests/test_colour.py
@@ -8,7 +8,7 @@ import pytest
 from disnake import Color, Colour
 
 
-def test_init():
+def test_init() -> None:
     with pytest.raises(TypeError, match=r"Expected int parameter, received str instead."):
         Colour("0")  # type: ignore
 
@@ -16,11 +16,11 @@ def test_init():
 @pytest.mark.parametrize(
     ("value", "string"), [(0, "#000000"), (0x123, "#000123"), (0x12AB34, "#12ab34")]
 )
-def test_str(value: int, string: str):
+def test_str(value: int, string: str) -> None:
     assert str(Colour(value)) == string
 
 
-def test_compare():
+def test_compare() -> None:
     assert Colour(123) == Colour(123)
 
 
@@ -28,7 +28,7 @@ def test_compare():
     ("value", "parts"),
     [(0, (0, 0, 0)), (0xA00233, (0xA0, 0x02, 0x33)), (0x123456, (0x12, 0x34, 0x56))],
 )
-def test_to_rgb(value: int, parts: Tuple[int, int, int]):
+def test_to_rgb(value: int, parts: Tuple[int, int, int]) -> None:
     c = Colour(value)
     assert c.to_rgb() == parts
     assert (c.r, c.g, c.b) == parts
@@ -38,7 +38,7 @@ def test_to_rgb(value: int, parts: Tuple[int, int, int]):
     ("value", "parts"),
     [(0, (0, 0, 0)), (0xA00233, (0xA0, 0x02, 0x33)), (0x123456, (0x12, 0x34, 0x56))],
 )
-def test_from_rgb(value: int, parts: Tuple[int, int, int]):
+def test_from_rgb(value: int, parts: Tuple[int, int, int]) -> None:
     assert Colour.from_rgb(*parts).value == value
 
 
@@ -50,11 +50,11 @@ def test_from_rgb(value: int, parts: Tuple[int, int, int]):
         (0x5CCFF9, (196 / 360, 63 / 100, 98 / 100)),
     ],
 )
-def test_from_hsv(value: int, parts: Tuple[float, float, float]):
+def test_from_hsv(value: int, parts: Tuple[float, float, float]) -> None:
     expected = Colour(value)
     col = Colour.from_hsv(*parts)
     assert all(math.isclose(a, b, abs_tol=1) for a, b in zip(expected.to_rgb(), col.to_rgb()))
 
 
-def test_alias():
+def test_alias() -> None:
     assert Color is Colour

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -43,5 +43,5 @@ from disnake.http import HTTPClient
         ),
     ],
 )
-def test_format_gateway_url(url: str, encoding: str, zlib: bool, expected: str):
+def test_format_gateway_url(url: str, encoding: str, zlib: bool, expected: str) -> None:
     assert HTTPClient._format_gateway_url(url, encoding=encoding, zlib=zlib) == expected

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -17,7 +17,7 @@ from disnake.utils import MISSING
         "👩‍👩‍👧‍👦",
     ],
 )
-def test_convert_emoji_reaction__standard(emoji):
+def test_convert_emoji_reaction__standard(emoji) -> None:
     assert message.convert_emoji_reaction(emoji) == emoji
 
 
@@ -31,7 +31,7 @@ def test_convert_emoji_reaction__standard(emoji):
         "<a:test:1234>",
     ],
 )
-def test_convert_emoji_reaction__custom(emoji):
+def test_convert_emoji_reaction__custom(emoji) -> None:
     assert message.convert_emoji_reaction(emoji) == "test:1234"
 
 
@@ -53,5 +53,5 @@ def _create_emoji(animated: bool) -> disnake.Emoji:
         (_create_emoji(True)._to_partial(), "test:1234"),
     ],
 )
-def test_convert_emoji_reaction__object(emoji, expected):
+def test_convert_emoji_reaction__object(emoji, expected) -> None:
     assert message.convert_emoji_reaction(emoji) == expected

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -9,21 +9,21 @@ from disnake import Object
 snowflake = 881536165478499999  # date/time of first commit
 
 
-def test_init():
+def test_init() -> None:
     with pytest.raises(
         TypeError, match=r"id parameter must be convertable to int not <class 'str'>"
     ):
         Object("hi")
 
 
-def test_compare():
+def test_compare() -> None:
     assert Object(42) == Object(42)
     assert Object(42) != Object(43)
 
 
-def test_hash():
+def test_hash() -> None:
     assert hash(Object(snowflake)) == 210174600000
 
 
-def test_created_at():
+def test_created_at() -> None:
     assert Object(snowflake).created_at == datetime(2021, 8, 29, 13, 50, 0, tzinfo=timezone.utc)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -168,7 +168,7 @@ class TestPermissions:
         perms.handle_overwrite(allow, deny)
         assert perms.value == expected
 
-    def test_none_is_none(self):
+    def test_none_is_none(self) -> None:
         perms = Permissions.none()
         assert perms.value == 0
 
@@ -189,7 +189,7 @@ class TestPermissions:
             "private_channel",
         ],
     )
-    def test_classmethods(self, method_name: str):
+    def test_classmethods(self, method_name: str) -> None:
         method = getattr(Permissions, method_name)
 
         perms: Permissions = method()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,12 +20,12 @@ from disnake import utils
 from . import helpers
 
 
-def test_missing():
+def test_missing() -> None:
     assert utils.MISSING != utils.MISSING
     assert not bool(utils.MISSING)
 
 
-def test_cached_property():
+def test_cached_property() -> None:
     class Test:
         @utils.cached_property
         def prop(self) -> object:
@@ -38,7 +38,7 @@ def test_cached_property():
     assert isinstance(Test.prop, utils.cached_property)
 
 
-def test_cached_slot_property():
+def test_cached_slot_property() -> None:
     class Test:
         __slots__ = ("_cs_prop",)
 
@@ -53,14 +53,14 @@ def test_cached_slot_property():
     assert isinstance(Test.prop, utils.CachedSlotProperty)
 
 
-def test_parse_time():
+def test_parse_time() -> None:
     assert utils.parse_time(None) is None
     assert utils.parse_time("2021-08-29T13:50:00+00:00") == datetime.datetime(
         2021, 8, 29, 13, 50, 0, tzinfo=timezone.utc
     )
 
 
-def test_copy_doc():
+def test_copy_doc() -> None:
     def func(num: int, *, arg: str) -> float:
         """returns the best number"""
         ...
@@ -78,7 +78,7 @@ def test_copy_doc():
     ("instead", "msg"),
     [(None, "stuff is deprecated."), ("other", "stuff is deprecated, use other instead.")],
 )
-def test_deprecated(mock_warn: mock.Mock, instead, msg):
+def test_deprecated(mock_warn: mock.Mock, instead, msg) -> None:
     @utils.deprecated(instead)
     def stuff(num: int) -> int:
         return num
@@ -115,7 +115,7 @@ def test_deprecated(mock_warn: mock.Mock, instead, msg):
         ),
     ],
 )
-def test_oauth_url(expected, perms, guild, redirect, scopes, disable_select):
+def test_oauth_url(expected, perms, guild, redirect, scopes, disable_select) -> None:
     url = utils.oauth_url(
         1234,
         permissions=perms,
@@ -127,7 +127,7 @@ def test_oauth_url(expected, perms, guild, redirect, scopes, disable_select):
     assert dict(yarl.URL(url).query) == {"client_id": "1234", **expected}
 
 
-def test_parse_token():
+def test_parse_token() -> None:
     # don't get your hopes up, this token isn't valid.
     # taken from https://guide.disnake.dev/getting-started/initial-files
     token = "OTA4MjgxMjk4NTU1MTA5Mzk2.YYzc4A.TB7Ng6DOnVDlpMS4idjGptsreFg"  # noqa: S105
@@ -146,7 +146,7 @@ def test_parse_token():
         (10000000000000000000, datetime.datetime(2090, 7, 20, 17, 49, 51, tzinfo=timezone.utc)),
     ],
 )
-def test_snowflake_time(num, expected):
+def test_snowflake_time(num: int, expected) -> None:
     assert utils.snowflake_time(num).replace(microsecond=0) == expected
 
 
@@ -157,7 +157,7 @@ def test_snowflake_time(num, expected):
         (datetime.datetime(2021, 8, 29, 13, 50, 0, tzinfo=timezone.utc), 881536165478400000),
     ],
 )
-def test_time_snowflake(dt, expected):
+def test_time_snowflake(dt, expected) -> None:
     low = utils.time_snowflake(dt)
     assert low == expected
 
@@ -166,7 +166,7 @@ def test_time_snowflake(dt, expected):
     assert high + 1 == utils.time_snowflake(dt + timedelta(milliseconds=1))
 
 
-def test_find():
+def test_find() -> None:
     pred = lambda i: i == 42  # type: ignore
     assert utils.find(pred, []) is None
     assert utils.find(pred, [42]) == 42
@@ -177,7 +177,7 @@ def test_find():
     assert utils.find(pred, lst) is lst[1]
 
 
-def test_get():
+def test_get() -> None:
     @dataclass
     class A:
         value: int
@@ -214,7 +214,7 @@ def test_get():
         ([2, 1], [2, 1]),
     ],
 )
-def test_unique(it, expected):
+def test_unique(it, expected) -> None:
     assert utils._unique(it) == expected
 
 
@@ -228,11 +228,11 @@ def test_unique(it, expected):
         ({"key": "42"}, 42),
     ],
 )
-def test_get_as_snowflake(data, expected):
+def test_get_as_snowflake(data, expected) -> None:
     assert utils._get_as_snowflake(data, "key") == expected
 
 
-def test_maybe_cast():
+def test_maybe_cast() -> None:
     convert = lambda v: v + 1  # type: ignore
     default = object()
 
@@ -256,7 +256,7 @@ def test_maybe_cast():
         (b"RIFFxxxxWEBP", "image/webp", ".webp"),
     ],
 )
-def test_mime_type_valid(data, expected_mime, expected_ext):
+def test_mime_type_valid(data, expected_mime, expected_ext) -> None:
     for d in (data, data + b"\xFF"):
         assert utils._get_mime_type_for_image(d) == expected_mime
         assert utils._get_extension_for_image(d) == expected_ext
@@ -277,14 +277,14 @@ def test_mime_type_valid(data, expected_mime, expected_ext):
         b"",
     ],
 )
-def test_mime_type_invalid(data):
+def test_mime_type_invalid(data) -> None:
     with pytest.raises(ValueError, match=r"Unsupported image type given"):
         utils._get_mime_type_for_image(data)
     assert utils._get_extension_for_image(data) is None
 
 
 @pytest.mark.asyncio
-async def test_assetbytes_base64():
+async def test_assetbytes_base64() -> None:
     assert await utils._assetbytes_to_base64_data(None) is None
 
     # test bytes
@@ -312,7 +312,7 @@ async def test_assetbytes_base64():
     ],
 )
 @helpers.freeze_time()
-def test_parse_ratelimit_header(after, use_clock, expected):
+def test_parse_ratelimit_header(after, use_clock, expected) -> None:
     reset_time = utils.utcnow() + timedelta(seconds=7)
 
     request = mock.Mock()
@@ -331,7 +331,7 @@ def test_parse_ratelimit_header(after, use_clock, expected):
     ],
 )
 @pytest.mark.asyncio
-async def test_maybe_coroutine(func: mock.Mock):
+async def test_maybe_coroutine(func: mock.Mock) -> None:
     assert await utils.maybe_coroutine(func, 42, arg="uwu") is func.return_value
     func.assert_called_once_with(42, arg="uwu")
 
@@ -348,13 +348,13 @@ async def test_maybe_coroutine(func: mock.Mock):
     ],
 )
 @pytest.mark.asyncio
-async def test_async_all(mock_type, gen, expected):
+async def test_async_all(mock_type, gen, expected) -> None:
     assert await utils.async_all(mock_type(return_value=x)() for x in gen) is expected
 
 
 @pytest.mark.looptime
 @pytest.mark.asyncio
-async def test_sane_wait_for(looptime):
+async def test_sane_wait_for(looptime) -> None:
     times = [10, 50, 25]
 
     def create():
@@ -377,7 +377,7 @@ async def test_sane_wait_for(looptime):
     assert all(t.done() for t in tasks)
 
 
-def test_get_slots():
+def test_get_slots() -> None:
     class A:
         __slots__ = ("a", "a2")
 
@@ -406,7 +406,7 @@ def test_get_slots():
 )
 @pytest.mark.parametrize(("delta", "expected"), [(7, 7), (-100, 0)])
 @helpers.freeze_time()
-def test_compute_timedelta(tz, delta, expected):
+def test_compute_timedelta(tz, delta, expected) -> None:
     dt = datetime.datetime.now()  # noqa: DTZ005
     if tz is not utils.MISSING:
         dt = dt.astimezone(tz)
@@ -417,17 +417,17 @@ def test_compute_timedelta(tz, delta, expected):
 @pytest.mark.looptime
 @pytest.mark.asyncio
 @helpers.freeze_time()
-async def test_sleep_until(looptime, delta, expected):
+async def test_sleep_until(looptime, delta, expected) -> None:
     o = object()
     assert await utils.sleep_until(utils.utcnow() + timedelta(seconds=delta), o) is o
     assert looptime == expected
 
 
-def test_utcnow():
+def test_utcnow() -> None:
     assert utils.utcnow().tzinfo == timezone.utc
 
 
-def test_valid_icon_size():
+def test_valid_icon_size() -> None:
     for s in (2**x for x in range(4, 13)):
         assert utils.valid_icon_size(s)
 
@@ -436,7 +436,7 @@ def test_valid_icon_size():
 
 
 @pytest.mark.parametrize(("s", "expected"), [("a一b", 4), ("abc", 3)])
-def test_string_width(s, expected):
+def test_string_width(s, expected) -> None:
     assert utils._string_width(s) == expected
 
 
@@ -452,7 +452,7 @@ def test_string_width(s, expected):
     ],
 )
 @pytest.mark.parametrize("with_params", [False, True])
-def test_resolve_invite(url, params, expected, with_params):
+def test_resolve_invite(url, params, expected, with_params) -> None:
     res = utils.resolve_invite(url, with_params=with_params)
     if with_params:
         assert res == (expected, params)
@@ -471,7 +471,7 @@ def test_resolve_invite(url, params, expected, with_params):
         ("https://discordapp.com/template/disnake", "disnake"),
     ],
 )
-def test_resolve_template(url, expected):
+def test_resolve_template(url, expected) -> None:
     assert utils.resolve_template(url) == expected
 
 
@@ -498,7 +498,7 @@ def test_resolve_template(url, expected):
         ),
     ],
 )
-def test_markdown(text, exp_remove, exp_escape):
+def test_markdown(text: str, exp_remove, exp_escape) -> None:
     assert utils.remove_markdown(text, ignore_links=False) == exp_remove
     assert utils.remove_markdown(text, ignore_links=True) == exp_remove
 
@@ -521,7 +521,7 @@ def test_markdown(text, exp_remove, exp_escape):
         ),
     ],
 )
-def test_markdown_links(text, expected, expected_ignore):
+def test_markdown_links(text: str, expected, expected_ignore) -> None:
     assert utils.remove_markdown(text, ignore_links=False) == expected
     assert utils.remove_markdown(text, ignore_links=True) == expected_ignore
 
@@ -536,7 +536,7 @@ def test_markdown_links(text, expected, expected_ignore):
         ("<@&12341234123412341>", "<@\u200b&12341234123412341>"),
     ],
 )
-def test_escape_mentions(text, expected):
+def test_escape_mentions(text: str, expected) -> None:
     assert utils.escape_mentions(text) == expected
 
 
@@ -590,8 +590,8 @@ def test_escape_mentions(text, expected):
         ),
     ],
 )
-def test_parse_docstring_desc(docstring, expected):
-    def f():
+def test_parse_docstring_desc(docstring: str, expected) -> None:
+    def f() -> None:
         ...
 
     f.__doc__ = docstring
@@ -650,8 +650,8 @@ def test_parse_docstring_desc(docstring, expected):
         ),
     ],
 )
-def test_parse_docstring_param(docstring, expected):
-    def f():
+def test_parse_docstring_param(docstring: str, expected) -> None:
+    def f() -> None:
         ...
 
     f.__doc__ = docstring
@@ -662,8 +662,8 @@ def test_parse_docstring_param(docstring, expected):
     assert utils.parse_docstring(f)["params"] == expected  # ignore description
 
 
-def test_parse_docstring_localizations():
-    def f():
+def test_parse_docstring_localizations() -> None:
+    def f() -> None:
         """
         Does stuff. {{cool_key}}
 
@@ -708,7 +708,7 @@ def test_parse_docstring_localizations():
 )
 @pytest.mark.parametrize("sync", [False, True])
 @pytest.mark.asyncio
-async def test_as_chunks(sync, it, max_size, expected):
+async def test_as_chunks(sync, it, max_size: int, expected) -> None:
     if sync:
         assert list(utils.as_chunks(it, max_size)) == expected
     else:
@@ -721,7 +721,7 @@ async def test_as_chunks(sync, it, max_size, expected):
 
 
 @pytest.mark.parametrize("max_size", [-1, 0])
-def test_as_chunks_size(max_size):
+def test_as_chunks_size(max_size: int) -> None:
     with pytest.raises(ValueError, match=r"Chunk sizes must be greater than 0."):
         utils.as_chunks(iter([]), max_size)
 
@@ -736,7 +736,7 @@ def test_as_chunks_size(max_size):
         ([Literal[1, 1, 2, 3, 3]], (1, 2, 3)),
     ],
 )
-def test_flatten_literal_params(params, expected):
+def test_flatten_literal_params(params, expected) -> None:
     assert utils.flatten_literal_params(params) == expected
 
 
@@ -747,7 +747,7 @@ NoneType = type(None)
     ("params", "expected"),
     [([NoneType], (NoneType,)), ([NoneType, int, NoneType, float], (int, float, NoneType))],
 )
-def test_normalise_optional_params(params, expected):
+def test_normalise_optional_params(params, expected) -> None:
     assert utils.normalise_optional_params(params) == expected
 
 
@@ -777,7 +777,7 @@ def test_normalise_optional_params(params, expected):
         ),
     ],
 )
-def test_resolve_annotation(tp, expected, expected_cache):
+def test_resolve_annotation(tp, expected, expected_cache) -> None:
     cache = {}
     result = utils.resolve_annotation(tp, globals(), locals(), cache)
     assert result == expected
@@ -789,7 +789,7 @@ def test_resolve_annotation(tp, expected, expected_cache):
         assert utils.resolve_annotation(tp, globals(), locals(), cache) is result
 
 
-def test_resolve_annotation_literal():
+def test_resolve_annotation_literal() -> None:
     with pytest.raises(
         TypeError, match=r"Literal arguments must be of type str, int, bool, or NoneType."
     ):
@@ -804,7 +804,7 @@ def test_resolve_annotation_literal():
         (datetime.datetime(2021, 8, 29, 13, 50, 0, tzinfo=timezone.utc), "f", "<t:1630245000:f>"),
     ],
 )
-def test_format_dt(dt, style, expected):
+def test_format_dt(dt, style, expected) -> None:
     assert utils.format_dt(dt, style) == expected
 
 
@@ -834,7 +834,7 @@ def tmp_module_root(tmp_path_factory):
         ("empty/", []),
     ],
 )
-def test_search_directory(tmp_module_root, path, expected):
+def test_search_directory(tmp_module_root, path, expected) -> None:
     orig_cwd = os.getcwd()
     try:
         os.chdir(tmp_module_root)
@@ -854,7 +854,7 @@ def test_search_directory(tmp_module_root, path, expected):
         ("test.py", r"Provided path '.*?test.py' is not a directory"),
     ],
 )
-def test_search_directory_exc(tmp_module_root, path, exc):
+def test_search_directory_exc(tmp_module_root, path, exc) -> None:
     orig_cwd = os.getcwd()
     try:
         os.chdir(tmp_module_root)
@@ -876,7 +876,7 @@ def test_search_directory_exc(tmp_module_root, path, exc):
         ("de_DE", "de"),
     ],
 )
-def test_as_valid_locale(locale, expected):
+def test_as_valid_locale(locale, expected) -> None:
     assert utils.as_valid_locale(locale) == expected
 
 
@@ -890,5 +890,5 @@ def test_as_valid_locale(locale, expected):
         (["one", "two", "three", "four"], "one, two, three, plus four"),
     ],
 )
-def test_humanize_list(values, expected):
+def test_humanize_list(values, expected) -> None:
     assert utils.humanize_list(values, "plus") == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -590,7 +590,7 @@ def test_escape_mentions(text: str, expected) -> None:
         ),
     ],
 )
-def test_parse_docstring_desc(docstring: str, expected) -> None:
+def test_parse_docstring_desc(docstring: Optional[str], expected) -> None:
     def f() -> None:
         ...
 

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -32,10 +32,10 @@ class TestActionRow:
             ([select], 5),
         ],
     )
-    def test_width(self, value, expected):
+    def test_width(self, value, expected) -> None:
         assert ActionRow(*value).width == expected
 
-    def test_append_item(self):
+    def test_append_item(self) -> None:
         r = ActionRow()
         r.append_item(button1)
         r.append_item(button2)
@@ -45,7 +45,7 @@ class TestActionRow:
 
         assert list(r.children) == [button1, button2]
 
-    def test_insert_item(self):
+    def test_insert_item(self) -> None:
         r = ActionRow()
         r.insert_item(0, button1)
         r.insert_item(0, button2)
@@ -57,7 +57,7 @@ class TestActionRow:
         assert list(r.children) == [button2, button1, button3, button1]
 
     @pytest.mark.parametrize("index", [None, 1])
-    def test_add_button(self, index):
+    def test_add_button(self, index) -> None:
         r = ActionRow(button1, button2)
         r.add_button(
             **({"index": index} if index is not None else {}),
@@ -77,7 +77,7 @@ class TestActionRow:
             # should not work
             ActionRow.with_modal_components().add_button  # type: ignore
 
-    def test_add_select(self):
+    def test_add_select(self) -> None:
         r = ActionRow.with_message_components()
         r.add_string_select(custom_id="asdf")
 
@@ -91,7 +91,7 @@ class TestActionRow:
             # should not work  # TODO: revert when modal select support is added.
             ActionRow.with_modal_components().add_select  # type: ignore
 
-    def test_add_text_input(self):
+    def test_add_text_input(self) -> None:
         r = ActionRow.with_modal_components()
         r.add_text_input(label="a", custom_id="asdf")
 
@@ -105,29 +105,29 @@ class TestActionRow:
             # should not work
             ActionRow.with_message_components().add_text_input  # type: ignore
 
-    def test_clear_items(self):
+    def test_clear_items(self) -> None:
         r = ActionRow(button1, button2)
         r.clear_items()
         assert list(r.children) == []
 
-    def test_remove_item(self):
+    def test_remove_item(self) -> None:
         r = ActionRow(button1, button2)
         r.remove_item(button1)
         assert list(r.children) == [button2]
 
-    def test_pop(self):
+    def test_pop(self) -> None:
         r = ActionRow(button1, button2)
         assert r.pop(0) is button1
         assert list(r.children) == [button2]
 
-    def test_dunder(self):
+    def test_dunder(self) -> None:
         r = ActionRow(button1, button2)
         assert r[1] is button2
 
         del r[0]
         assert list(r.children) == [button2]
 
-    def test_with_components(self):
+    def test_with_components(self) -> None:
         row_modal = ActionRow.with_modal_components()
         assert list(row_modal.children) == []
         row_msg = ActionRow.with_message_components()
@@ -137,7 +137,7 @@ class TestActionRow:
             assert_type(row_modal, ActionRow[ModalUIComponent])
             assert_type(row_msg, ActionRow[MessageUIComponent])
 
-    def test_rows_from_message(self):
+    def test_rows_from_message(self) -> None:
         rows = [
             ActionRow(button1, button2),
             ActionRow(select),
@@ -156,7 +156,7 @@ class TestActionRow:
                 (type(c), c.custom_id) for c in expected
             ]
 
-    def test_rows_from_message__invalid(self):
+    def test_rows_from_message__invalid(self) -> None:
         message = mock.Mock(disnake.Message)
         message.components = [ActionRow(text_input)._underlying]
 
@@ -169,7 +169,7 @@ class TestActionRow:
         with pytest.raises(TypeError, match=r"Encountered unknown component type: .*text_input"):
             ActionRow.rows_from_message(message)
 
-    def test_walk_components(self):
+    def test_walk_components(self) -> None:
         rows = [
             ActionRow(button1, button2),
             ActionRow(select),
@@ -195,7 +195,7 @@ class TestActionRow:
             assert act_cmp is exp_cmp
 
     # theis method is mainly for pyright to check, the asserts wouldn't do anything at runtime
-    def _test_typing_init(self):  # pragma: no cover
+    def _test_typing_init(self) -> None:  # pragma: no cover
         assert_type(ActionRow(), ActionRow[WrappedComponent])
 
         assert_type(ActionRow(button1), ActionRow[MessageUIComponent])
@@ -238,13 +238,13 @@ class TestActionRow:
         ([select, button1, button2], [[select], [button1, button2]]),
     ],
 )
-def test_components_to_rows(value, expected):
+def test_components_to_rows(value, expected) -> None:
     rows = components_to_rows(value)
     assert all(isinstance(row, ActionRow) for row in rows)
     assert [list(row.children) for row in rows] == expected
 
 
-def test_components_to_rows__invalid():
+def test_components_to_rows__invalid() -> None:
     for value in (42, [42], [ActionRow(), 42], iter([button1])):
         with pytest.raises(TypeError, match=r"`components` must be a"):
             components_to_rows(value)  # type: ignore
@@ -253,7 +253,7 @@ def test_components_to_rows__invalid():
             components_to_rows(value)  # type: ignore
 
 
-def test_components_to_dict():
+def test_components_to_dict() -> None:
     result = components_to_dict([button1, button2, select, ActionRow(button3)])
     assert result == [
         {

--- a/tests/ui/test_decorators.py
+++ b/tests/ui/test_decorators.py
@@ -14,7 +14,7 @@ T = TypeVar("T", bound=ui.Item)
 
 @contextlib.contextmanager
 def create_callback(item_type: Type[T]) -> Iterator["ui.item.ItemCallbackType[T]"]:
-    async def callback(self, item, inter):
+    async def callback(self, item, inter) -> None:
         pytest.fail("callback should not be invoked")
 
     yield callback
@@ -24,7 +24,7 @@ def create_callback(item_type: Type[T]) -> Iterator["ui.item.ItemCallbackType[T]
 
 
 class _CustomButton(ui.Button[V_co]):
-    def __init__(self, *, param: float = 42.0):
+    def __init__(self, *, param: float = 42.0) -> None:
         pass
 
 


### PR DESCRIPTION
## Summary

Add autotyping for automatic typing of dunder methods and other parameters that are easily detectable.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
