### PR TITLE
fix: prevent an attribute error when accessing channel.flags in DMChannels under certain conditions

### DIFF
--- a/changelog/960.bugfix.rst
+++ b/changelog/960.bugfix.rst
@@ -1,1 +1,1 @@
-Fix attribute error when attempting to access :class:`DMChannel.flags`.
+Fix attribute error when attempting to access :class:`DMChannel.flags` under certain circumstances.

--- a/changelog/960.bugfix.rst
+++ b/changelog/960.bugfix.rst
@@ -1,0 +1,1 @@
+Fix attribute error when attempting to access :class:`DMChannel.flags`.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -3808,6 +3808,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
         self.me = state.user
         self.recipient = state.get_user(user_id) if user_id != self.me.id else None
         self.last_pin_timestamp = None
+        self._flags = 0
         return self
 
     @property


### PR DESCRIPTION
this would be unset causing an attribute error when trying to access
channel.Flags for DMChannel objects
