### PR TITLE
lint: enable more pydocstyle rules

### DIFF
--- a/changelog/961.doc.rst
+++ b/changelog/961.doc.rst
@@ -1,0 +1,1 @@
+Remove incorrect documentation for :meth:`InvokableApplicationCommand.invoke`.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1837,7 +1837,7 @@ class Messageable:
             The request to get message history failed.
 
         Yields
-        -------
+        ------
         :class:`.Message`
             The message with the message data parsed.
         """

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -909,7 +909,6 @@ class GuildChannel(ABC):
 
         Examples
         --------
-
         Setting allow and deny: ::
 
             await message.channel.set_permissions(message.author, view_channel=True,
@@ -1790,7 +1789,6 @@ class Messageable:
 
         Examples
         --------
-
         Usage ::
 
             counter = 0

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -122,7 +122,7 @@ class AssetMixin:
             Raises :exc:`TypeError` instead of ``InvalidArgument``.
 
         Parameters
-        -----------
+        ----------
         spoiler: :class:`bool`
             Whether the file is a spoiler.
         filename: Optional[:class:`str`]

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -523,7 +523,6 @@ class AutoModRule:
 
         Examples
         --------
-
         Edit name and enable rule:
 
         .. code-block:: python3

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -560,7 +560,6 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
 
         Examples
         --------
-
         Deleting bot's messages ::
 
             def is_me(m):

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -989,7 +989,7 @@ class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
             The request to get the archived threads failed.
 
         Yields
-        -------
+        ------
         :class:`Thread`
             The archived threads.
         """
@@ -3614,7 +3614,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
             The request to get the archived threads failed.
 
         Yields
-        -------
+        ------
         :class:`Thread`
             The archived threads.
         """

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1782,7 +1782,7 @@ class Client:
             Retrieving the guilds failed.
 
         Yields
-        --------
+        ------
         :class:`.Guild`
             The guild with the guild data parsed.
         """

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1545,7 +1545,6 @@ class Client:
 
         Examples
         --------
-
         Waiting for a user reply: ::
 
             @client.event
@@ -1747,7 +1746,6 @@ class Client:
 
         Examples
         --------
-
         Usage ::
 
             async for guild in client.fetch_guilds(limit=150):

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -380,8 +380,8 @@ class InvokableApplicationCommand(ABC):
 
         return 0.0
 
+    # This method isn't really usable in this class, but it's usable in subclasses.
     async def invoke(self, inter: ApplicationCommandInteraction, *args, **kwargs) -> None:
-        """This method isn't really usable in this class, but it's usable in subclasses."""
         await self.prepare(inter)
 
         try:

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -265,7 +265,7 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
 
 
 class AutoShardedBot(BotBase, InteractionBotBase, disnake.AutoShardedClient):
-    """This is similar to :class:`.Bot` except that it is inherited from
+    """Similar to :class:`.Bot`, except that it is inherited from
     :class:`disnake.AutoShardedClient` instead.
     """
 
@@ -466,7 +466,7 @@ class InteractionBot(InteractionBotBase, disnake.Client):
 
 
 class AutoShardedInteractionBot(InteractionBotBase, disnake.AutoShardedClient):
-    """This is similar to :class:`.InteractionBot` except that it is inherited from
+    """Similar to :class:`.InteractionBot`, except that it is inherited from
     :class:`disnake.AutoShardedClient` instead.
     """
 

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -92,7 +92,7 @@ def when_mentioned_or(*prefixes: str) -> Callable[[BotBase, Message], List[str]]
 
 
     See Also
-    ----------
+    --------
     :func:`.when_mentioned`
     """
 
@@ -280,7 +280,7 @@ class BotBase(CommonBotBase, GroupMixin):
         :exc:`.CommandError`.
 
         Example
-        ---------
+        -------
 
         .. code-block:: python3
 
@@ -321,7 +321,7 @@ class BotBase(CommonBotBase, GroupMixin):
         :exc:`.CommandError`.
 
         Example
-        ---------
+        -------
 
         .. code-block:: python3
 

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -281,7 +281,6 @@ class BotBase(CommonBotBase, GroupMixin):
 
         Example
         -------
-
         .. code-block:: python3
 
             @bot.check
@@ -322,7 +321,6 @@ class BotBase(CommonBotBase, GroupMixin):
 
         Example
         -------
-
         .. code-block:: python3
 
             @bot.check_once

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -127,7 +127,7 @@ class Converter(Protocol[T_co]):
         properly propagate to the error handlers.
 
         Parameters
-        -----------
+        ----------
         ctx: Union[:class:`.Context`, :class:`.ApplicationCommandInteraction`]
             The invocation context that the argument is being used in.
         argument: :class:`str`

--- a/disnake/ext/commands/cooldowns.py
+++ b/disnake/ext/commands/cooldowns.py
@@ -267,7 +267,7 @@ class DynamicCooldownMapping(CooldownMapping):
 
 
 class _Semaphore:
-    """This class is a version of a semaphore.
+    """A custom version of a semaphore.
 
     If you're wondering why asyncio.Semaphore isn't being used,
     it's because it doesn't expose the internal value. This internal

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -1727,7 +1727,6 @@ def check(predicate: Check) -> Callable[[T], T]:
 
     Examples
     --------
-
     Creating a basic check to see if the command invoker is you.
 
     .. code-block:: python3
@@ -1811,7 +1810,6 @@ def check_any(*checks: Check) -> Callable[[T], T]:
 
     Examples
     --------
-
     Creating a basic check to see if it's the bot owner or
     the server owner:
 
@@ -2613,7 +2611,6 @@ def before_invoke(coro) -> Callable[[T], T]:
 
     Example
     -------
-
     .. code-block:: python3
 
         async def record_usage(ctx):

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -2612,7 +2612,7 @@ def before_invoke(coro) -> Callable[[T], T]:
     .. versionadded:: 1.4
 
     Example
-    ---------
+    -------
 
     .. code-block:: python3
 

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -1008,7 +1008,7 @@ class InteractionBotBase(CommonBotBase):
         func
             The function that will be used as a global check.
         call_once: :class:`bool`
-            Whether the function should only be called once per :meth:`.InvokableApplicationCommand.invoke` call.
+            Whether the function should only be called once per invoke call.
         slash_commands: :class:`bool`
             Whether this check is for slash commands.
         user_commands: :class:`bool`
@@ -1158,7 +1158,7 @@ class InteractionBotBase(CommonBotBase):
         Parameters
         ----------
         call_once: :class:`bool`
-            Whether the function should only be called once per :meth:`.InvokableApplicationCommand.invoke` call.
+            Whether the function should only be called once per invoke call.
         slash_commands: :class:`bool`
             Whether this check is for slash commands.
         user_commands: :class:`bool`

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -121,7 +121,7 @@ def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[Type
 
 
 def remove_optionals(annotation: Any) -> Any:
-    """remove unwanted optionals from an annotation"""
+    """Remove unwanted optionals from an annotation"""
     if get_origin(annotation) in (Union, UnionType):
         args = tuple(i for i in annotation.__args__ if i not in (None, type(None)))
         if len(args) == 1:

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2716,7 +2716,7 @@ class Guild(Hashable):
             Due to a breaking change in Discord's API, this now returns an :class:`~disnake.AsyncIterator` instead of a :class:`list`.
 
         Examples
-        ---------
+        --------
 
         Usage ::
 
@@ -2752,7 +2752,7 @@ class Guild(Hashable):
             An error occurred while fetching the bans.
 
         Yields
-        -------
+        ------
         :class:`~disnake.BanEntry`
             The ban with the ban data parsed.
         """
@@ -3903,7 +3903,7 @@ class Guild(Hashable):
             An error occurred while fetching the audit logs.
 
         Yields
-        --------
+        ------
         :class:`AuditLogEntry`
             The audit log entry.
         """
@@ -4097,7 +4097,7 @@ class Guild(Hashable):
             The members intent is not enabled.
 
         Returns
-        --------
+        -------
         Optional[List[:class:`Member`]]
              Returns a list of all the members within the guild.
         """
@@ -4203,7 +4203,7 @@ class Guild(Hashable):
         .. versionadded:: 2.5
 
         Parameters
-        -----------
+        ----------
         query: :class:`str`
             The string that the usernames or nicknames start with.
         limit: :class:`int`
@@ -4214,12 +4214,12 @@ class Guild(Hashable):
             such as :meth:`get_member` work for those that matched.
 
         Raises
-        -------
+        ------
         ValueError
             Invalid parameters were passed to the function
 
         Returns
-        --------
+        -------
         List[:class:`Member`]
             The list of members that have matched the query.
         """
@@ -4257,7 +4257,7 @@ class Guild(Hashable):
         .. versionadded:: 2.4
 
         Parameters
-        -----------
+        ----------
         user_ids: List[:class:`int`]
             List of user IDs to search for. If the user ID is not in the guild then it won't be returned.
         presences: :class:`bool`
@@ -4268,14 +4268,14 @@ class Guild(Hashable):
             It also speeds up this method on repeated calls. Defaults to ``True``.
 
         Raises
-        -------
+        ------
         asyncio.TimeoutError
             The query timed out waiting for the members.
         ClientException
             The presences intent is not enabled.
 
         Returns
-        --------
+        -------
         List[:class:`Member`]
             The list of members with the given IDs, if they exist.
         """

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -1225,7 +1225,6 @@ class Guild(Hashable):
 
         Examples
         --------
-
         Creating a basic channel:
 
         .. code-block:: python3
@@ -2581,7 +2580,6 @@ class Guild(Hashable):
 
         Examples
         --------
-
         Usage ::
 
             async for member in guild.fetch_members(limit=150):
@@ -2717,7 +2715,6 @@ class Guild(Hashable):
 
         Examples
         --------
-
         Usage ::
 
             counter = 0
@@ -3858,7 +3855,6 @@ class Guild(Hashable):
 
         Examples
         --------
-
         Getting the first 100 entries: ::
 
             async for entry in guild.audit_logs(limit=100):
@@ -4644,7 +4640,6 @@ class GuildBuilder:
 
     Examples
     --------
-
     Basic usage:
 
     .. code-block:: python3

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -688,7 +688,6 @@ class GuildScheduledEvent(Hashable):
 
         Examples
         --------
-
         Usage ::
 
             async for user in event.fetch_users(limit=500):

--- a/disnake/i18n.py
+++ b/disnake/i18n.py
@@ -306,7 +306,7 @@ class LocalizationStore(LocalizationProtocol):
     .. versionadded:: 2.5
 
     Attributes
-    ------------
+    ----------
     strict: :class:`bool`
         Specifies whether :meth:`.get` raises an exception if localizations for a provided key couldn't be found.
     """

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -253,7 +253,7 @@ class ApplicationCommandInteractionData(Dict[str, Any]):
 
 
 class ApplicationCommandInteractionDataOption(Dict[str, Any]):
-    """This class represents the structure of an interaction data option from the API.
+    """Represents the structure of an interaction data option from the API.
 
     Attributes
     ----------

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -399,7 +399,7 @@ class BanIterator(_AsyncIterator["BanEntry"]):
     bans endpoint.
 
     Parameters
-    -----------
+    ----------
     guild: :class:`~disnake.Guild`
         The guild to get bans from.
     limit: Optional[:class:`int`]

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -429,7 +429,6 @@ class FFmpegOpusAudio(FFmpegAudio):
 
         Examples
         --------
-
         Use this function to create an :class:`FFmpegOpusAudio` instance instead of the constructor: ::
 
             source = await disnake.FFmpegOpusAudio.from_probe("song.webm")

--- a/disnake/reaction.py
+++ b/disnake/reaction.py
@@ -185,7 +185,7 @@ class Reaction:
             Getting the users for the reaction failed.
 
         Yields
-        --------
+        ------
         Union[:class:`User`, :class:`Member`]
             The member (if retrievable) or the user that has reacted
             to this message. The case where it can be a :class:`Member` is

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -536,7 +536,6 @@ class Thread(Messageable, Hashable):
 
         Examples
         --------
-
         Deleting bot's messages ::
 
             def is_me(m):
@@ -1091,7 +1090,6 @@ class ForumTag(Hashable):
 
     Examples
     --------
-
     Creating a new tag:
 
     .. code-block:: python3

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -333,8 +333,6 @@ def oauth_url(
 def parse_token(token: str) -> Tuple[int, datetime.datetime, bytes]:
     """Parse a token into its parts
 
-    Returns
-
     Parameters
     ----------
     token: :class:`str`

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -438,7 +438,6 @@ def get(iterable: Iterable[T], **attrs: Any) -> Optional[T]:
 
     Examples
     --------
-
     Basic usage:
 
     .. code-block:: python3

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1285,7 +1285,7 @@ def search_directory(path: str) -> Iterator[str]:
         The path to search for modules
 
     Yields
-    -------
+    ------
     :class:`str`
         The name of the found module. (usable in load_extension)
     """

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -149,7 +149,9 @@ class VoiceProtocol:
         raise NotImplementedError
 
     def cleanup(self) -> None:
-        """This method *must* be called to ensure proper clean-up during a disconnect.
+        """Cleans up the internal state.
+
+        **This method *must* be called to ensure proper clean-up during a disconnect.**
 
         It is advisable to call this from within :meth:`disconnect` when you are
         completely done with the voice protocol instance.

--- a/examples/secret.py
+++ b/examples/secret.py
@@ -20,8 +20,7 @@ async def secret(ctx: commands.Context):
 
 
 def create_overwrites(ctx: commands.GuildContext, *objects: Union[disnake.Role, disnake.Member]):
-    """This is just a helper function that creates the overwrites for the
-    voice/text channels.
+    """A helper function that creates the overwrites for the voice/text channels.
 
     A `disnake.PermissionOverwrite` allows you to determine the permissions
     of an object, whether it be a `disnake.Role` or a `disnake.Member`.
@@ -51,8 +50,8 @@ def create_overwrites(ctx: commands.GuildContext, *objects: Union[disnake.Role, 
 async def text(
     ctx: commands.GuildContext, name: str, *objects: Union[disnake.Role, disnake.Member]
 ):
-    """This makes a text channel with a specified name
-    that is only visible to roles or members that are specified.
+    """Creates a text channel with the specified name
+    that is only visible to the specified roles and/or members.
     """
     overwrites = create_overwrites(ctx, *objects)
 
@@ -69,9 +68,7 @@ async def text(
 async def voice(
     ctx: commands.GuildContext, name: str, *objects: Union[disnake.Role, disnake.Member]
 ):
-    """This does the same thing as the `text` subcommand
-    but instead creates a voice channel.
-    """
+    """Does the same thing as the `text` subcommand but instead creates a voice channel."""
     overwrites = create_overwrites(ctx, *objects)
 
     await ctx.guild.create_voice_channel(
@@ -82,7 +79,7 @@ async def voice(
 @secret.command()
 @commands.guild_only()
 async def emoji(ctx: commands.GuildContext, emoji: disnake.PartialEmoji, *roles: disnake.Role):
-    """This clones a specified emoji that only specified roles are allowed to use."""
+    """Clones a specified emoji that only specified roles are allowed to use."""
     # fetch the emoji asset and read it as bytes.
     emoji_bytes = await emoji.read()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ select = [
     "E", "W", # pycodestyle
     # "D", # pydocstyle
     "D2",  # pydocstyle, docstring formatting
+    "D4",  # pydocstyle, docstring structure/content
     # "ANN", # flake8-annotations
     "S", # flake8-bandit
     "B", # flake8-bugbear
@@ -164,6 +165,9 @@ ignore = [
     # pydocstyle
     "D203", # incompat with D211
     "D213", # multiline docstring should start on second line, incompatiable with D212
+    "D400", # first line ends in period, does not work with `|coro|` etc.
+    "D415", # same thing but punctuation in general
+    "D416", # section name should end with a colon, incompatible with D406
 
     # unknown if this is actually an issue
     "RUF005", # might not be actually faster
@@ -182,7 +186,9 @@ ignore = [
     "PLW2901",
 
     # temporary disables, to fix later
-    "D205",   # blank line required between summary and description. Requires a docstring rewrite.
+    "D205",   # blank line required between summary and description
+    "D401",   # first line of docstring should be in imperative mood
+    "D417",   # missing argument description in docstring
     "B904",   # within an except clause raise from error or from none
     "B026",   # backwards star-arg unpacking
     "E501",   # line too long

--- a/test_bot/cogs/injections.py
+++ b/test_bot/cogs/injections.py
@@ -12,7 +12,7 @@ from disnake.ext import commands
 
 
 def injected(user: disnake.User, channel: disnake.TextChannel):
-    """This description should not be shown
+    """An injection callback. This description should not be shown.
 
     Parameters
     ----------
@@ -62,7 +62,7 @@ async def perhaps_this_is_it(
     disc_channel: disnake.TextChannel = commands.Param(lambda i: i.channel),
     large: int = commands.Param(0, large=True),
 ) -> PerhapsThis:
-    """This description should not be shown
+    """A registered injection callback. This description should not be shown.
 
     Parameters
     ----------
@@ -78,7 +78,7 @@ class InjectionSlashCommands(commands.Cog):
         self.exponent = 2
 
     async def injected_method(self, number: int = 3):
-        """This should not be shown
+        """An instance injection callback. This description should not be shown.
 
         Parameters
         ----------

--- a/test_bot/cogs/slash_commands.py
+++ b/test_bot/cogs/slash_commands.py
@@ -55,7 +55,7 @@ class SlashCommands(commands.Cog):
         c: Optional[commands.Range[0, 10]] = None,
         d: Optional[commands.Range[0, 10.0]] = None,
     ):
-        """limit slash command options to a range of values
+        """Limit slash command options to a range of values
 
         Parameters
         ----------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,12 +29,12 @@ def test_cached_property():
     class Test:
         @utils.cached_property
         def prop(self) -> object:
-            """stuff"""
+            """Does things"""
             return object()
 
     inst = Test()
     assert inst.prop is inst.prop
-    assert Test.prop.__doc__ == "stuff"
+    assert Test.prop.__doc__ == "Does things"
     assert isinstance(Test.prop, utils.cached_property)
 
 
@@ -44,12 +44,12 @@ def test_cached_slot_property():
 
         @utils.cached_slot_property("_cs_prop")
         def prop(self) -> object:
-            """stuff"""
+            """Does things"""
             return object()
 
     inst = Test()
     assert inst.prop is inst.prop
-    assert Test.prop.__doc__ == "stuff"
+    assert Test.prop.__doc__ == "Does things"
     assert isinstance(Test.prop, utils.CachedSlotProperty)
 
 
@@ -62,7 +62,7 @@ def test_parse_time():
 
 def test_copy_doc():
     def func(num: int, *, arg: str) -> float:
-        """returns the best number"""
+        """Returns the best number"""
         ...
 
     @utils.copy_doc(func)


### PR DESCRIPTION
## Summary

Enables all relevant `D4*` lint rules, ignoring the ones that aren't usable or only apply to google-style docstrings.
Little to no changes in resulting documentation.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
