### PR TITLE
docs: add searching within sidebar

### DIFF
--- a/changelog/963.doc.rst
+++ b/changelog/963.doc.rst
@@ -1,2 +1,1 @@
-
 Add a sidebar searchbox for searching within the sidebar on the API Reference pages.

--- a/changelog/963.doc.rst
+++ b/changelog/963.doc.rst
@@ -1,0 +1,2 @@
+
+Add a sidebar searchbox for searching within the sidebar on the API Reference pages.

--- a/changelog/963.doc.rst
+++ b/changelog/963.doc.rst
@@ -1,1 +1,1 @@
-Add a sidebar searchbox for searching within the sidebar on the API Reference pages.
+Add a searchbox for filtering the sidebar on the API Reference pages.

--- a/docs/_static/sidebar.js
+++ b/docs/_static/sidebar.js
@@ -123,27 +123,22 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function sidebarSearch() {
-  // Declare variables
-  var input, filter, ul, li, a, i, txtValue;
-  input = document.getElementById('sidebar-search-box');
-  filter = input.value.toUpperCase();
-  ul = document.getElementById("sidebar");
-  li = ul.querySelectorAll('li');
+  const filter = document.getElementById('sidebar-search-box').value.toUpperCase();
+  const items = document.querySelectorAll('#sidebar li')
 
   // Loop through all list items, and hide those who don't match the search query
-  for (i = 0; i < li.length; i++) {
-    a = li[i].getElementsByTagName("a")[0];
-    txtValue = a.textContent || a.innerText;
-    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+  for (const item of items) {
+    const a = item.querySelector("a");
+    const itemText = a.textContent || a.innerText;
+    if (itemText.toUpperCase().indexOf(filter) > -1) {
       // we need to convert all of the parents back into visible mode
-      let el = li[i]
+      let el = item;
       while (el) {
         el.style.display = "";
-
         el = el.parentNode.closest("#sidebar li");
       }
     } else {
-      li[i].style.display = "none";
+      item.style.display = "none";
     }
   }
 }

--- a/docs/_static/sidebar.js
+++ b/docs/_static/sidebar.js
@@ -121,3 +121,29 @@ document.addEventListener('DOMContentLoaded', () => {
     sidebar.setActiveLink(getCurrentSection());
   });
 });
+
+function sidebarSearch() {
+  // Declare variables
+  var input, filter, ul, li, a, i, txtValue;
+  input = document.getElementById('sidebar-search-box');
+  filter = input.value.toUpperCase();
+  ul = document.getElementById("sidebar");
+  li = ul.querySelectorAll('li');
+
+  // Loop through all list items, and hide those who don't match the search query
+  for (i = 0; i < li.length; i++) {
+    a = li[i].getElementsByTagName("a")[0];
+    txtValue = a.textContent || a.innerText;
+    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+      // we need to convert all of the parents back into visible mode
+      let el = li[i]
+      while (el) {
+        el.style.display = "";
+
+        el = el.parentNode.closest("#sidebar li");
+      }
+    } else {
+      li[i].style.display = "none";
+    }
+  }
+}

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -669,6 +669,31 @@ aside .material-icons {
   align-items: baseline;
 }
 
+/* sidebar search box stuff */
+
+.sidebar-search-wrapper {
+  display: flex;
+  align-items: stretch;
+}
+.sidebar-search-wrapper {
+  border: 2px solid var(--search-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.sidebar-search-wrapper:focus-within {
+  border-color: var(--search-focus);
+}
+
+#sidebar-search-box {
+  background-color: var(--sub-header-background);
+  border: none;
+  color: var(--search-text);
+  padding: 0.25em 0.25em;
+  flex: 9;
+}
+
+
 aside::-webkit-scrollbar {
   width: 0.5em;
   overflow-y: overlay;

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -295,7 +295,7 @@ footer a {
 
 main {
   /* aside width + 10px because of scrollbar gutter */
-  margin-left: 395px;
+  margin-left: 350px;
   padding: 12px;
   z-index: 1;
 }
@@ -315,7 +315,7 @@ aside {
   z-index: 3;
   top: 50px; /* Space for sticky header */
   bottom: 0;
-  width: 385px;
+  width: 350px;
   overscroll-behavior: contain;
   scrollbar-width: thin;
 }
@@ -533,13 +533,13 @@ header form.search {
   }
 
   main > * {
-    margin-left: calc(calc(calc(calc(100vw - 1500px) / 2) + 395px) + 12px) !important;
-    max-width: calc(1500px - 395px);
+    margin-left: calc(calc(calc(calc(100vw - 1500px) / 2) + 350px) + 12px) !important;
+    max-width: calc(1500px - 350px);
     padding-right: 12px;
   }
 
   main > .admonition {
-    max-width: calc(calc(1500px - 395px) - 12px);
+    max-width: calc(calc(1500px - 350px) - 12px);
   }
 
   aside {
@@ -566,6 +566,10 @@ header form.search {
 
   #hamburger-toggle {
     left: 8px;
+  }
+
+  .sidebar-search-wrapper {
+    width: fit-content;
   }
 }
 
@@ -676,6 +680,7 @@ aside .material-icons {
   align-items: stretch;
 }
 .sidebar-search-wrapper {
+  width: 200px;
   border: 2px solid var(--search-border);
   border-radius: 8px;
   overflow: hidden;
@@ -689,8 +694,9 @@ aside .material-icons {
   background-color: var(--sub-header-background);
   border: none;
   color: var(--search-text);
-  padding: 0.25em 0.25em;
-  flex: 9;
+  width: 40;
+  padding: 0.4em 1em;
+  flex: 10;
 }
 
 

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -673,13 +673,16 @@ aside .material-icons {
 
 .sidebar-search-wrapper {
   display: flex;
-  align-items: stretch;
-}
-.sidebar-search-wrapper {
-  width: 200px;
   border: 2px solid var(--search-border);
   border-radius: 8px;
   overflow: hidden;
+}
+
+/* Make toc search bar take up entire screen width only on smaller screens */
+@media screen and (min-width: 425px) {
+  .sidebar-search-wrapper {
+    width: 200px;
+  }
 }
 
 .sidebar-search-wrapper:focus-within {

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -567,10 +567,6 @@ header form.search {
   #hamburger-toggle {
     left: 8px;
   }
-
-  .sidebar-search-wrapper {
-    width: fit-content;
-  }
 }
 
 @media screen and (max-width: 365px) {
@@ -694,7 +690,6 @@ aside .material-icons {
   background-color: var(--sub-header-background);
   border: none;
   color: var(--search-text);
-  width: 40;
   padding: 0.4em 1em;
   flex: 10;
 }

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -123,7 +123,9 @@
   </div>
   <div id="sidebar">
     {% if pagename == 'api' or '/api' in pagename %}
-    <input type="text" id="sidebar-search-box" onkeyup="sidebarSearch()" placeholder="Search API Reference.." autocomplete=off>
+    <div class="sidebar-search-wrapper">
+      <input type="text" id="sidebar-search-box" onkeyup="sidebarSearch()" placeholder="Search API Reference.." autocomplete=off>
+    </div>
     {% endif %}
     {%- include "localtoc.html" %}
   </div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -124,7 +124,7 @@
   <div id="sidebar">
     {% if pagename == 'api' or '/api' in pagename %}
     <div class="sidebar-search-wrapper">
-      <input type="text" id="sidebar-search-box" onkeyup="sidebarSearch()" placeholder="Search API Reference.." autocomplete=off>
+      <input type="text" id="sidebar-search-box" onkeyup="sidebarSearch()" placeholder="Filter..." autocomplete=off>
     </div>
     {% endif %}
     {%- include "localtoc.html" %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -122,7 +122,7 @@
     {%- endfor %}
   </div>
   <div id="sidebar">
-    {% if pagename == 'api' or '/api' in pagename %}
+    {% if 'api' in pagename.split('/') %}
     <div class="sidebar-search-wrapper">
       <input type="text" id="sidebar-search-box" onkeyup="sidebarSearch()" placeholder="Filter..." autocomplete=off>
     </div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -122,6 +122,9 @@
     {%- endfor %}
   </div>
   <div id="sidebar">
+    {% if pagename == 'api' or '/api' in pagename %}
+    <input type="text" id="sidebar-search-box" onkeyup="sidebarSearch()" placeholder="Search API Reference.." autocomplete=off>
+    {% endif %}
     {%- include "localtoc.html" %}
   </div>
 </aside>


### PR DESCRIPTION
## Summary

Adds some searching of the objects within the sidebar. This should make it easier to find a specific object when you already know a portion of the name.

Thanks to @ItsAleph for the idea and @bast0006 for help with the implementation.

(still has some css stuff to look at but made the pr for the rtd preview)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
