### PR TITLE
fix(typing): install pytz for type-checking examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,11 @@ codemod = [
     "black==23.1.0",
 ]
 typing = [
-    "typing-extensions~=4.2.0",
     # this is not pyright itself, but the python wrapper
     "pyright==1.1.291",
+    "typing-extensions~=4.2.0",
+    # only used for type-checking, version does not matter
+    "pytz",
 ]
 test = [
     "pytest~=7.2.0",


### PR DESCRIPTION
## Summary

This previously worked fine thanks to a transitive dependency through `-Gdocs -> sphinx -> babel>=2.9 -> pytz` :^)
[Babel 2.12](https://github.com/python-babel/babel/releases/tag/v2.12.0) (released a few hours ago) dropped the pytz requirement for py>=3.9 and uses zoneinfo, which means new pyright runs will [fail](https://github.com/DisnakeDev/disnake/actions/runs/4291757014).

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
