### PR TITLE
chore: add py3.11 to local nox testing

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -136,7 +136,7 @@ def pyright(session: nox.Session):
         pass
 
 
-@nox.session(python=["3.8", "3.9", "3.10"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize(
     "extras",
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ runner = "pdm run"
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310"]
+target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary

Everywhere else officially supports python 3.11. We forgot to add python 3.11 as a default for local testing and to black's configuration. CI already includes 3.11 and its required as well.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
