### PR TITLE
fix: use correct packet sizes for voice IP discovery

### DIFF
--- a/changelog/967.bugfix.rst
+++ b/changelog/967.bugfix.rst
@@ -1,0 +1,1 @@
+Fix voice connection discovery using incorrect packet sizes.

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -1021,16 +1021,16 @@ class DiscordVoiceWebSocket:
         state.voice_port = data["port"]
         state.endpoint_ip = data["ip"]
 
-        packet = bytearray(70)
+        packet = bytearray(74)
         struct.pack_into(">H", packet, 0, 1)  # 1 = Send
         struct.pack_into(">H", packet, 2, 70)  # 70 = Length
         struct.pack_into(">I", packet, 4, state.ssrc)
         state.socket.sendto(packet, (state.endpoint_ip, state.voice_port))
-        recv = await self.loop.sock_recv(state.socket, 70)
+        recv = await self.loop.sock_recv(state.socket, 74)
         _log.debug("received packet in initial_connection: %s", recv)
 
-        # the ip is ascii starting at the 4th byte and ending at the first null
-        ip_start = 4
+        # the ip is ascii starting at the 8th byte and ending at the first null
+        ip_start = 8
         ip_end = recv.index(0, ip_start)
         state.ip = recv[ip_start:ip_end].decode("ascii")
 


### PR DESCRIPTION
## Summary

IP discovery (needed for op 1) previously used 70-byte packets for both sending and receiving, which worked fine up until today. The packets *should* have been 74 bytes, which is the correct and now the only accepted size/structure.

Not sending the correct size results in the connection flow indefinitely stalling on the `sock_recv` here while waiting for a response that never arrives:
https://github.com/DisnakeDev/disnake/blob/6fcc0a6922f1a1612b2f684d977637c5436c837c/disnake/gateway.py#L1028-L1029

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
