### PR TITLE
chore(deps): allow PyNaCl 1.5 to be used

### DIFF
--- a/changelog/968.misc.rst
+++ b/changelog/968.misc.rst
@@ -1,0 +1,1 @@
+Support PyNaCl v1.5.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ speed = [
     'cchardet; python_version < "3.10"',
 ]
 voice = [
-    "PyNaCl>=1.3.0,<1.5",
+    "PyNaCl>=1.3.0,<1.6",
 ]
 docs = [
     "sphinx==6.0.1",


### PR DESCRIPTION
## Summary

PyNaCl 1.5 was released last year and shouldn't contain any breaking changes. This was noticed when reviewing #967.

changelog: https://github.com/pyca/pynacl/blob/main/CHANGELOG.rst

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
