### PR TITLE
ci: use the native libcst parser

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,18 +24,8 @@ os.environ.update(
         "PDM_IGNORE_SAVED_PYTHON": "1",
     },
 )
-
-
-# load specific variables from the dotenv file if it exists
-def load_env_var(var: str, *, default: str, override: bool = False):
-    try:
-        import dotenv
-    except ImportError:
-        return default
-
-    result = dotenv.get_key(dotenv.find_dotenv(), var) or default
-    if var not in os.environ or override:
-        os.environ[var] = result
+# support the python parser in case the native parser isn't available
+os.environ.setdefault("LIBCST_PARSER_TYPE", "native")
 
 
 nox.options.error_on_external_run = True
@@ -119,7 +109,6 @@ def autotyping(session: nox.Session) -> None:
     """
     session.run_always("pdm", "install", "-dG", "codemod", external=True)
 
-    load_env_var("LIBCST_PARSER_TYPE", default="native")
     base_command = ["python", "-m", "libcst.tool", "codemod", "autotyping.AutotypeCommand"]
     dir_options: Dict[Tuple[str, ...], Tuple[str, ...]] = {
         (
@@ -177,7 +166,6 @@ def codemod(session: nox.Session) -> None:
     """Run libcst codemods."""
     session.run_always("pdm", "install", "-dG", "codemod", external=True)
 
-    load_env_var("LIBCST_PARSER_TYPE", default="native")
     if session.posargs and session.posargs[0] == "run-all" or not session.interactive:
         # run all of the transformers on disnake
         session.log("Running all transformers.")


### PR DESCRIPTION
## Summary

Use the native libcst parser. Its not yet compatiable with all 3.10 and 3.11 features (eg match statements and the new union format), but that's okay, as we're compatible with python 3.8 and so we don't use those features.

This should result in codemods being faster both locally and in ci.

~~Depending on when #958 is merged, a change will need to be made to add this environment to both codemods.~~

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
