### PR TITLE
fix(nox): always run autotyping from codemod session, set `--hide-progress` consistently

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -103,6 +103,9 @@ def autotyping(session: nox.Session) -> None:
     session.run_always("pdm", "install", "-dG", "codemod", external=True)
 
     base_command = ["python", "-m", "libcst.tool", "codemod", "autotyping.AutotypeCommand"]
+    if not session.interactive:
+        base_command += ["--hide-progress"]
+
     dir_options: Dict[Tuple[str, ...], Tuple[str, ...]] = {
         (
             "disnake",
@@ -152,11 +155,16 @@ def codemod(session: nox.Session) -> None:
     """Run libcst codemods."""
     session.run_always("pdm", "install", "-dG", "codemod", external=True)
 
+    base_command = ["python", "-m", "libcst.tool"]
+    base_command_codemod = base_command + ["codemod"]
+    if not session.interactive:
+        base_command_codemod += ["--hide-progress"]
+
     if (session.posargs and session.posargs[0] == "run-all") or not session.interactive:
         # run all of the transformers on disnake
         session.log("Running all transformers.")
 
-        res: str = session.run("python", "-m", "libcst.tool", "list", silent=True)  # type: ignore
+        res: str = session.run(*base_command, "list", silent=True)  # type: ignore
         transformers = [line.split("-")[0].strip() for line in res.splitlines()]
         session.log("Transformers: " + ", ".join(transformers))
 
@@ -166,28 +174,15 @@ def codemod(session: nox.Session) -> None:
                 session.log("Skipping autotyping transformer.")
                 continue
 
-            session.run(
-                "python",
-                "-m",
-                "libcst.tool",
-                "codemod",
-                trans,
-                "disnake",
-                "--hide-progress",
-            )
+            session.run(*base_command_codemod, trans, "disnake")
     elif session.posargs:
         if len(session.posargs) < 2:
             session.posargs.append("disnake")
 
-        session.run(
-            "python",
-            "-m",
-            "libcst.tool",
-            "codemod",
-            *session.posargs,
-        )
+        session.run(*base_command_codemod, *session.posargs)
     else:
-        session.run("python", "-m", "libcst.tool", "list")
+        session.run(*base_command, "list")
+        return  # don't run autotyping in this case
 
     session.notify("autotyping", posargs=[])
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -189,8 +189,7 @@ def codemod(session: nox.Session) -> None:
     else:
         session.run("python", "-m", "libcst.tool", "list")
 
-    if not session.interactive:
-        session.notify("autotyping", posargs=[])
+    session.notify("autotyping", posargs=[])
 
 
 @nox.session()


### PR DESCRIPTION
## Summary

- Change `codemod` session to always follow up with `autotyping` session (except when listing modules), not just when running non-interactively
    - This resolves a somewhat weird issue where where CI would complain about missing codemod changes, but running `nox -s codemod -- run-all` locally didn't change anything
- Set `--hide-progress` if and only if running non-interactively
- lil bit of cleanup/formatting

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
