### PR TITLE
fix: member not being cached in `Guild.getch_members` in the case of `user_ids` of length one

### DIFF
--- a/changelog/974.bugfix.rst
+++ b/changelog/974.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :meth:`Guild.get_or_fetch_members` not caching anything in the case of 1 unresolved ID.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4294,7 +4294,9 @@ class Guild(Hashable):
         if len(unresolved_ids) == 1:
             # fetch_member is cheaper than query_members
             try:
-                members.append(await self.fetch_member(unresolved_ids[0]))
+                member = await self.get_or_fetch_member(unresolved_ids[0])
+                if member is not None:
+                    members.append(member)
             except HTTPException:
                 pass
         else:

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4295,8 +4295,9 @@ class Guild(Hashable):
             # fetch_member is cheaper than query_members
             try:
                 member = await self.fetch_member(unresolved_ids[0])
-                self._add_member(member)
                 members.append(member)
+                if cache:
+                    self._add_member(member)
             except HTTPException:
                 pass
         else:

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4294,9 +4294,9 @@ class Guild(Hashable):
         if len(unresolved_ids) == 1:
             # fetch_member is cheaper than query_members
             try:
-                member = await self.get_or_fetch_member(unresolved_ids[0])
-                if member is not None:
-                    members.append(member)
+                member = await self.fetch_member(unresolved_ids[0])
+                self._add_member(member)
+                members.append(member)
             except HTTPException:
                 pass
         else:


### PR DESCRIPTION
## Summary

`Guild.get_or_fetch_members` uses `Guild.fetch_member` in case `user_ids` contains only 1 unresolved ID. However, it does not cache the value afterwards, which is certainly a bug that we missed.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
