### PR TITLE
fix(ci): avoid installing dependencies outside of venv for pyright

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -71,15 +71,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies out of venv
-      run: |
-        pdm export --pyproject --without-hashes -d -G speed -G docs -G voice -o requirements.txt
-        pip install -r requirements.txt
-        pip install .
+    - name: Install dependencies
+      run: pdm install -d -Gspeed -Gdocs -Gvoice
+
+    - name: Add .venv/bin to PATH
+      run: dirname "$(pdm info --python)" >> $GITHUB_PATH
 
     - name: Set pyright version
       run: |
-        PYRIGHT_VERSION="$(python -c 'import pyright; print(pyright.__pyright_version__)')"
+        PYRIGHT_VERSION="$(pdm run python -c 'import pyright; print(pyright.__pyright_version__)')"
         echo "PYRIGHT_VERSION=$PYRIGHT_VERSION" >> $GITHUB_ENV
 
     - name: Run pyright (Linux)


### PR DESCRIPTION
## Summary

This avoids the `pdm export` + `pip install -r` workaround by adding the venv's bin path to `$PATH`.

https://github.com/DisnakeDev/disnake/pull/836#discussion_r1009645787

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
