### PR TITLE
chore: deprecate/remove `AutoModTriggerType.harmful_link`

### DIFF
--- a/changelog/986.deprecate.rst
+++ b/changelog/986.deprecate.rst
@@ -1,0 +1,1 @@
+:attr:`AutoModTriggerType.harmful_link` is obsolete, it is now enabled Discord-wide.

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -822,7 +822,8 @@ class AutoModEventType(Enum):
 
 class AutoModTriggerType(Enum):
     keyword = 1
-    harmful_link = 2
+    if not TYPE_CHECKING:
+        harmful_link = 2  # obsolete/deprecated
     spam = 3
     keyword_preset = 4
     mention_spam = 5

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3836,15 +3836,14 @@ of :class:`enum.Enum`.
 
     .. versionadded:: 2.6
 
+    .. versionchanged:: 2.9
+        Removed obsolete ``harmful_link`` type.
+
     .. attribute:: keyword
 
         The rule will filter messages based on a custom keyword list.
 
         This trigger type requires additional :class:`metadata <AutoModTriggerMetadata>`.
-
-    .. attribute:: harmful_link
-
-        The rule will filter messages containing malicious links.
 
     .. attribute:: spam
 


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/264938af7399058db863b0a259048e5932cd32e2

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
