### PR TITLE
fix!: remove `utils.parse_token`

### DIFF
--- a/changelog/990.misc.rst
+++ b/changelog/990.misc.rst
@@ -1,1 +1,1 @@
-Remove :func:`disnake.utils.parse_token` (previously undocumented), which has been broken for newer tokens for some time, and was based on unofficial information about the token structure.
+Remove :func:`disnake.utils.parse_token` (never documented), which has been broken for newer tokens for some time, and was based on unofficial information about the token structure.

--- a/changelog/990.misc.rst
+++ b/changelog/990.misc.rst
@@ -1,0 +1,1 @@
+Remove :func:`disnake.utils.parse_token` (previously undocumented), which has been broken for newer tokens for some time, and was based on unofficial information about the token structure.

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -13,7 +13,7 @@ import re
 import sys
 import unicodedata
 import warnings
-from base64 import b64encode, urlsafe_b64decode as b64decode
+from base64 import b64encode
 from bisect import bisect_left
 from inspect import getdoc as _getdoc, isawaitable as _isawaitable, signature as _signature
 from operator import attrgetter
@@ -58,7 +58,6 @@ else:
 
 __all__ = (
     "oauth_url",
-    "parse_token",
     "snowflake_time",
     "time_snowflake",
     "find",
@@ -328,31 +327,6 @@ def oauth_url(
     if disable_guild_select:
         url += "&disable_guild_select=true"
     return url
-
-
-def parse_token(token: str) -> Tuple[int, datetime.datetime, bytes]:
-    """Parse a token into its parts
-
-    Parameters
-    ----------
-    token: :class:`str`
-        The bot token
-
-    Returns
-    -------
-    Tuple[:class:`int`, :class:`datetime.datetime`, :class:`bytes`]
-        The bot's ID, the time when the token was generated and the hmac.
-    """
-    parts = token.split(".")
-
-    user_id = int(b64decode(parts[0]))
-
-    timestamp = int.from_bytes(b64decode(parts[1] + "=="), "big")
-    created_at = datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
-
-    hmac = b64decode(parts[2] + "==")
-
-    return user_id, created_at, hmac
 
 
 def snowflake_time(id: int) -> datetime.datetime:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,17 +127,6 @@ def test_oauth_url(expected, perms, guild, redirect, scopes, disable_select) -> 
     assert dict(yarl.URL(url).query) == {"client_id": "1234", **expected}
 
 
-def test_parse_token() -> None:
-    # don't get your hopes up, this token isn't valid.
-    # taken from https://guide.disnake.dev/getting-started/initial-files
-    token = "OTA4MjgxMjk4NTU1MTA5Mzk2.YYzc4A.TB7Ng6DOnVDlpMS4idjGptsreFg"  # noqa: S105
-
-    parts = utils.parse_token(token)
-    assert parts[0] == 908281298555109396
-    assert parts[1] == datetime.datetime(2021, 11, 11, 9, 5, 36, tzinfo=timezone.utc)
-    assert parts[2] == bytes.fromhex("4c1ecd83a0ce9d50e5a4c4b889d8c6a6db2b7858")
-
-
 @pytest.mark.parametrize(
     ("num", "expected"),
     [


### PR DESCRIPTION
## Summary

Removes `parse_token`, which has been broken for newer tokens for some time, and was based on unofficial information about the token structure (which, while very unlikely, could technically change).
The "timestamp" part seems to no longer be a timestamp at all, at least there's no discernible pattern; the created datetime thus is completely inaccurate, or results in `ValueError`s if the timestamp exceeds `datetime.MAXYEAR`.

While this function did have a docstring, it wasn't part of the documentation, so I don't think this is worth a breaking changelog entry.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
