### PR TITLE
refactor: suffix entries of `types` namespace with `Payload`

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -76,7 +76,7 @@ if TYPE_CHECKING:
     from .state import ConnectionState
     from .threads import AnyThreadArchiveDuration, ForumTag
     from .types.channel import (
-        Channel as ChannelPayload,
+        ChannelPayload,
         DefaultReaction as DefaultReactionPayload,
         GuildChannel as GuildChannelPayload,
         OverwriteType,

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -78,7 +78,7 @@ if TYPE_CHECKING:
     from .types.channel import (
         ChannelPayload,
         DefaultReaction as DefaultReactionPayload,
-        GuildChannel as GuildChannelPayload,
+        GuildChannelPayload,
         OverwriteType,
         PermissionOverwrite as PermissionOverwritePayload,
     )

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -77,10 +77,10 @@ if TYPE_CHECKING:
     from .threads import AnyThreadArchiveDuration, ForumTag
     from .types.channel import (
         ChannelPayload,
-        DefaultReaction as DefaultReactionPayload,
+        DefaultReactionPayload,
         GuildChannelPayload,
         OverwriteType,
-        PermissionOverwrite as PermissionOverwritePayload,
+        PermissionOverwritePayload,
     )
     from .types.threads import PartialForumTag as PartialForumTagPayload
     from .ui.action_row import Components, MessageUIComponent

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -60,10 +60,7 @@ if TYPE_CHECKING:
         AutoModAction as AutoModActionPayload,
         AutoModTriggerMetadata as AutoModTriggerMetadataPayload,
     )
-    from .types.channel import (
-        DefaultReaction as DefaultReactionPayload,
-        PermissionOverwrite as PermissionOverwritePayload,
-    )
+    from .types.channel import DefaultReactionPayload, PermissionOverwritePayload
     from .types.role import Role as RolePayload
     from .types.snowflake import Snowflake
     from .types.threads import ForumTag as ForumTagPayload

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -77,13 +77,13 @@ if TYPE_CHECKING:
     from .sticker import GuildSticker, StickerItem
     from .threads import AnyThreadArchiveDuration, ThreadType
     from .types.channel import (
-        CategoryChannel as CategoryChannelPayload,
-        DMChannel as DMChannelPayload,
-        ForumChannel as ForumChannelPayload,
-        GroupDMChannel as GroupChannelPayload,
-        StageChannel as StageChannelPayload,
-        TextChannel as TextChannelPayload,
-        VoiceChannel as VoiceChannelPayload,
+        CategoryChannelPayload,
+        DMChannelPayload,
+        ForumChannelPayload,
+        GroupDMChannelPayload,
+        StageChannelPayload,
+        TextChannelPayload,
+        VoiceChannelPayload,
     )
     from .types.snowflake import SnowflakeList
     from .types.threads import ThreadArchiveDurationLiteral
@@ -3937,14 +3937,14 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
     __slots__ = ("id", "recipients", "owner_id", "owner", "_icon", "name", "me", "_state")
 
     def __init__(
-        self, *, me: ClientUser, state: ConnectionState, data: GroupChannelPayload
+        self, *, me: ClientUser, state: ConnectionState, data: GroupDMChannelPayload
     ) -> None:
         self._state: ConnectionState = state
         self.id: int = int(data["id"])
         self.me: ClientUser = me
         self._update_group(data)
 
-    def _update_group(self, data: GroupChannelPayload) -> None:
+    def _update_group(self, data: GroupDMChannelPayload) -> None:
         self.owner_id: Optional[int] = utils._get_as_snowflake(data, "owner_id")
         self._icon: Optional[str] = data.get("icon")
         self.name: Optional[str] = data.get("name")

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         ButtonComponentPayload,
         ChannelSelectMenuPayload,
         ComponentPayload,
-        MentionableSelectMenu as MentionableSelectMenuPayload,
+        MentionableSelectMenuPayload,
         RoleSelectMenu as RoleSelectMenuPayload,
         SelectOption as SelectOptionPayload,
         StringSelectMenu as StringSelectMenuPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
         BaseSelectMenuPayload,
         ButtonComponentPayload,
         ChannelSelectMenuPayload,
-        Component as ComponentPayload,
+        ComponentPayload,
         MentionableSelectMenu as MentionableSelectMenuPayload,
         RoleSelectMenu as RoleSelectMenuPayload,
         SelectOption as SelectOptionPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
         MentionableSelectMenuPayload,
         RoleSelectMenuPayload,
         SelectOptionPayload,
-        StringSelectMenu as StringSelectMenuPayload,
+        StringSelectMenuPayload,
         TextInput as TextInputPayload,
         UserSelectMenu as UserSelectMenuPayload,
     )

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         ActionRowPayload,
         BaseSelectMenuPayload,
         ButtonComponentPayload,
-        ChannelSelectMenu as ChannelSelectMenuPayload,
+        ChannelSelectMenuPayload,
         Component as ComponentPayload,
         MentionableSelectMenu as MentionableSelectMenuPayload,
         RoleSelectMenu as RoleSelectMenuPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
         ChannelSelectMenuPayload,
         ComponentPayload,
         MentionableSelectMenuPayload,
-        RoleSelectMenu as RoleSelectMenuPayload,
+        RoleSelectMenuPayload,
         SelectOption as SelectOptionPayload,
         StringSelectMenu as StringSelectMenuPayload,
         TextInput as TextInputPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
         SelectOptionPayload,
         StringSelectMenuPayload,
         TextInputPayload,
-        UserSelectMenu as UserSelectMenuPayload,
+        UserSelectMenuPayload,
     )
 
 __all__ = (

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from .types.components import (
         ActionRowPayload,
         BaseSelectMenu as BaseSelectMenuPayload,
-        ButtonComponent as ButtonComponentPayload,
+        ButtonComponentPayload,
         ChannelSelectMenu as ChannelSelectMenuPayload,
         Component as ComponentPayload,
         MentionableSelectMenu as MentionableSelectMenuPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from .emoji import Emoji
     from .types.components import (
-        ActionRow as ActionRowPayload,
+        ActionRowPayload,
         BaseSelectMenu as BaseSelectMenuPayload,
         ButtonComponent as ButtonComponentPayload,
         ChannelSelectMenu as ChannelSelectMenuPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         ComponentPayload,
         MentionableSelectMenuPayload,
         RoleSelectMenuPayload,
-        SelectOption as SelectOptionPayload,
+        SelectOptionPayload,
         StringSelectMenu as StringSelectMenuPayload,
         TextInput as TextInputPayload,
         UserSelectMenu as UserSelectMenuPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from .emoji import Emoji
     from .types.components import (
         ActionRowPayload,
-        BaseSelectMenu as BaseSelectMenuPayload,
+        BaseSelectMenuPayload,
         ButtonComponentPayload,
         ChannelSelectMenu as ChannelSelectMenuPayload,
         Component as ComponentPayload,

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
         RoleSelectMenuPayload,
         SelectOptionPayload,
         StringSelectMenuPayload,
-        TextInput as TextInputPayload,
+        TextInputPayload,
         UserSelectMenu as UserSelectMenuPayload,
     )
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -94,7 +94,7 @@ if TYPE_CHECKING:
     from .state import ConnectionState
     from .template import Template
     from .threads import AnyThreadArchiveDuration, ForumTag
-    from .types.channel import PermissionOverwrite as PermissionOverwritePayload
+    from .types.channel import PermissionOverwritePayload
     from .types.guild import (
         Ban as BanPayload,
         CreateGuildPlaceholderChannel,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -494,7 +494,7 @@ class HTTPClient:
 
     def start_group(
         self, user_id: Snowflake, recipients: List[int]
-    ) -> Response[channel.GroupDMChannel]:
+    ) -> Response[channel.GroupDMChannelPayload]:
         payload = {
             "recipients": recipients,
         }
@@ -508,7 +508,7 @@ class HTTPClient:
 
     # Message management
 
-    def start_private_message(self, user_id: Snowflake) -> Response[channel.DMChannel]:
+    def start_private_message(self, user_id: Snowflake) -> Response[channel.DMChannelPayload]:
         payload = {
             "recipient_id": user_id,
         }
@@ -1010,7 +1010,7 @@ class HTTPClient:
         *,
         reason: Optional[str] = None,
         **options: Any,
-    ) -> Response[channel.GuildChannel]:
+    ) -> Response[channel.GuildChannelPayload]:
         payload = {
             "type": channel_type,
         }
@@ -1470,7 +1470,9 @@ class HTTPClient:
             reason=reason,
         )
 
-    def get_all_guild_channels(self, guild_id: Snowflake) -> Response[List[guild.GuildChannel]]:
+    def get_all_guild_channels(
+        self, guild_id: Snowflake
+    ) -> Response[List[channel.GuildChannelPayload]]:
         return self.request(Route("GET", "/guilds/{guild_id}/channels", guild_id=guild_id))
 
     def get_members(
@@ -1984,12 +1986,12 @@ class HTTPClient:
 
     # Stage instance management
 
-    def get_stage_instance(self, channel_id: Snowflake) -> Response[channel.StageInstance]:
+    def get_stage_instance(self, channel_id: Snowflake) -> Response[channel.StageInstancePayload]:
         return self.request(Route("GET", "/stage-instances/{channel_id}", channel_id=channel_id))
 
     def create_stage_instance(
         self, *, reason: Optional[str] = None, **payload: Any
-    ) -> Response[channel.StageInstance]:
+    ) -> Response[channel.StageInstancePayload]:
         valid_keys = (
             "channel_id",
             "topic",

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -527,7 +527,7 @@ class HTTPClient:
         allowed_mentions: Optional[message.AllowedMentions] = None,
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[Sequence[Snowflake]] = None,
-        components: Optional[Sequence[components.Component]] = None,
+        components: Optional[Sequence[components.ComponentPayload]] = None,
         flags: Optional[int] = None,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)
@@ -581,7 +581,7 @@ class HTTPClient:
         allowed_mentions: Optional[message.AllowedMentions] = None,
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[Sequence[Snowflake]] = None,
-        components: Optional[Sequence[components.Component]] = None,
+        components: Optional[Sequence[components.ComponentPayload]] = None,
         flags: Optional[int] = None,
     ) -> Response[message.Message]:
         payload: Dict[str, Any] = {"tts": tts}
@@ -621,7 +621,7 @@ class HTTPClient:
         allowed_mentions: Optional[message.AllowedMentions] = None,
         message_reference: Optional[message.MessageReference] = None,
         stickers: Optional[Sequence[Snowflake]] = None,
-        components: Optional[Sequence[components.Component]] = None,
+        components: Optional[Sequence[components.ComponentPayload]] = None,
         flags: Optional[int] = None,
     ) -> Response[message.Message]:
         r = Route("POST", "/channels/{channel_id}/messages", channel_id=channel_id)

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1006,7 +1006,7 @@ class HTTPClient:
     def create_channel(
         self,
         guild_id: Snowflake,
-        channel_type: channel.ChannelType,
+        channel_type: channel.LiteralChannelType,
         *,
         reason: Optional[str] = None,
         **options: Any,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -773,7 +773,7 @@ class HTTPClient:
         )
         return self.request(r)
 
-    def get_channel(self, channel_id: Snowflake) -> Response[channel.Channel]:
+    def get_channel(self, channel_id: Snowflake) -> Response[channel.ChannelPayload]:
         r = Route("GET", "/channels/{channel_id}", channel_id=channel_id)
         return self.request(r)
 
@@ -962,7 +962,7 @@ class HTTPClient:
         *,
         reason: Optional[str] = None,
         **options: Any,
-    ) -> Response[channel.Channel]:
+    ) -> Response[channel.ChannelPayload]:
         r = Route("PATCH", "/channels/{channel_id}", channel_id=channel_id)
         valid_keys = (
             "name",

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -74,7 +74,7 @@ if TYPE_CHECKING:
     from ..mentions import AllowedMentions
     from ..state import ConnectionState
     from ..threads import Thread
-    from ..types.components import Modal as ModalPayload
+    from ..types.components import ModalPayload
     from ..types.interactions import (
         ApplicationCommandOptionChoice as ApplicationCommandOptionChoicePayload,
         Interaction as InteractionPayload,

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from .role import Role
     from .state import ConnectionState
     from .threads import AnyThreadArchiveDuration
-    from .types.components import Component as ComponentPayload
+    from .types.components import ComponentPayload
     from .types.embed import Embed as EmbedPayload
     from .types.gateway import (
         MessageReactionAddEvent,

--- a/disnake/stage_instance.py
+++ b/disnake/stage_instance.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from .guild import Guild
     from .guild_scheduled_event import GuildScheduledEvent
     from .state import ConnectionState
-    from .types.channel import StageInstance as StageInstancePayload
+    from .types.channel import StageInstancePayload
 
 
 class StageInstance(Hashable):

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -95,7 +95,7 @@ if TYPE_CHECKING:
     from .http import HTTPClient
     from .types import gateway
     from .types.activity import Activity as ActivityPayload
-    from .types.channel import DMChannel as DMChannelPayload
+    from .types.channel import DMChannelPayload
     from .types.emoji import Emoji as EmojiPayload
     from .types.guild import Guild as GuildPayload, UnavailableGuild as UnavailableGuildPayload
     from .types.message import Message as MessagePayload

--- a/disnake/types/audit_log.py
+++ b/disnake/types/audit_log.py
@@ -14,7 +14,7 @@ from .automod import (
     AutoModTriggerMetadata,
     AutoModTriggerType,
 )
-from .channel import ChannelType, PermissionOverwrite, VideoQualityMode
+from .channel import LiteralChannelType, PermissionOverwritePayload, VideoQualityMode
 from .guild import (
     DefaultMessageNotificationLevel,
     ExplicitContentFilterLevel,
@@ -213,8 +213,8 @@ class _AuditLogChange_DefaultMessageNotificationLevel(TypedDict):
 
 class _AuditLogChange_ChannelType(TypedDict):
     key: Literal["type"]
-    new_value: ChannelType
-    old_value: ChannelType
+    new_value: LiteralChannelType
+    old_value: LiteralChannelType
 
 
 class _AuditLogChange_IntegrationExpireBehaviour(TypedDict):
@@ -231,8 +231,8 @@ class _AuditLogChange_VideoQualityMode(TypedDict):
 
 class _AuditLogChange_Overwrites(TypedDict):
     key: Literal["permission_overwrites"]
-    new_value: List[PermissionOverwrite]
-    old_value: List[PermissionOverwrite]
+    new_value: List[PermissionOverwritePayload]
+    old_value: List[PermissionOverwritePayload]
 
 
 class _AuditLogChange_Datetime(TypedDict):

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -21,11 +21,11 @@ class PermissionOverwrite(TypedDict):
 ChannelType = Literal[0, 1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14, 15]
 
 
-class _BaseChannel(TypedDict):
+class _BaseChannelPayload(TypedDict):
     id: Snowflake
 
 
-class _BaseGuildChannel(_BaseChannel):
+class _BaseGuildChannelPayload(_BaseChannelPayload):
     guild_id: Snowflake
     position: int
     permission_overwrites: List[PermissionOverwrite]
@@ -36,7 +36,7 @@ class _BaseGuildChannel(_BaseChannel):
     flags: NotRequired[int]
 
 
-class PartialChannel(_BaseChannel):
+class PartialChannelPayload(_BaseChannelPayload):
     type: ChannelType
 
 
@@ -44,13 +44,13 @@ class GroupInviteRecipient(TypedDict):
     username: str
 
 
-class InviteChannel(PartialChannel, total=False):
+class InviteChannel(PartialChannelPayload, total=False):
     name: Optional[str]
     recipients: List[GroupInviteRecipient]
     icon: Optional[str]
 
 
-class _BaseTextChannel(_BaseGuildChannel, total=False):
+class _BaseTextChannel(_BaseGuildChannelPayload, total=False):
     topic: Optional[str]
     last_message_id: Optional[Snowflake]
     last_pin_timestamp: Optional[str]
@@ -59,40 +59,40 @@ class _BaseTextChannel(_BaseGuildChannel, total=False):
     default_thread_rate_limit_per_user: NotRequired[int]
 
 
-class TextChannel(_BaseTextChannel):
+class TextChannelPayload(_BaseTextChannel):
     type: Literal[0]
 
 
-class NewsChannel(_BaseTextChannel):
+class NewsChannelPayload(_BaseTextChannel):
     type: Literal[5]
 
 
 VideoQualityMode = Literal[1, 2]
 
 
-class _BaseVocalGuildChannel(_BaseGuildChannel):
+class _BaseVocalGuildChannel(_BaseGuildChannelPayload):
     bitrate: int
     user_limit: int
     rtc_region: NotRequired[Optional[str]]
 
 
-class VoiceChannel(_BaseVocalGuildChannel):
+class VoiceChannelPayload(_BaseVocalGuildChannel):
     type: Literal[2]
     last_message_id: NotRequired[Optional[Snowflake]]
     rate_limit_per_user: NotRequired[int]
     video_quality_mode: NotRequired[VideoQualityMode]
 
 
-class CategoryChannel(_BaseGuildChannel):
+class CategoryChannelPayload(_BaseGuildChannelPayload):
     type: Literal[4]
 
 
-class StageChannel(_BaseVocalGuildChannel):
+class StageChannelPayload(_BaseVocalGuildChannel):
     type: Literal[13]
     topic: NotRequired[Optional[str]]
 
 
-class ThreadChannel(_BaseChannel):
+class ThreadChannelPayload(_BaseChannelPayload):
     type: Literal[10, 11, 12]
     guild_id: Snowflake
     name: str
@@ -118,7 +118,7 @@ ThreadSortOrder = Literal[0, 1]
 ThreadLayout = Literal[0, 1, 2]
 
 
-class ForumChannel(_BaseGuildChannel):
+class ForumChannelPayload(_BaseGuildChannelPayload):
     type: Literal[15]
     topic: NotRequired[Optional[str]]
     last_message_id: NotRequired[Optional[Snowflake]]
@@ -130,36 +130,36 @@ class ForumChannel(_BaseGuildChannel):
     default_forum_layout: NotRequired[ThreadLayout]
 
 
-GuildChannel = Union[
-    TextChannel,
-    NewsChannel,
-    VoiceChannel,
-    CategoryChannel,
-    StageChannel,
-    ThreadChannel,
-    ForumChannel,
+GuildChannelPayload = Union[
+    TextChannelPayload,
+    NewsChannelPayload,
+    VoiceChannelPayload,
+    CategoryChannelPayload,
+    StageChannelPayload,
+    ThreadChannelPayload,
+    ForumChannelPayload,
 ]
 
 
-class DMChannel(_BaseChannel):
+class DMChannelPayload(_BaseChannelPayload):
     type: Literal[1]
     last_message_id: Optional[Snowflake]
     recipients: List[PartialUser]
 
 
-class GroupDMChannel(_BaseChannel):
+class GroupDMChannelPayload(_BaseChannelPayload):
     name: Optional[str]
     type: Literal[3]
     icon: Optional[str]
     owner_id: Snowflake
 
 
-ChannelPayload = Union[GuildChannel, DMChannel, GroupDMChannel]
+ChannelPayload = Union[GuildChannelPayload, DMChannelPayload, GroupDMChannelPayload]
 
 PrivacyLevel = Literal[1, 2]
 
 
-class StageInstance(TypedDict):
+class StageInstancePayload(TypedDict):
     id: Snowflake
     guild_id: Snowflake
     channel_id: Snowflake
@@ -169,7 +169,7 @@ class StageInstance(TypedDict):
     guild_scheduled_event_id: Optional[Snowflake]
 
 
-class GuildDirectory(_BaseChannel):
+class GuildDirectoryPayload(_BaseChannelPayload):
     type: Literal[14]
     name: str
 

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -11,14 +11,14 @@ from .user import PartialUser
 OverwriteType = Literal[0, 1]
 
 
-class PermissionOverwrite(TypedDict):
+class PermissionOverwritePayload(TypedDict):
     id: Snowflake
     type: OverwriteType
     allow: str
     deny: str
 
 
-ChannelType = Literal[0, 1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14, 15]
+LiteralChannelType = Literal[0, 1, 2, 3, 4, 5, 6, 10, 11, 12, 13, 14, 15]
 
 
 class _BaseChannelPayload(TypedDict):
@@ -28,7 +28,7 @@ class _BaseChannelPayload(TypedDict):
 class _BaseGuildChannelPayload(_BaseChannelPayload):
     guild_id: Snowflake
     position: int
-    permission_overwrites: List[PermissionOverwrite]
+    permission_overwrites: List[PermissionOverwritePayload]
     # In theory, this will never be None and will always be present. In practice...
     name: NotRequired[Optional[str]]
     nsfw: bool
@@ -37,7 +37,7 @@ class _BaseGuildChannelPayload(_BaseChannelPayload):
 
 
 class PartialChannelPayload(_BaseChannelPayload):
-    type: ChannelType
+    type: LiteralChannelType
 
 
 class GroupInviteRecipient(TypedDict):
@@ -50,7 +50,7 @@ class InviteChannel(PartialChannelPayload, total=False):
     icon: Optional[str]
 
 
-class _BaseTextChannel(_BaseGuildChannelPayload, total=False):
+class _BaseTextChannelPayload(_BaseGuildChannelPayload, total=False):
     topic: Optional[str]
     last_message_id: Optional[Snowflake]
     last_pin_timestamp: Optional[str]
@@ -59,24 +59,24 @@ class _BaseTextChannel(_BaseGuildChannelPayload, total=False):
     default_thread_rate_limit_per_user: NotRequired[int]
 
 
-class TextChannelPayload(_BaseTextChannel):
+class TextChannelPayload(_BaseTextChannelPayload):
     type: Literal[0]
 
 
-class NewsChannelPayload(_BaseTextChannel):
+class NewsChannelPayload(_BaseTextChannelPayload):
     type: Literal[5]
 
 
 VideoQualityMode = Literal[1, 2]
 
 
-class _BaseVocalGuildChannel(_BaseGuildChannelPayload):
+class _BaseVocalGuildChannelPayload(_BaseGuildChannelPayload):
     bitrate: int
     user_limit: int
     rtc_region: NotRequired[Optional[str]]
 
 
-class VoiceChannelPayload(_BaseVocalGuildChannel):
+class VoiceChannelPayload(_BaseVocalGuildChannelPayload):
     type: Literal[2]
     last_message_id: NotRequired[Optional[Snowflake]]
     rate_limit_per_user: NotRequired[int]
@@ -87,7 +87,7 @@ class CategoryChannelPayload(_BaseGuildChannelPayload):
     type: Literal[4]
 
 
-class StageChannelPayload(_BaseVocalGuildChannel):
+class StageChannelPayload(_BaseVocalGuildChannelPayload):
     type: Literal[13]
     topic: NotRequired[Optional[str]]
 
@@ -109,7 +109,7 @@ class ThreadChannelPayload(_BaseChannelPayload):
     total_message_sent: NotRequired[int]
 
 
-class DefaultReaction(TypedDict):
+class DefaultReactionPayload(TypedDict):
     emoji_id: Optional[Snowflake]
     emoji_name: Optional[str]
 
@@ -124,7 +124,7 @@ class ForumChannelPayload(_BaseGuildChannelPayload):
     last_message_id: NotRequired[Optional[Snowflake]]
     default_auto_archive_duration: NotRequired[ThreadArchiveDurationLiteral]
     available_tags: NotRequired[List[ForumTag]]
-    default_reaction_emoji: NotRequired[Optional[DefaultReaction]]
+    default_reaction_emoji: NotRequired[Optional[DefaultReactionPayload]]
     default_thread_rate_limit_per_user: NotRequired[int]
     default_sort_order: NotRequired[Optional[ThreadSortOrder]]
     default_forum_layout: NotRequired[ThreadLayout]
@@ -176,13 +176,13 @@ class GuildDirectoryPayload(_BaseChannelPayload):
 
 class CreateGuildChannel(TypedDict):
     name: str
-    type: NotRequired[Optional[ChannelType]]
+    type: NotRequired[Optional[LiteralChannelType]]
     topic: NotRequired[Optional[str]]
     bitrate: NotRequired[Optional[int]]
     user_limit: NotRequired[Optional[int]]
     rate_limit_per_user: NotRequired[Optional[int]]
     position: NotRequired[Optional[int]]
-    permission_overwrites: NotRequired[List[PermissionOverwrite]]
+    permission_overwrites: NotRequired[List[PermissionOverwritePayload]]
     parent_id: NotRequired[Optional[Snowflake]]
     nsfw: NotRequired[Optional[bool]]
     rtc_region: NotRequired[Optional[str]]

--- a/disnake/types/channel.py
+++ b/disnake/types/channel.py
@@ -154,7 +154,7 @@ class GroupDMChannel(_BaseChannel):
     owner_id: Snowflake
 
 
-Channel = Union[GuildChannel, DMChannel, GroupDMChannel]
+ChannelPayload = Union[GuildChannel, DMChannel, GroupDMChannel]
 
 PrivacyLevel = Literal[1, 2]
 

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -14,7 +14,9 @@ LiteralButtonStyle = Literal[1, 2, 3, 4, 5]
 LiteralTextInputStyle = Literal[1, 2]
 
 
-ComponentPayload = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenuPayload", "TextInputPayload"]
+ComponentPayload = Union[
+    "ActionRowPayload", "ButtonComponentPayload", "AnySelectMenuPayload", "TextInputPayload"
+]
 
 
 class ActionRowPayload(TypedDict):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -61,7 +61,7 @@ class UserSelectMenu(_SelectMenu):
     type: Literal[5]
 
 
-class RoleSelectMenu(_SelectMenu):
+class RoleSelectMenuPayload(_SelectMenu):
     type: Literal[6]
 
 
@@ -77,7 +77,7 @@ class ChannelSelectMenuPayload(_SelectMenu):
 AnySelectMenu = Union[
     StringSelectMenu,
     UserSelectMenu,
-    RoleSelectMenu,
+    RoleSelectMenuPayload,
     MentionableSelectMenuPayload,
     ChannelSelectMenuPayload,
 ]

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -83,7 +83,7 @@ AnySelectMenu = Union[
 ]
 
 
-class Modal(TypedDict):
+class ModalPayload(TypedDict):
     title: str
     custom_id: str
     components: List[ActionRowPayload]

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -48,7 +48,7 @@ class _SelectMenu(TypedDict):
     disabled: NotRequired[bool]
 
 
-class BaseSelectMenu(_SelectMenu):
+class BaseSelectMenuPayload(_SelectMenu):
     type: Literal[3, 5, 6, 7, 8]
 
 

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -14,7 +14,7 @@ ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextInputStyle = Literal[1, 2]
 
 
-Component = Union["ActionRowPayload", "ButtonComponent", "AnySelectMenu", "TextInput"]
+Component = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenu", "TextInput"]
 
 
 class ActionRowPayload(TypedDict):
@@ -22,7 +22,7 @@ class ActionRowPayload(TypedDict):
     components: List[Component]
 
 
-class ButtonComponent(TypedDict):
+class ButtonComponentPayload(TypedDict):
     type: Literal[2]
     style: ButtonStyle
     label: NotRequired[str]

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -14,7 +14,7 @@ ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextInputStyle = Literal[1, 2]
 
 
-ComponentPayload = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenu", "TextInputPayload"]
+ComponentPayload = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenuPayload", "TextInputPayload"]
 
 
 class ActionRowPayload(TypedDict):
@@ -74,7 +74,7 @@ class ChannelSelectMenuPayload(_SelectMenu):
     channel_types: NotRequired[List[ChannelType]]
 
 
-AnySelectMenu = Union[
+AnySelectMenuPayload = Union[
     StringSelectMenuPayload,
     UserSelectMenuPayload,
     RoleSelectMenuPayload,

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -32,7 +32,7 @@ class ButtonComponentPayload(TypedDict):
     disabled: NotRequired[bool]
 
 
-class SelectOption(TypedDict):
+class SelectOptionPayload(TypedDict):
     label: str
     value: str
     description: NotRequired[str]
@@ -54,7 +54,7 @@ class BaseSelectMenuPayload(_SelectMenu):
 
 class StringSelectMenu(_SelectMenu):
     type: Literal[3]
-    options: List[SelectOption]
+    options: List[SelectOptionPayload]
 
 
 class UserSelectMenu(_SelectMenu):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -65,7 +65,7 @@ class RoleSelectMenu(_SelectMenu):
     type: Literal[6]
 
 
-class MentionableSelectMenu(_SelectMenu):
+class MentionableSelectMenuPayload(_SelectMenu):
     type: Literal[7]
 
 
@@ -78,7 +78,7 @@ AnySelectMenu = Union[
     StringSelectMenu,
     UserSelectMenu,
     RoleSelectMenu,
-    MentionableSelectMenu,
+    MentionableSelectMenuPayload,
     ChannelSelectMenuPayload,
 ]
 

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -57,7 +57,7 @@ class StringSelectMenuPayload(_SelectMenu):
     options: List[SelectOptionPayload]
 
 
-class UserSelectMenu(_SelectMenu):
+class UserSelectMenuPayload(_SelectMenu):
     type: Literal[5]
 
 
@@ -76,7 +76,7 @@ class ChannelSelectMenuPayload(_SelectMenu):
 
 AnySelectMenu = Union[
     StringSelectMenuPayload,
-    UserSelectMenu,
+    UserSelectMenuPayload,
     RoleSelectMenuPayload,
     MentionableSelectMenuPayload,
     ChannelSelectMenuPayload,

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -9,9 +9,9 @@ from typing_extensions import NotRequired
 from .channel import ChannelType
 from .emoji import PartialEmoji
 
-ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8]
-ButtonStyle = Literal[1, 2, 3, 4, 5]
-TextInputStyle = Literal[1, 2]
+LiteralComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8]
+LiteralButtonStyle = Literal[1, 2, 3, 4, 5]
+LiteralTextInputStyle = Literal[1, 2]
 
 
 ComponentPayload = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenuPayload", "TextInputPayload"]
@@ -24,7 +24,7 @@ class ActionRowPayload(TypedDict):
 
 class ButtonComponentPayload(TypedDict):
     type: Literal[2]
-    style: ButtonStyle
+    style: LiteralButtonStyle
     label: NotRequired[str]
     emoji: NotRequired[PartialEmoji]
     custom_id: NotRequired[str]
@@ -92,7 +92,7 @@ class ModalPayload(TypedDict):
 class TextInputPayload(TypedDict):
     type: Literal[4]
     custom_id: str
-    style: TextInputStyle
+    style: LiteralTextInputStyle
     label: str
     min_length: NotRequired[int]
     max_length: NotRequired[int]

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -52,7 +52,7 @@ class BaseSelectMenuPayload(_SelectMenu):
     type: Literal[3, 5, 6, 7, 8]
 
 
-class StringSelectMenu(_SelectMenu):
+class StringSelectMenuPayload(_SelectMenu):
     type: Literal[3]
     options: List[SelectOptionPayload]
 
@@ -75,7 +75,7 @@ class ChannelSelectMenuPayload(_SelectMenu):
 
 
 AnySelectMenu = Union[
-    StringSelectMenu,
+    StringSelectMenuPayload,
     UserSelectMenu,
     RoleSelectMenuPayload,
     MentionableSelectMenuPayload,

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -14,12 +14,12 @@ ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextInputStyle = Literal[1, 2]
 
 
-Component = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenu", "TextInput"]
+ComponentPayload = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenu", "TextInput"]
 
 
 class ActionRowPayload(TypedDict):
     type: Literal[1]
-    components: List[Component]
+    components: List[ComponentPayload]
 
 
 class ButtonComponentPayload(TypedDict):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -69,7 +69,7 @@ class MentionableSelectMenu(_SelectMenu):
     type: Literal[7]
 
 
-class ChannelSelectMenu(_SelectMenu):
+class ChannelSelectMenuPayload(_SelectMenu):
     type: Literal[8]
     channel_types: NotRequired[List[ChannelType]]
 
@@ -79,7 +79,7 @@ AnySelectMenu = Union[
     UserSelectMenu,
     RoleSelectMenu,
     MentionableSelectMenu,
-    ChannelSelectMenu,
+    ChannelSelectMenuPayload,
 ]
 
 

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -14,10 +14,10 @@ ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextInputStyle = Literal[1, 2]
 
 
-Component = Union["ActionRow", "ButtonComponent", "AnySelectMenu", "TextInput"]
+Component = Union["ActionRowPayload", "ButtonComponent", "AnySelectMenu", "TextInput"]
 
 
-class ActionRow(TypedDict):
+class ActionRowPayload(TypedDict):
     type: Literal[1]
     components: List[Component]
 
@@ -86,7 +86,7 @@ AnySelectMenu = Union[
 class Modal(TypedDict):
     title: str
     custom_id: str
-    components: List[ActionRow]
+    components: List[ActionRowPayload]
 
 
 class TextInput(TypedDict):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -14,7 +14,7 @@ ButtonStyle = Literal[1, 2, 3, 4, 5]
 TextInputStyle = Literal[1, 2]
 
 
-ComponentPayload = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenu", "TextInput"]
+ComponentPayload = Union["ActionRowPayload", "ButtonComponentPayload", "AnySelectMenu", "TextInputPayload"]
 
 
 class ActionRowPayload(TypedDict):
@@ -89,7 +89,7 @@ class Modal(TypedDict):
     components: List[ActionRowPayload]
 
 
-class TextInput(TypedDict):
+class TextInputPayload(TypedDict):
     type: Literal[4]
     custom_id: str
     style: TextInputStyle

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -6,7 +6,7 @@ from typing import List, Literal, TypedDict, Union
 
 from typing_extensions import NotRequired
 
-from .channel import ChannelType
+from .channel import LiteralChannelType
 from .emoji import PartialEmoji
 
 LiteralComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8]
@@ -73,7 +73,7 @@ class MentionableSelectMenuPayload(_SelectMenu):
 
 class ChannelSelectMenuPayload(_SelectMenu):
     type: Literal[8]
-    channel_types: NotRequired[List[ChannelType]]
+    channel_types: NotRequired[List[LiteralChannelType]]
 
 
 AnySelectMenuPayload = Union[

--- a/disnake/types/gateway.py
+++ b/disnake/types/gateway.py
@@ -10,7 +10,7 @@ from .activity import PartialPresenceUpdate, PresenceData, SendableActivity
 from .appinfo import PartialAppInfo, PartialGatewayAppInfo
 from .audit_log import AuditLogEntry
 from .automod import AutoModAction, AutoModRule, AutoModTriggerType
-from .channel import Channel, GuildChannel, StageInstance
+from .channel import ChannelPayload, GuildChannel, StageInstance
 from .emoji import Emoji, PartialEmoji
 from .guild import Guild, UnavailableGuild
 from .guild_scheduled_event import GuildScheduledEvent
@@ -361,11 +361,11 @@ ChannelCreateEvent = GuildChannel
 
 
 # https://discord.com/developers/docs/topics/gateway-events#channel-update
-ChannelUpdateEvent = Channel
+ChannelUpdateEvent = ChannelPayload
 
 
 # https://discord.com/developers/docs/topics/gateway-events#channel-delete
-ChannelDeleteEvent = Channel
+ChannelDeleteEvent = ChannelPayload
 
 
 # https://discord.com/developers/docs/topics/gateway-events#channel-pins-update

--- a/disnake/types/gateway.py
+++ b/disnake/types/gateway.py
@@ -10,7 +10,7 @@ from .activity import PartialPresenceUpdate, PresenceData, SendableActivity
 from .appinfo import PartialAppInfo, PartialGatewayAppInfo
 from .audit_log import AuditLogEntry
 from .automod import AutoModAction, AutoModRule, AutoModTriggerType
-from .channel import ChannelPayload, GuildChannel, StageInstance
+from .channel import ChannelPayload, GuildChannelPayload, StageInstancePayload
 from .emoji import Emoji, PartialEmoji
 from .guild import Guild, UnavailableGuild
 from .guild_scheduled_event import GuildScheduledEvent
@@ -357,7 +357,7 @@ class InviteDeleteEvent(TypedDict):
 
 
 # https://discord.com/developers/docs/topics/gateway-events#channel-create
-ChannelCreateEvent = GuildChannel
+ChannelCreateEvent = GuildChannelPayload
 
 
 # https://discord.com/developers/docs/topics/gateway-events#channel-update
@@ -567,15 +567,15 @@ class WebhooksUpdateEvent(TypedDict):
 
 
 # https://discord.com/developers/docs/topics/gateway-events#stage-instance-create
-StageInstanceCreateEvent = StageInstance
+StageInstanceCreateEvent = StageInstancePayload
 
 
 # https://discord.com/developers/docs/topics/gateway-events#stage-instance-update
-StageInstanceUpdateEvent = StageInstance
+StageInstanceUpdateEvent = StageInstancePayload
 
 
 # https://discord.com/developers/docs/topics/gateway-events#stage-instance-delete
-StageInstanceDeleteEvent = StageInstance
+StageInstanceDeleteEvent = StageInstancePayload
 
 
 # https://discord.com/developers/docs/topics/gateway-events#voice-state-update

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -5,7 +5,7 @@ from typing import List, Literal, Optional, TypedDict
 from typing_extensions import NotRequired
 
 from .activity import PartialPresenceUpdate
-from .channel import CreateGuildChannel, GuildChannel, StageInstance
+from .channel import CreateGuildChannel, GuildChannelPayload, StageInstancePayload
 from .emoji import Emoji
 from .guild_scheduled_event import GuildScheduledEvent
 from .member import Member
@@ -134,10 +134,10 @@ class Guild(_BaseGuildPreview):
     member_count: NotRequired[int]
     voice_states: NotRequired[List[GuildVoiceState]]
     members: NotRequired[List[Member]]
-    channels: NotRequired[List[GuildChannel]]
+    channels: NotRequired[List[GuildChannelPayload]]
     threads: NotRequired[List[Thread]]
     presences: NotRequired[List[PartialPresenceUpdate]]
-    stage_instances: NotRequired[List[StageInstance]]
+    stage_instances: NotRequired[List[StageInstancePayload]]
     guild_scheduled_events: NotRequired[List[GuildScheduledEvent]]
 
 

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Unio
 from typing_extensions import NotRequired
 
 from .channel import ChannelType
-from .components import Component, Modal
+from .components import ComponentPayload, Modal
 from .embed import Embed
 from .i18n import LocalizationDict
 from .member import Member, MemberWithUser
@@ -305,7 +305,7 @@ class InteractionApplicationCommandCallbackData(TypedDict, total=False):
     embeds: List[Embed]
     allowed_mentions: AllowedMentions
     flags: int
-    components: List[Component]
+    components: List[ComponentPayload]
     # TODO: missing attachment field
 
 

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Unio
 
 from typing_extensions import NotRequired
 
-from .channel import ChannelType
+from .channel import LiteralChannelType
 from .components import ComponentPayload, ModalPayload
 from .embed import Embed
 from .i18n import LocalizationDict
@@ -52,7 +52,7 @@ class ApplicationCommandOption(TypedDict):
     required: NotRequired[bool]
     choices: NotRequired[List[ApplicationCommandOptionChoice]]
     options: NotRequired[List[ApplicationCommandOption]]
-    channel_types: NotRequired[List[ChannelType]]
+    channel_types: NotRequired[List[LiteralChannelType]]
     min_value: NotRequired[float]
     max_value: NotRequired[float]
     min_length: NotRequired[int]
@@ -90,7 +90,7 @@ InteractionType = Literal[1, 2, 3, 4, 5]
 
 class ResolvedPartialChannel(TypedDict):
     id: Snowflake
-    type: ChannelType
+    type: LiteralChannelType
     permissions: str
     name: str
 

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Unio
 from typing_extensions import NotRequired
 
 from .channel import ChannelType
-from .components import ComponentPayload, Modal
+from .components import ComponentPayload, ModalPayload
 from .embed import Embed
 from .i18n import LocalizationDict
 from .member import Member, MemberWithUser
@@ -318,7 +318,7 @@ InteractionResponseType = Literal[1, 4, 5, 6, 7]
 InteractionCallbackData = Union[
     InteractionApplicationCommandCallbackData,
     InteractionAutocompleteCallbackData,
-    Modal,
+    ModalPayload,
 ]
 
 

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -6,7 +6,7 @@ from typing import List, Literal, Optional, TypedDict, Union
 
 from typing_extensions import NotRequired
 
-from .channel import ChannelType
+from .channel import LiteralChannelType
 from .components import ComponentPayload
 from .embed import Embed
 from .emoji import PartialEmoji
@@ -21,7 +21,7 @@ from .user import User
 class ChannelMention(TypedDict):
     id: Snowflake
     guild_id: Snowflake
-    type: ChannelType
+    type: LiteralChannelType
     name: str
 
 

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -7,7 +7,7 @@ from typing import List, Literal, Optional, TypedDict, Union
 from typing_extensions import NotRequired
 
 from .channel import ChannelType
-from .components import Component
+from .components import ComponentPayload
 from .embed import Embed
 from .emoji import PartialEmoji
 from .interactions import InteractionMessageReference
@@ -100,7 +100,7 @@ class Message(TypedDict):
     referenced_message: NotRequired[Optional[Message]]
     interaction: NotRequired[InteractionMessageReference]
     thread: NotRequired[Thread]
-    components: NotRequired[List[Component]]
+    components: NotRequired[List[ComponentPayload]]
     sticker_items: NotRequired[List[StickerItem]]
     position: NotRequired[int]
 

--- a/disnake/types/webhook.py
+++ b/disnake/types/webhook.py
@@ -6,7 +6,7 @@ from typing import Literal, Optional, TypedDict
 
 from typing_extensions import NotRequired
 
-from .channel import PartialChannel
+from .channel import PartialChannelPayload
 from .snowflake import Snowflake
 from .user import User
 
@@ -23,7 +23,7 @@ WebhookType = Literal[1, 2, 3]
 class FollowerWebhook(TypedDict):
     channel_id: Snowflake
     webhook_id: Snowflake
-    source_channel: NotRequired[PartialChannel]
+    source_channel: NotRequired[PartialChannelPayload]
     source_guild: NotRequired[SourceGuild]
 
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from ..emoji import Emoji
     from ..message import Message
     from ..partial_emoji import PartialEmoji
-    from ..types.components import ActionRow as ActionRowPayload
+    from ..types.components import ActionRowPayload
 
 __all__ = (
     "ActionRow",

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from ..components import NestedComponent
     from ..enums import ComponentType
     from ..interactions import MessageInteraction
-    from ..types.components import Component as ComponentPayload
+    from ..types.components import ComponentPayload
     from .view import View
 
     ItemCallbackType = Callable[[Any, ItemT, MessageInteraction], Coroutine[Any, Any, Any]]

--- a/disnake/ui/modal.py
+++ b/disnake/ui/modal.py
@@ -16,7 +16,7 @@ from .text_input import TextInput
 if TYPE_CHECKING:
     from ..interactions.modal import ModalInteraction
     from ..state import ConnectionState
-    from ..types.components import Modal as ModalPayload
+    from ..types.components import ModalPayload
     from .action_row import Components, ModalUIComponent
 
 

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -45,10 +45,7 @@ if TYPE_CHECKING:
     from ..interactions import MessageInteraction
     from ..message import Message
     from ..state import ConnectionState
-    from ..types.components import (
-        ActionRowPayload,
-        Component as ComponentPayload,
-    )
+    from ..types.components import ActionRowPayload, ComponentPayload
     from .item import ItemCallbackType
 
 

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -45,7 +45,10 @@ if TYPE_CHECKING:
     from ..interactions import MessageInteraction
     from ..message import Message
     from ..state import ConnectionState
-    from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
+    from ..types.components import (
+        ActionRowPayload,
+        Component as ComponentPayload,
+    )
     from .item import ItemCallbackType
 
 

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from .guild import Guild
     from .message import Message
     from .state import ConnectionState
-    from .types.channel import DMChannel as DMChannelPayload
+    from .types.channel import DMChannelPayload
     from .types.user import PartialUser as PartialUserPayload, User as UserPayload
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR aims to normalize names within `types` namespace which are imported by other modules via `from types.foo import XYZ as XYZPayload` by adding the `Payload` suffix right to the type definition. It also renames other symbols which share name with enums etc. to clear any possible name collisions in upcoming refactors.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
