### PR TITLE
fix(auditlog): handle `options.channel_id` null value

### DIFF
--- a/changelog/995.bugfix.rst
+++ b/changelog/995.bugfix.rst
@@ -1,0 +1,1 @@
+Fix audit log parsing issue with new user profile automod actions.

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -597,10 +597,9 @@ class AuditLogEntry(Hashable):
                 self.action is enums.AuditLogAction.member_move
                 or self.action is enums.AuditLogAction.message_delete
             ):
-                channel_id = int(extra["channel_id"])
                 elems = {
                     "count": int(extra["count"]),
-                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id),
+                    "channel": self._get_channel(utils._get_as_snowflake(extra, "channel_id")),
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()
             elif self.action is enums.AuditLogAction.member_disconnect:
@@ -611,9 +610,8 @@ class AuditLogEntry(Hashable):
                 self.extra = type("_AuditLogProxy", (), elems)()
             elif self.action.name.endswith("pin"):
                 # the pin actions have a dict with some information
-                channel_id = int(extra["channel_id"])
                 elems = {
-                    "channel": self.guild.get_channel(channel_id) or Object(id=channel_id),
+                    "channel": self._get_channel(utils._get_as_snowflake(extra, "channel_id")),
                     "message_id": int(extra["message_id"]),
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()
@@ -630,8 +628,9 @@ class AuditLogEntry(Hashable):
                         role.name = extra.get("role_name")  # type: ignore
                     self.extra = role
             elif self.action.name.startswith("stage_instance"):
-                channel_id = int(extra["channel_id"])
-                elems = {"channel": self.guild.get_channel(channel_id) or Object(id=channel_id)}
+                elems = {
+                    "channel": self._get_channel(utils._get_as_snowflake(extra, "channel_id")),
+                }
                 self.extra = type("_AuditLogProxy", (), elems)()
             elif self.action is enums.AuditLogAction.application_command_permission_update:
                 app_id = int(extra["application_id"])
@@ -644,11 +643,8 @@ class AuditLogEntry(Hashable):
                 enums.AuditLogAction.automod_send_alert_message,
                 enums.AuditLogAction.automod_timeout,
             ):
-                channel_id = int(extra["channel_id"])
                 elems = {
-                    "channel": (
-                        self.guild.get_channel_or_thread(channel_id) or Object(id=channel_id)
-                    ),
+                    "channel": (self._get_channel(utils._get_as_snowflake(extra, "channel_id"))),
                     "rule_name": extra["auto_moderation_rule_name"],
                     "rule_trigger_type": enums.try_enum(
                         enums.AutoModTriggerType,
@@ -684,6 +680,11 @@ class AuditLogEntry(Hashable):
         if not user_id:
             return None
         return self.guild.get_member(user_id) or self._users.get(user_id) or Object(id=user_id)
+
+    def _get_channel(self, channel_id: Optional[int]) -> Union[abc.GuildChannel, Object, None]:
+        if not channel_id:
+            return None
+        return self.guild.get_channel(channel_id) or Object(channel_id)
 
     def _get_integration_by_application_id(
         self, application_id: int

--- a/disnake/types/audit_log.py
+++ b/disnake/types/audit_log.py
@@ -299,7 +299,7 @@ AuditLogChange = Union[
 class AuditEntryInfo(TypedDict):
     delete_member_days: str
     members_removed: str
-    channel_id: Snowflake
+    channel_id: Optional[Snowflake]
     message_id: Snowflake
     count: str
     id: Snowflake

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -1649,7 +1649,7 @@ AuditLogAction
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
         set to an unspecified proxy object with these attributes:
 
-        - ``channel``: A :class:`~abc.GuildChannel`, :class:`Thread` or :class:`Object` with the channel ID where the message got blocked.
+        - ``channel``: A :class:`~abc.GuildChannel`, :class:`Thread` or :class:`Object` with the channel ID where the message got blocked. May also be ``None``.
         - ``rule_name``: A :class:`str` with the name of the rule that matched.
         - ``rule_trigger_type``: An :class:`AutoModTriggerType` value with the trigger type of the rule.
 


### PR DESCRIPTION
## Summary

With the introduction of new automod trigger types for usernames/nicknames, audit log data for automod actions can contain `entry.options.channel_id == null` (or `""`). This PR fixes the resulting deserialization issue.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
