### PR TITLE
fix(typing): update misc payload types

### DIFF
--- a/changelog/996.bugfix.rst
+++ b/changelog/996.bugfix.rst
@@ -1,0 +1,1 @@
+Improve :class:`GuildSticker` deserialization, fix :meth:`GuildSticker.edit` parameter types to match documentation.

--- a/changelog/996.misc.rst
+++ b/changelog/996.misc.rst
@@ -1,0 +1,1 @@
+Update typings of :attr:`Message.activity` and internal :class:`Team` payloads to match API documentation.

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -263,7 +263,7 @@ class Sticker(_StickerTag):
     def _from_data(self, data: StickerPayload) -> None:
         self.id: int = int(data["id"])
         self.name: str = data["name"]
-        self.description: str = data["description"]
+        self.description: str = data.get("description") or ""
         self.format: StickerFormatType = try_enum(StickerFormatType, data["format_type"])
 
     def __repr__(self) -> str:
@@ -402,7 +402,7 @@ class GuildSticker(Sticker):
 
     def _from_data(self, data: GuildStickerPayload) -> None:
         super()._from_data(data)
-        self.available: bool = data["available"]
+        self.available: bool = data.get("available", True)
         self.guild_id: int = int(data["guild_id"])
         user = data.get("user")
         self.user: Optional[User] = self._state.store_user(user) if user else None
@@ -425,7 +425,7 @@ class GuildSticker(Sticker):
         self,
         *,
         name: str = MISSING,
-        description: str = MISSING,
+        description: Optional[str] = MISSING,
         emoji: str = MISSING,
         reason: Optional[str] = None,
     ) -> GuildSticker:

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -49,7 +49,7 @@ MessageActivityType = Literal[1, 2, 3, 5]
 
 class MessageActivity(TypedDict):
     type: MessageActivityType
-    party_id: str
+    party_id: NotRequired[str]
 
 
 class MessageApplication(TypedDict):

--- a/disnake/types/sticker.py
+++ b/disnake/types/sticker.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, TypedDict, Union
+from typing import List, Literal, Optional, TypedDict, Union
 
 from typing_extensions import NotRequired
 
@@ -21,7 +21,7 @@ class StickerItem(TypedDict):
 class BaseSticker(TypedDict):
     id: Snowflake
     name: str
-    description: str
+    description: Optional[str]
     tags: str
     format_type: StickerFormatType
 
@@ -34,7 +34,7 @@ class StandardSticker(BaseSticker):
 
 class GuildSticker(BaseSticker):
     type: Literal[2]
-    available: bool
+    available: NotRequired[bool]
     guild_id: Snowflake
     user: NotRequired[User]
 
@@ -61,7 +61,7 @@ class CreateGuildSticker(TypedDict):
 class EditGuildSticker(TypedDict, total=False):
     name: str
     tags: str
-    description: str
+    description: Optional[str]
 
 
 class ListPremiumStickerPacks(TypedDict):

--- a/disnake/types/team.py
+++ b/disnake/types/team.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TypedDict
+from typing import List, Literal, Optional, TypedDict
 
 from .snowflake import Snowflake
 from .user import PartialUser
 
+TeamMembershipState = Literal[1, 2]
+
 
 class TeamMember(TypedDict):
     user: PartialUser
-    membership_state: int
+    membership_state: TeamMembershipState
     permissions: List[str]
     team_id: Snowflake
 
@@ -18,6 +20,6 @@ class TeamMember(TypedDict):
 class Team(TypedDict):
     id: Snowflake
     name: str
-    owner_id: Snowflake
+    owner_user_id: Snowflake
     members: List[TeamMember]
     icon: Optional[str]


### PR DESCRIPTION
## Summary

Updates some typings in `disnake.types` to match the API docs, which weren't worth a PR on their own.
Almost no runtime changes, except for some new defaults/fallbacks in sticker parsing.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
