### PR TITLE
chore(deps): update ruff to 0.0.261

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,6 @@ repos:
         name: "run black in all files"
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.257
+    rev: v0.0.261
     hooks:
       - id: ruff

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -348,7 +348,7 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
             return None
 
         try:
-            entity.qualified_name
+            entity.qualified_name  # noqa: B018
         except AttributeError:
             # if we're here then it's not a cog, group, or command.
             return None

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -347,9 +347,7 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
         if entity is None:
             return None
 
-        try:
-            entity.qualified_name  # noqa: B018
-        except AttributeError:
+        if not hasattr(entity, "qualified_name"):
             # if we're here then it's not a cog, group, or command.
             return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ tools = [
     "python-dotenv~=1.0.0",
     "towncrier==22.12.0",
     "check-manifest==0.49",
-    "ruff==0.0.257",
+    "ruff==0.0.261",
 ]
 codemod = [
     # run codemods on the respository (mostly automated typing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,8 +219,9 @@ ignore = [
 # we are not using noqa in the example files themselves
 "examples/*.py" = [
     "B008", # do not perform function calls in argument defaults, this is how most commands work
-    "T201", # print found, printing is okay in examples
     "PT",   # this is not a module of pytest tests
+    "S311", # pseudo-random generators aren't suitable for cryptographic purposes
+    "T201", # print found, printing is okay in examples
 ]
 "examples/basic_voice.py" = ["S104"] # possible binding to all interfaces
 "examples/views/tic_tac_toe.py" = ["E741"] # ambigious variable name: `O`

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -479,4 +479,4 @@ def test_emptyembed() -> None:
 
     # make sure unknown module attrs continue to raise
     with pytest.raises(AttributeError):
-        embeds.this_does_not_exist  # type: ignore
+        embeds.this_does_not_exist  # type: ignore  # noqa: B018

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -479,4 +479,4 @@ def test_emptyembed() -> None:
 
     # make sure unknown module attrs continue to raise
     with pytest.raises(AttributeError):
-        embeds.this_does_not_exist  # type: ignore  # noqa: B018
+        _ = embeds.this_does_not_exist  # type: ignore

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -72,10 +72,10 @@ class TestActionRow:
             assert list(r.children) == [button1, new_button, button2]
 
         if TYPE_CHECKING:
-            ActionRow().add_button  # noqa: B018
-            ActionRow.with_message_components().add_button  # noqa: B018
+            _ = ActionRow().add_button
+            _ = ActionRow.with_message_components().add_button
             # should not work
-            ActionRow.with_modal_components().add_button  # type: ignore  # noqa: B018
+            _ = ActionRow.with_modal_components().add_button  # type: ignore
 
     def test_add_select(self) -> None:
         r = ActionRow.with_message_components()
@@ -86,10 +86,10 @@ class TestActionRow:
         assert c.custom_id == "asdf"
 
         if TYPE_CHECKING:
-            ActionRow().add_string_select  # noqa: B018
-            ActionRow.with_message_components().add_string_select  # noqa: B018
+            _ = ActionRow().add_string_select
+            _ = ActionRow.with_message_components().add_string_select
             # should not work  # TODO: revert when modal select support is added.
-            ActionRow.with_modal_components().add_select  # type: ignore  # noqa: B018
+            _ = ActionRow.with_modal_components().add_select  # type: ignore
 
     def test_add_text_input(self) -> None:
         r = ActionRow.with_modal_components()
@@ -100,10 +100,10 @@ class TestActionRow:
         assert c.custom_id == "asdf"
 
         if TYPE_CHECKING:
-            ActionRow().add_text_input  # noqa: B018
-            ActionRow.with_modal_components().add_text_input  # noqa: B018
+            _ = ActionRow().add_text_input
+            _ = ActionRow.with_modal_components().add_text_input
             # should not work
-            ActionRow.with_message_components().add_text_input  # type: ignore  # noqa: B018
+            _ = ActionRow.with_message_components().add_text_input  # type: ignore
 
     def test_clear_items(self) -> None:
         r = ActionRow(button1, button2)

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -72,10 +72,10 @@ class TestActionRow:
             assert list(r.children) == [button1, new_button, button2]
 
         if TYPE_CHECKING:
-            ActionRow().add_button
-            ActionRow.with_message_components().add_button
+            ActionRow().add_button  # noqa: B018
+            ActionRow.with_message_components().add_button  # noqa: B018
             # should not work
-            ActionRow.with_modal_components().add_button  # type: ignore
+            ActionRow.with_modal_components().add_button  # type: ignore  # noqa: B018
 
     def test_add_select(self) -> None:
         r = ActionRow.with_message_components()
@@ -86,10 +86,10 @@ class TestActionRow:
         assert c.custom_id == "asdf"
 
         if TYPE_CHECKING:
-            ActionRow().add_string_select
-            ActionRow.with_message_components().add_string_select
+            ActionRow().add_string_select  # noqa: B018
+            ActionRow.with_message_components().add_string_select  # noqa: B018
             # should not work  # TODO: revert when modal select support is added.
-            ActionRow.with_modal_components().add_select  # type: ignore
+            ActionRow.with_modal_components().add_select  # type: ignore  # noqa: B018
 
     def test_add_text_input(self) -> None:
         r = ActionRow.with_modal_components()
@@ -100,10 +100,10 @@ class TestActionRow:
         assert c.custom_id == "asdf"
 
         if TYPE_CHECKING:
-            ActionRow().add_text_input
-            ActionRow.with_modal_components().add_text_input
+            ActionRow().add_text_input  # noqa: B018
+            ActionRow.with_modal_components().add_text_input  # noqa: B018
             # should not work
-            ActionRow.with_message_components().add_text_input  # type: ignore
+            ActionRow.with_message_components().add_text_input  # type: ignore  # noqa: B018
 
     def test_clear_items(self) -> None:
         r = ActionRow(button1, button2)


### PR DESCRIPTION
## Summary

bumps ruff to 0.0.261. Needed before another wave of prs to add more ruff rules.

Changelogs: 
https://github.com/charliermarsh/ruff/releases/tag/v0.0.261
https://github.com/charliermarsh/ruff/releases/tag/v0.0.260
https://github.com/charliermarsh/ruff/releases/tag/v0.0.259
https://github.com/charliermarsh/ruff/releases/tag/v0.0.258

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
