### PR TITLE
feat: implement member profile automod

### DIFF
--- a/changelog/1004.feature.rst
+++ b/changelog/1004.feature.rst
@@ -1,0 +1,3 @@
+Add member profile auto moderation types.
+- New event/trigger type: :attr:`AutoModEventType.member_update`, :attr:`AutoModTriggerType.member_profile`
+- New action: :attr:`AutoModActionType.block_member_interaction` / :class:`AutoModBlockInteractionAction`

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -230,7 +230,7 @@ class AutoModTimeoutAction(AutoModAction):
 
 class AutoModBlockInteractionAction(AutoModAction):
     """Represents an auto moderation action that prevents the user
-    from interacting through text, voice, etc.
+    from using text, voice, or other interactions.
 
     .. versionadded:: 2.9
 

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -814,10 +814,12 @@ class AutoModActionType(Enum):
     block_message = 1
     send_alert_message = 2
     timeout = 3
+    block_member_interaction = 4
 
 
 class AutoModEventType(Enum):
     message_send = 1
+    member_update = 2
 
 
 class AutoModTriggerType(Enum):
@@ -827,6 +829,7 @@ class AutoModTriggerType(Enum):
     spam = 3
     keyword_preset = 4
     mention_spam = 5
+    member_profile = 6
 
 
 class ThreadSortOrder(Enum):

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4573,9 +4573,10 @@ class Guild(Hashable):
         trigger_type: :class:`AutoModTriggerType`
             The type of trigger that determines whether this rule's actions should run for a specific event.
             If set to :attr:`~AutoModTriggerType.keyword`, :attr:`~AutoModTriggerType.keyword_preset`,
-            or :attr:`~AutoModTriggerType.mention_spam`, ``trigger_metadata`` must be set accordingly.
+            :attr:`~AutoModTriggerType.mention_spam`, or :attr:`~AutoModTriggerType.member_profile`,
+            ``trigger_metadata`` must be set accordingly.
             This cannot be changed after creation.
-        actions: Sequence[Union[:class:`AutoModBlockMessageAction`, :class:`AutoModSendAlertAction`, :class:`AutoModTimeoutAction`, :class:`AutoModAction`]]
+        actions: Sequence[Union[:class:`AutoModBlockMessageAction`, :class:`AutoModSendAlertAction`, :class:`AutoModTimeoutAction`, :class:`AutoModBlockInteractionAction`, :class:`AutoModAction`]]
             The list of actions that will execute if a matching event triggered this rule.
             Must contain at least one action.
         trigger_metadata: Optional[:class:`AutoModTriggerMetadata`]
@@ -4610,6 +4611,7 @@ class Guild(Hashable):
             AutoModTriggerType.keyword.value,
             AutoModTriggerType.keyword_preset.value,
             AutoModTriggerType.mention_spam.value,
+            AutoModTriggerType.member_profile.value,
         ):
             raise ValueError("Specified trigger type requires `trigger_metadata` to not be empty")
 

--- a/disnake/types/automod.py
+++ b/disnake/types/automod.py
@@ -8,9 +8,9 @@ from typing_extensions import NotRequired
 
 from .snowflake import Snowflake, SnowflakeList
 
-AutoModTriggerType = Literal[1, 2, 3, 4, 5]
-AutoModEventType = Literal[1]
-AutoModActionType = Literal[1, 2]
+AutoModTriggerType = Literal[1, 2, 3, 4, 5, 6]
+AutoModEventType = Literal[1, 2]
+AutoModActionType = Literal[1, 2, 3, 4]
 AutoModPresetType = Literal[1, 2, 3]
 
 
@@ -26,10 +26,15 @@ class AutoModTimeoutActionMetadata(TypedDict):
     duration_seconds: int
 
 
+class AutoModBlockInteractionActionMetadata(TypedDict):
+    ...  # currently empty
+
+
 AutoModActionMetadata = Union[
     AutoModBlockMessageActionMetadata,
     AutoModSendAlertActionMetadata,
     AutoModTimeoutActionMetadata,
+    AutoModBlockInteractionActionMetadata,
 ]
 
 

--- a/docs/api/automod.rst
+++ b/docs/api/automod.rst
@@ -143,7 +143,7 @@ AutoModEventType
 
     .. attribute:: member_update
 
-        The rule will apply when a member edits their profile.
+        The rule will apply when a member joins or edits their profile.
 
         .. versionadded:: 2.9
 

--- a/docs/api/automod.rst
+++ b/docs/api/automod.rst
@@ -77,6 +77,14 @@ AutoModTimeoutAction
 .. autoclass:: AutoModTimeoutAction
     :members:
 
+AutoModBlockInteractionAction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: AutoModBlockInteractionAction
+
+.. autoclass:: AutoModBlockInteractionAction
+    :members:
+
 Enumerations
 ------------
 
@@ -93,6 +101,10 @@ AutoModActionType
 
         The rule will prevent matching messages from being posted.
 
+        .. note::
+            This action type is *not* available for rules with trigger type
+            :attr:`~AutoModTriggerType.member_profile`.
+
     .. attribute:: send_alert_message
 
         The rule will send an alert to a specified channel.
@@ -106,6 +118,16 @@ AutoModActionType
             :attr:`~AutoModTriggerType.keyword` or :attr:`~AutoModTriggerType.mention_spam`,
             and :attr:`~Permissions.moderate_members` permissions are required to use it.
 
+    .. attribute:: block_member_interaction
+
+        The rule will prevent the user from interacting through text, voice, etc.
+
+        .. versionadded:: 2.9
+
+        .. note::
+            This action type is only available for rules with trigger type
+            :attr:`~AutoModTriggerType.member_profile`.
+
 AutoModEventType
 ~~~~~~~~~~~~~~~~
 
@@ -118,6 +140,12 @@ AutoModEventType
     .. attribute:: message_send
 
         The rule will apply when a member sends or edits a message in the guild.
+
+    .. attribute:: member_update
+
+        The rule will apply when a member edits their profile.
+
+        .. versionadded:: 2.9
 
 AutoModTriggerType
 ~~~~~~~~~~~~~~~~~~
@@ -150,6 +178,12 @@ AutoModTriggerType
     .. attribute:: mention_spam
 
         The rule will filter messages based on the number of member/role mentions they contain.
+
+        This trigger type requires additional :class:`metadata <AutoModTriggerMetadata>`.
+
+    .. attribute:: member_profile
+
+        The rule will filter member profiles based on a custom keyword list.
 
         This trigger type requires additional :class:`metadata <AutoModTriggerMetadata>`.
 

--- a/docs/api/automod.rst
+++ b/docs/api/automod.rst
@@ -120,7 +120,7 @@ AutoModActionType
 
     .. attribute:: block_member_interaction
 
-        The rule will prevent the user from interacting through text, voice, etc.
+        The rule will prevent the user from using text, voice, or other interactions.
 
         .. versionadded:: 2.9
 


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/pull/6040

See also #995, which isn't required but fixes the audit log issue closely related to this.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
