### PR TITLE
fix(ci): update pdm to 2.5.4 to fix requests and cachecontrol incompatibility

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -25,7 +25,7 @@ runs:
       uses: pdm-project/setup-pdm@v3
       with:
         python-version: ${{ inputs.python-version }}
-        version: "2.5.5"
+        version: "2.5.4"
         cache: false
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
         enable-pep582: false  # Disable PEP 582 package loading globally

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -25,7 +25,7 @@ runs:
       uses: pdm-project/setup-pdm@v3
       with:
         python-version: ${{ inputs.python-version }}
-        version: "2.4.6"
+        version: "2.5.4"
         cache: false
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
         enable-pep582: false  # Disable PEP 582 package loading globally

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -25,7 +25,7 @@ runs:
       uses: pdm-project/setup-pdm@v3
       with:
         python-version: ${{ inputs.python-version }}
-        version: "2.5.4"
+        version: "2.5.5"
         cache: false
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
         enable-pep582: false  # Disable PEP 582 package loading globally

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ venvs/
 .coverage*
 coverage.xml
 __pypackages__/
+.pdm-python
 .pdm.toml
+pdm.toml
 pdm.lock
 
 !test_bot/locale/*.json

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,15 +47,9 @@ reset_coverage = True
 def lock_deps(session: nox.Session):
     """Lock all dependency groups into pdm.lock, instead of only specific ones which could result in issues."""
     args = ["pdm", "lock", "-G:all"]
-    output = session.run_always(
-        *args,
-        "--check",
-        external=True,
-        success_codes=list(range(0, 128)),
-        silent=True,
-    )
-    if output:
-        print(output)
+    try:
+        session.run_always(*args, "--check", external=True)
+    except Exception:
         session.run_always(*args, external=True)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,7 +46,7 @@ reset_coverage = True
 
 def lock_deps(session: nox.Session):
     """Lock all dependency groups into pdm.lock, instead of only specific ones which could result in issues."""
-    args = ["pdm", "lock", "-G:all", "-dG:all"]
+    args = ["pdm", "lock", "-G:all"]
     output = session.run_always(
         *args,
         "--check",

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,7 +46,15 @@ reset_coverage = True
 
 def lock_deps(session: nox.Session):
     args = ["pdm", "lock", "-G:all", "-dG:all"]
-    if not session.run_always(*args, "--check", external=True, success_codes=[0]):
+    output = session.run_always(
+        *args,
+        "--check",
+        external=True,
+        success_codes=list(range(0, 128)),
+        silent=True,
+    )
+    if output:
+        print(output)
         session.run_always(*args, external=True)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,6 +45,7 @@ reset_coverage = True
 
 
 def lock_deps(session: nox.Session):
+    """Lock all dependency groups into pdm.lock, instead of only specific ones which could result in issues."""
     args = ["pdm", "lock", "-G:all", "-dG:all"]
     output = session.run_always(
         *args,


### PR DESCRIPTION
## Summary

https://github.com/pdm-project/pdm/pull/1886
https://github.com/ionrock/cachecontrol/pull/294

changelog: https://pdm.fming.dev/2.5/dev/changelog/#release-v254-2023-05-05

this also fixes ci https://github.com/DisnakeDev/disnake/actions/runs/4891445480

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
