### PR TITLE
fix: always deserialize `application_flags` in ready event

### DIFF
--- a/changelog/1027.bugfix.rst
+++ b/changelog/1027.bugfix.rst
@@ -1,0 +1,1 @@
+Fix error when trying to access :attr:`Client.application_flags` if an ``application_id`` was passed to the constructor.

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -725,15 +725,14 @@ class ConnectionState:
         # self._users is a list of Users, we're setting a ClientUser
         self._users[self.user.id] = self.user  # type: ignore
 
-        if self.application_id is None:
-            try:
-                application = data["application"]
-            except KeyError:
-                pass
-            else:
+        try:
+            application = data["application"]
+        except KeyError:
+            pass
+        else:
+            if self.application_id is None:
                 self.application_id = utils._get_as_snowflake(application, "id")
-                # flags will always be present here
-                self.application_flags = ApplicationFlags._from_value(application["flags"])
+            self.application_flags = ApplicationFlags._from_value(application["flags"])
 
         for guild_data in data["guilds"]:
             self._add_guild_from_data(guild_data)
@@ -2286,14 +2285,14 @@ class AutoShardedConnectionState(ConnectionState):
         # self._users is a list of Users, we're setting a ClientUser
         self._users[user.id] = user  # type: ignore
 
-        if self.application_id is None:
-            try:
-                application = data["application"]
-            except KeyError:
-                pass
-            else:
+        try:
+            application = data["application"]
+        except KeyError:
+            pass
+        else:
+            if self.application_id is None:
                 self.application_id = utils._get_as_snowflake(application, "id")
-                self.application_flags = ApplicationFlags._from_value(application["flags"])
+            self.application_flags = ApplicationFlags._from_value(application["flags"])
 
         for guild_data in data["guilds"]:
             self._add_guild_from_data(guild_data)

--- a/disnake/types/appinfo.py
+++ b/disnake/types/appinfo.py
@@ -50,6 +50,7 @@ class PartialAppInfo(BaseAppInfo, total=False):
     flags: int
 
 
+# see https://discord.com/developers/docs/topics/gateway-events#ready-ready-event-fields
 class PartialGatewayAppInfo(TypedDict):
     id: Snowflake
     flags: int


### PR DESCRIPTION
## Summary

Trying to access `client.application_flags` when you created a client with `Client(application_id=...)` previously resulted in an `AttributeError`, since the logic was gated by `application_id` not being set in the first place.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
