### PR TITLE
fix(automod): improve validation for invalid `actions`

### DIFF
--- a/changelog/1030.bugfix.rst
+++ b/changelog/1030.bugfix.rst
@@ -1,0 +1,1 @@
+Raise :exc:`TypeError` in :meth:`Guild.create_automod_rule` and :meth:`AutoModRule.edit` when an action has an invalid type, instead of a rather cryptic error.

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -544,6 +544,9 @@ class AutoModRule:
 
         All fields are optional.
 
+        .. versionchanged:: 2.9
+            Now raises a :exc:`TypeError` if given ``actions`` have an invalid type.
+
         Examples
         --------
         Edit name and enable rule:
@@ -598,6 +601,8 @@ class AutoModRule:
         ------
         ValueError
             When editing the list of actions, at least one action must be provided.
+        TypeError
+            The specified ``actions`` are of an invalid type.
         Forbidden
             You do not have proper permissions to edit the rule.
         NotFound
@@ -619,8 +624,13 @@ class AutoModRule:
         if trigger_metadata is not MISSING:
             payload["trigger_metadata"] = trigger_metadata.to_dict()
         if actions is not MISSING:
-            if len(actions) == 0:
+            if not actions:
                 raise ValueError("At least one action must be provided.")
+            for action in actions:
+                if not isinstance(action, AutoModAction):
+                    raise TypeError(
+                        f"actions must be of type `AutoModAction` (or subtype), not {type(action)!r}"
+                    )
             payload["actions"] = [a.to_dict() for a in actions]
         if enabled is not MISSING:
             payload["enabled"] = enabled

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -26,7 +26,7 @@ from typing import (
 from . import abc, utils
 from .app_commands import GuildApplicationCommandPermissions
 from .asset import Asset
-from .automod import AutoModAction, AutoModRule, AutoModTriggerMetadata
+from .automod import AutoModAction, AutoModRule
 from .bans import BanEntry
 from .channel import (
     CategoryChannel,
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
     from .abc import Snowflake, SnowflakeTime
     from .app_commands import APIApplicationCommand
     from .asset import AssetBytes
+    from .automod import AutoModTriggerMetadata
     from .permissions import Permissions
     from .state import ConnectionState
     from .template import Template

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -26,7 +26,7 @@ from typing import (
 from . import abc, utils
 from .app_commands import GuildApplicationCommandPermissions
 from .asset import Asset
-from .automod import AutoModRule
+from .automod import AutoModAction, AutoModRule, AutoModTriggerMetadata
 from .bans import BanEntry
 from .channel import (
     CategoryChannel,
@@ -90,7 +90,6 @@ if TYPE_CHECKING:
     from .abc import Snowflake, SnowflakeTime
     from .app_commands import APIApplicationCommand
     from .asset import AssetBytes
-    from .automod import AutoModAction, AutoModTriggerMetadata
     from .permissions import Permissions
     from .state import ConnectionState
     from .template import Template
@@ -4565,6 +4564,9 @@ class Guild(Hashable):
 
         .. versionadded:: 2.6
 
+        .. versionchanged:: 2.9
+            Now raises a :exc:`TypeError` if given ``actions`` have an invalid type.
+
         Parameters
         ----------
         name: :class:`str`
@@ -4594,8 +4596,10 @@ class Guild(Hashable):
         Raises
         ------
         ValueError
-            The specified trigger type requires `trigger_metadata` to be set,
+            The specified trigger type requires ``trigger_metadata`` to be set,
             or no actions have been provided.
+        TypeError
+            The specified ``actions`` are of an invalid type.
         Forbidden
             You do not have proper permissions to create auto moderation rules.
         HTTPException
@@ -4614,8 +4618,13 @@ class Guild(Hashable):
         ):
             raise ValueError("Specified trigger type requires `trigger_metadata` to not be empty")
 
-        if len(actions) == 0:
+        if not actions:
             raise ValueError("At least one action must be provided.")
+        for action in actions:
+            if not isinstance(action, AutoModAction):
+                raise TypeError(
+                    f"actions must be of type `AutoModAction` (or subtype), not {type(action)!r}"
+                )
 
         data = await self._state.http.create_auto_moderation_rule(
             self.id,


### PR DESCRIPTION
## Summary

This improves validation in `Guild.create_automod_rule` and `AutoModRule.edit`, now raising a proper `TypeError` for invalid action types in the most common error cases.

ref: https://canary.discord.com/channels/808030843078836254/1093894067135463475

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
