### PR TITLE
docs: exclude `pins()` from voice/stage channels

### DIFF
--- a/changelog/1033.doc.rst
+++ b/changelog/1033.doc.rst
@@ -1,0 +1,1 @@
+Remove ``pins()`` method from unsupported channel types.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1795,6 +1795,8 @@ class Message(Hashable):
         You must have the :attr:`~Permissions.manage_messages` permission to do
         this in a non-private channel context.
 
+        This does not work with messages sent in a :class:`VoiceChannel` or :class:`StageChannel`.
+
         Parameters
         ----------
         reason: Optional[:class:`str`]
@@ -1810,7 +1812,7 @@ class Message(Hashable):
             The message or channel was not found or deleted.
         HTTPException
             Pinning the message failed, probably due to the channel
-            having more than 50 pinned messages.
+            having more than 50 pinned messages or the channel not supporting pins.
         """
         await self._state.http.pin_message(self.channel.id, self.id, reason=reason)
         self.pinned = True

--- a/docs/api/channels.rst
+++ b/docs/api/channels.rst
@@ -34,6 +34,7 @@ VoiceChannel
 .. autoclass:: VoiceChannel()
     :members:
     :inherited-members:
+    :exclude-members: pins
 
 CategoryChannel
 ~~~~~~~~~~~~~~~
@@ -76,6 +77,7 @@ StageChannel
 .. autoclass:: StageChannel()
     :members:
     :inherited-members:
+    :exclude-members: pins
 
 ForumChannel
 ~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Resolves the documentation side of #1033. Voice/Stage channels having a `pins()` method isn't necessarily an issue, especially since the API returns an empty list instead of throwing an error, but this is still something that can be solved by a refactor in the future.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
