### PR TITLE
feat: Add .payload property to interaction class

### DIFF
--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -161,6 +161,7 @@ class Interaction:
         "_app_permissions",
         "_permissions",
         "_state",
+        "_payload",
         "_session",
         "_original_response",
         "_cs_response",
@@ -173,6 +174,7 @@ class Interaction:
     def __init__(self, *, data: InteractionPayload, state: ConnectionState) -> None:
         self.data: Mapping[str, Any] = data.get("data") or {}
         self._state: ConnectionState = state
+        self._payload: InteractionPayload = data
         # TODO: Maybe use a unique session
         self._session: ClientSession = state.http._HTTPClient__session  # type: ignore
         self.client: Client = state._get_client()
@@ -286,6 +288,11 @@ class Interaction:
         if self.guild_id:
             return Permissions(self._app_permissions)
         return Permissions.private_channel()
+
+    @property
+    def payload(self) -> InteractionPayload:
+        """:class:`InteractionPayload`: Returns the payload dictionary that created the interaction."""
+        return self._payload
 
     @utils.cached_slot_property("_cs_response")
     def response(self) -> InteractionResponse:


### PR DESCRIPTION
## Summary

Interactions are valid for 15 minutes, so for slash commands which take a long time to complete, it's feasible that you might restart your bot for updates/maintenance while someone is currently in the middle of a command.

It's therefore useful in some rare cases to be able to store interaction payloads, such that if your bot restarts you can deserialize the payload and recreate the interaction.

This was obviously possible before doing some fairly basic monkey patching, for example doing it for ApplicationCommandInteraction:

```py
def patched_init(original):
    def patched(self, *, data, state):
        self._payload = data
        return original(self, data=data, state=state)

    return patched


disnake.ApplicationCommandInteraction.__init__ = patched_init(
    disnake.ApplicationCommandInteraction.__init__
)

# store/load interaction
store(pickle.dumps(inter._payload))
inter = disnake.ApplicationCommandInteraction(data=pickle.loads(payload), state=bot._connection)
```

This PR simply makes the `Interaction` class save the incoming `InteractionPayload` into the `Interaction._payload` attribute which is accessible through the `Interaction.payload` property, to make the monkey-patching unnecessary.

So you can then:
```py
store(inter.id, inter.payload)

# then after a reboot...
payload = load(payload_id)

# recreate ourselves
inter = disnake.ApplicationCommandInteraction(data=payload, state=bot._connection)

# or even have it re-dispatched, whatever kind of interaction it is
bot._connection.parse_interaction_create(data=payload)
```

### Improvements

Some kind of interactions, since they have an internal cache (like ViewStore) I think only make sense to re-dispatch as opposed to recreating it yourself, so maybe the `._payload` attribute shouldn't be in the `Interaction` base class.

It could also be useful to be able to generically recreate an interaction from the payload (as it has its `type` field), like is done in `ConnectionState.parse_interaction_create`. It's finicky using that however since it creates and dispatches the interaction at the same time.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
