### PR TITLE
fix(docs): use environment variable instead of config context for `html_baseurl`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,6 @@ import re
 import subprocess  # noqa: TID251
 import sys
 from typing import Any, Dict, Optional
-from urllib.parse import urljoin
 
 from sphinx.application import Sphinx
 
@@ -259,10 +258,22 @@ if _IS_READTHEDOCS:
 if not _IS_READTHEDOCS:
     notfound_urls_prefix = "/"
 
+# ignore common link types that we don't particularly care about or are unable to check
 linkcheck_ignore = [
     r"https?://github.com/.+?/.+?/(issues|pull)/\d+",
     r"https?://support.discord.com/",
 ]
+
+if _IS_READTHEDOCS:
+    # set html_baseurl based on readthedocs-provided env variable
+    # https://github.com/readthedocs/readthedocs.org/pull/10224
+    # https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_CANONICAL_URL
+    html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL")
+    if not html_baseurl:
+        raise RuntimeError("Expected `READTHEDOCS_CANONICAL_URL` to be set on readthedocs")
+
+    # enable opensearch (see description somewhere below)
+    html_use_opensearch = html_baseurl.rstrip("/")
 
 
 # -- Options for HTML output ----------------------------------------------
@@ -360,7 +371,7 @@ html_static_path = ["_static"]
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-# html_use_opensearch = ''
+# html_use_opensearch = ''  # NOTE: this is being set above
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = None
@@ -475,19 +486,6 @@ def setup(app: Sphinx) -> None:
         app.config.intersphinx_mapping["py"] = ("https://docs.python.org/ja/3", None)
         app.config.html_context["discord_invite"] = "https://discord.gg/disnake"
         app.config.resource_links["disnake"] = "https://discord.gg/disnake"
-
-    # readthedocs appends additional stuff to conf.py,
-    # we can't access it above since it wouldn't have run yet
-    if _IS_READTHEDOCS:
-        # this is the "canonical" url, which always points to stable in our case
-        if not (base_url := globals().get("html_baseurl")):
-            raise RuntimeError("Expected `html_baseurl` to be set on readthedocs")
-
-        # special case for convenience: if latest, use that for opensearch
-        if os.environ["READTHEDOCS_VERSION"] == "latest":
-            base_url = urljoin(base_url, "../latest")
-
-        app.config["html_use_opensearch"] = base_url.rstrip("/")
 
     # HACK: avoid deprecation warnings caused by sphinx always iterating over all class attributes
     import disnake


### PR DESCRIPTION
## Summary

Fixes readthedocs builds (https://github.com/DisnakeDev/disnake/pull/1048#issuecomment-1590358195), which broke some time within the last 24 hours due to an upstream change which resulted in the `html_baseurl` variable being set to `""`. Not quite sure what caused it, but as far as I can tell this PR is how you're *supposed* to do it nowadays (https://github.com/readthedocs/readthedocs.org/pull/10224).

This has the (positive) side-effect of `<link rel="canonical" />` no longer always pointing to `stable`, and instead using the version that's being built. The same applies to the opensearch config.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
