### PR TITLE
typing: fix `abc.User` protocol structural subtyping

### DIFF
--- a/changelog/1051.bugfix.rst
+++ b/changelog/1051.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typing issue with :class:`abc.User` protocol requirements, which previously resulted in :class:`User` and :class:`Member` not conforming to the protocol.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -146,8 +146,6 @@ class User(Snowflake, Protocol):
 
         .. versionadded:: 2.9
 
-    avatar: :class:`~disnake.Asset`
-        The avatar asset the user has.
     bot: :class:`bool`
         Whether the user is a bot account.
     """
@@ -157,7 +155,6 @@ class User(Snowflake, Protocol):
     name: str
     discriminator: str
     global_name: Optional[str]
-    avatar: Asset
     bot: bool
 
     @property
@@ -168,6 +165,13 @@ class User(Snowflake, Protocol):
     @property
     def mention(self) -> str:
         """:class:`str`: Returns a string that allows you to mention the given user."""
+        raise NotImplementedError
+
+    @property
+    def avatar(self) -> Optional[Asset]:
+        """Optional[:class:`~disnake.Asset`]: Returns an :class:`~disnake.Asset` for
+        the avatar the user has.
+        """
         raise NotImplementedError
 
 

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -279,6 +279,7 @@ class Member(disnake.abc.Messageable, _UserTag):
     if TYPE_CHECKING:
         name: str
         id: int
+        discriminator: str
         global_name: Optional[str]
         bot: bool
         system: bool
@@ -487,19 +488,7 @@ class Member(disnake.abc.Messageable, _UserTag):
     @property
     def tag(self) -> str:
         """:class:`str`: An alias of :attr:`.discriminator`."""
-        return self._user.discriminator
-
-    @property
-    def discriminator(self) -> str:
-        """:class:`str`: The user's discriminator.
-
-        .. note::
-            This is being phased out by Discord; the username system is moving away from ``username#discriminator``
-            to users having a globally unique username.
-            The value of a single zero (``"0"``) indicates that the user has been migrated to the new system.
-            See the `help article <https://dis.gd/app-usernames>`__ for details.
-        """
-        return self._user.discriminator
+        return self.discriminator
 
     @property
     def mobile_status(self) -> Status:

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -158,7 +158,7 @@ class TestUserProtocol:
     def handle_abc_user(self, user: disnake.abc.User) -> None:
         ...
 
-    def _test_typing_assignable(self):
+    def _test_typing_assignable(self) -> None:
         # All of these should match the abc.User protocol and thus type-check correctly
         # (they could just inherit from the protocol to ensure correct implementation,
         # but we really only want structural (i.e. implicit) subtyping)

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+from typing import cast
 from unittest import mock
 
 import pytest
@@ -151,3 +152,16 @@ class TestGuildChannelEdit:
         channel._state.http.edit_channel.assert_awaited_once_with(
             channel.id, permission_overwrites=[], reason=None
         )
+
+
+class TestUserProtocol:
+    def handle_abc_user(self, user: disnake.abc.User) -> None:
+        ...
+
+    def _test_typing_assignable(self):
+        # All of these should match the abc.User protocol and thus type-check correctly
+        # (they could just inherit from the protocol to ensure correct implementation,
+        # but we really only want structural (i.e. implicit) subtyping)
+        self.handle_abc_user(cast(disnake.User, ...))
+        self.handle_abc_user(cast(disnake.ClientUser, ...))
+        self.handle_abc_user(cast(disnake.Member, ...))

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -155,13 +155,13 @@ class TestGuildChannelEdit:
 
 
 class TestUserProtocol:
-    def handle_abc_user(self, user: disnake.abc.User) -> None:
-        ...
-
     def _test_typing_assignable(self) -> None:
+        def handle_abc_user(user: disnake.abc.User) -> None:
+            ...
+
         # All of these should match the abc.User protocol and thus type-check correctly
         # (they could just inherit from the protocol to ensure correct implementation,
         # but we really only want structural (i.e. implicit) subtyping)
-        self.handle_abc_user(cast(disnake.User, ...))
-        self.handle_abc_user(cast(disnake.ClientUser, ...))
-        self.handle_abc_user(cast(disnake.Member, ...))
+        handle_abc_user(cast(disnake.User, ...))
+        handle_abc_user(cast(disnake.ClientUser, ...))
+        handle_abc_user(cast(disnake.Member, ...))


### PR DESCRIPTION
## Summary

Fixes a typing issue where `disnake.User` and `disnake.Member` weren't assignable to the `disnake.abc.User` protocol due to mismatching attributes:
![image](https://github.com/DisnakeDev/disnake/assets/8530778/a775cab2-3aee-4e32-a4a3-8cefc8f30052)

ref: https://canary.discord.com/channels/808030843078836254/913779868985090089/1114931830458683422
cc @Enegg 

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
