### PR TITLE
docs: add disclaimer about creating >30d invites

### DIFF
--- a/changelog/1056.doc.rst
+++ b/changelog/1056.doc.rst
@@ -1,0 +1,1 @@
+Add note to :attr:`GuildChannel.create_invite <.abc.GuildChannel.create_invite>` and all subclasses about the new 30 day expiration limit imposed for non-community guilds.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1294,7 +1294,7 @@ class GuildChannel(ABC):
             .. warning::
 
                 If the guild is not a Community guild (has ``COMMUNITY`` in :attr:`.Guild.features`),
-                this must be set to a time between ``0`` and ``2592000`` seconds.
+                this must be set to a time between ``1`` and ``2592000`` seconds.
 
         max_uses: :class:`int`
             How many uses the invite could be used for. If it's 0 then there

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1294,8 +1294,7 @@ class GuildChannel(ABC):
             .. warning::
 
                 If the guild is not a Community guild (has ``COMMUNITY`` in :attr:`.Guild.features`),
-                this must be set to a time between ``0`` and ``2_592_000`` seconds.
-
+                this must be set to a time between ``0`` and ``2,592,000`` seconds.
         max_uses: :class:`int`
             How many uses the invite could be used for. If it's 0 then there
             are unlimited uses. Defaults to ``0``.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1294,7 +1294,7 @@ class GuildChannel(ABC):
             .. warning::
 
                 If the guild is not a Community guild (has ``COMMUNITY`` in :attr:`.Guild.features`),
-                this must be set to a time between ``0`` and ``2,592,000`` seconds.
+                this must be set to a time between ``0`` and ``2592000`` seconds.
         max_uses: :class:`int`
             How many uses the invite could be used for. If it's 0 then there
             are unlimited uses. Defaults to ``0``.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1295,6 +1295,7 @@ class GuildChannel(ABC):
 
                 If the guild is not a Community guild (has ``COMMUNITY`` in :attr:`.Guild.features`),
                 this must be set to a time between ``0`` and ``2592000`` seconds.
+
         max_uses: :class:`int`
             How many uses the invite could be used for. If it's 0 then there
             are unlimited uses. Defaults to ``0``.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1290,9 +1290,16 @@ class GuildChannel(ABC):
         max_age: :class:`int`
             How long the invite should last in seconds. If it's 0 then the invite
             doesn't expire. Defaults to ``0``.
+
+            .. warning::
+
+                If the guild is not a Community guild (has ``COMMUNITY`` in :attr:`.Guild.features`),
+                this must be set to a time between ``0`` and ``2_592_000`` seconds.
+
         max_uses: :class:`int`
             How many uses the invite could be used for. If it's 0 then there
             are unlimited uses. Defaults to ``0``.
+
         temporary: :class:`bool`
             Whether the invite grants temporary membership
             (i.e. they get kicked after they disconnect). Defaults to ``False``.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1298,7 +1298,6 @@ class GuildChannel(ABC):
         max_uses: :class:`int`
             How many uses the invite could be used for. If it's 0 then there
             are unlimited uses. Defaults to ``0``.
-
         temporary: :class:`bool`
             Whether the invite grants temporary membership
             (i.e. they get kicked after they disconnect). Defaults to ``False``.


### PR DESCRIPTION
## Summary

Adds simple documentation note about the new 30d invite link day limit.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
