### PR TITLE
docs: add links to version guarantees and whatsnew on both pages

### DIFF
--- a/docs/version_guarantees.rst
+++ b/docs/version_guarantees.rst
@@ -7,7 +7,7 @@ Version Guarantees
 
 This library does **not** quite follow the semantic versioning principle, the notable difference being that breaking changes may not only occur on major version increases, but also on minor version bumps (think Python's own versioning scheme).
 The primary reason for this is the lack of guarantees on the Discord API side when it comes to breaking changes, which along with the dynamic nature of the API results in breaking changes sometimes being required more frequently than desired.
-However, any breaking changes will always be explicitly marked as such in the release notes.
+However, any breaking changes will always be explicitly marked as such in the :ref:`whats_new`.
 
 In general, the versioning scheme (``major.minor.micro``) used in this library aims to follow these rules:
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -11,7 +11,7 @@ Changelog
 =========
 
 This page keeps a detailed human friendly rendering of what's new and changed
-in specific versions.
+in specific versions. Please see :ref:`version_guarantees` for more information.
 
 .. towncrier-draft-entries:: |release| [UNRELEASED]
 


### PR DESCRIPTION
## Summary

added a hyperlink to the release notes on version guarantees 
![image](https://github.com/DisnakeDev/disnake/assets/71233171/6805066a-6f41-4747-9a88-2f594662b187)
and a link on the changelog to the version guarantees 

![image](https://github.com/DisnakeDev/disnake/assets/71233171/740b66c7-5cd3-4cfb-b722-ae7567b4054a)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
