### PR TITLE
feat: Guest invites

### DIFF
--- a/changelog/1062.feature.rst
+++ b/changelog/1062.feature.rst
@@ -1,0 +1,1 @@
+Implement Guest invites.

--- a/changelog/1062.feature.rst
+++ b/changelog/1062.feature.rst
@@ -1,1 +1,1 @@
-Implement Guest invites.
+Implement Guest invites. See also :attr:`disnake.Invite.flags`.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -40,6 +40,7 @@ __all__ = (
     "ChannelFlags",
     "AutoModKeywordPresets",
     "MemberFlags",
+    "InviteFlags",
 )
 
 BF = TypeVar("BF", bound="BaseFlags")
@@ -2289,3 +2290,98 @@ class MemberFlags(BaseFlags):
     def started_onboarding(self):
         """:class:`bool`: Returns ``True`` if the member has started onboarding."""
         return 1 << 3
+
+
+class InviteFlags(BaseFlags):
+    """Wraps up a Discord Invite flag value.
+
+    See :class:`SystemChannelFlags`.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two InviteFlags instances are equal.
+        .. describe:: x != y
+
+            Checks if two InviteFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if a InviteFlags instance is a subset of another InviteFlags instance.
+
+        .. describe:: x >= y
+
+            Checks if a InviteFlags instance is a superset of another InviteFlags instance.
+
+        .. describe:: x < y
+
+            Checks if a InviteFlags instance is a strict subset of another InviteFlags instance.
+
+        .. describe:: x > y
+
+            Checks if a InviteFlags instance is a strict superset of another InviteFlags instance.
+
+        .. describe:: x | y, x |= y
+
+            Returns a new InviteFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
+
+        .. describe:: x & y, x &= y
+
+            Returns a new InviteFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
+
+        .. describe:: x ^ y, x ^= y
+
+            Returns a new InviteFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+
+        .. describe:: ~x
+
+            Returns a new InviteFlags instance with all flags from x inverted.
+
+        .. describe:: hash(x)
+
+               Return the flag's hash.
+        .. describe:: iter(x)
+
+               Returns an iterator of ``(name, value)`` pairs. This allows it
+               to be, for example, constructed as a dict or a list of pairs.
+
+
+        Additionally supported are a few operations on class attributes.
+
+        .. describe:: InviteFlags.y | InviteFlags.z, InviteFlags(y=True) | InviteFlags.z
+
+            Returns a InviteFlags instance with all provided flags enabled.
+
+        .. describe:: ~InviteFlags.y
+
+            Returns a InviteFlags instance with all flags except ``y`` inverted from their default value.
+
+    .. versionadded:: 2.10
+
+    Attributes
+    ----------
+    value: :class:`int`
+        The raw value. This value is a bit array field of a 53-bit integer
+        representing the currently available flags. You should query
+        flags via the properties rather than using this raw value.
+    """
+
+    __slots__ = ()
+
+    if TYPE_CHECKING:
+
+        @_generated
+        def __init__(
+            self,
+            *,
+            guest: bool = ...,
+        ) -> None:
+            ...
+
+    @flag_value
+    def guest(self):
+        """:class:`bool`: Returns ``True`` if the invite is a guest invite."""
+        return 1 << 0

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -2374,11 +2374,7 @@ class InviteFlags(BaseFlags):
     if TYPE_CHECKING:
 
         @_generated
-        def __init__(
-            self,
-            *,
-            guest: bool = ...,
-        ) -> None:
+        def __init__(self, *, guest: bool = ...) -> None:
             ...
 
     @flag_value

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -219,6 +219,7 @@ class Guild(Hashable):
         - ``DISCOVERABLE``: Guild shows up in Server Discovery.
         - ``ENABLED_DISCOVERABLE_BEFORE``: Guild had Server Discovery enabled at least once.
         - ``FEATURABLE``: Guild is able to be featured in Server Discovery.
+        - ``GUESTS_ENABLED``: Guild has access to guest invites.
         - ``HAS_DIRECTORY_ENTRY``: Guild is listed in a student hub.
         - ``HUB``: Guild is a student hub.
         - ``INVITE_SPLASH``: Guild's invite page can have a special splash.
@@ -245,7 +246,6 @@ class Guild(Hashable):
         - ``VERIFIED``: Guild is a verified server.
         - ``VIP_REGIONS``: Guild has VIP voice regions.
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.
-        - ``GUESTS_ENABLED``: Guild has access to guest invites.
     premium_progress_bar_enabled: :class:`bool`
         Whether the server boost progress bar is enabled.
     premium_tier: :class:`int`

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -245,6 +245,7 @@ class Guild(Hashable):
         - ``VERIFIED``: Guild is a verified server.
         - ``VIP_REGIONS``: Guild has VIP voice regions.
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.
+        - ``GUESTS_ENABLED``: Guild has access to guest invites.
     premium_progress_bar_enabled: :class:`bool`
         Whether the server boost progress bar is enabled.
     premium_tier: :class:`int`

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -571,6 +571,10 @@ class Invite(Hashable):
 
     @property
     def flags(self) -> InviteFlags:
+        """:class:`InviteFlags`: Invite's flags.
+
+        .. versionadded:: 2.10
+        """
         return InviteFlags._from_value(self._flags)
 
     async def delete(self, *, reason: Optional[str] = None) -> None:

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from .appinfo import PartialAppInfo
 from .asset import Asset
 from .enums import ChannelType, InviteTarget, NSFWLevel, VerificationLevel, try_enum
+from .flags import InviteFlags
 from .guild_scheduled_event import GuildScheduledEvent
 from .mixins import Hashable
 from .object import Object
@@ -398,6 +399,7 @@ class Invite(Hashable):
         "guild_scheduled_event",
         "guild_welcome_screen",
         "_state",
+        "_flags",
     )
 
     BASE = "https://discord.gg"
@@ -465,6 +467,8 @@ class Invite(Hashable):
             )
         else:
             self.guild_scheduled_event: Optional[GuildScheduledEvent] = None
+
+        self._flags: int = data.get("flags", 0)
 
     @classmethod
     def from_incomplete(cls, *, state: ConnectionState, data: InvitePayload) -> Self:
@@ -564,6 +568,10 @@ class Invite(Hashable):
         if self.guild_scheduled_event:
             url += f"?event={self.guild_scheduled_event.id}"
         return url
+
+    @property
+    def flags(self) -> InviteFlags:
+        return InviteFlags._from_value(self._flags)
 
     async def delete(self, *, reason: Optional[str] = None) -> None:
         """|coro|

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -717,7 +717,9 @@ class Member(disnake.abc.Messageable, _UserTag):
         return MemberFlags._from_value(self._flags)
 
     def is_guest(self) -> bool:
-        """Whether this member joined the guild as a guest (i.e., via a guest invite).
+        """Whether this member joined the guild as a guest (i.e. via a guest invite).
+
+        .. versionadded:: 2.10
 
         Returns
         -------

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -716,6 +716,16 @@ class Member(disnake.abc.Messageable, _UserTag):
         """
         return MemberFlags._from_value(self._flags)
 
+    def is_guest(self) -> bool:
+        """Whether this member joined the guild as a guest (i.e., via a guest invite).
+
+        Returns
+        -------
+        :class:`bool`
+            Whether the member is a guest.
+        """
+        return self.joined_at is None
+
     @overload
     async def ban(
         self,

--- a/disnake/types/gateway.py
+++ b/disnake/types/gateway.py
@@ -338,6 +338,7 @@ class InviteCreateEvent(TypedDict):
     channel_id: Snowflake
     code: str
     created_at: str
+    flags: NotRequired[int]
     guild_id: NotRequired[Snowflake]
     inviter: NotRequired[User]
     max_age: int

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -47,6 +47,7 @@ GuildFeature = Literal[
     "DISCOVERABLE",
     "ENABLED_DISCOVERABLE_BEFORE",
     "FEATURABLE",
+    "GUESTS_ENABLED",
     "GUILD_HOME_TEST",  # not yet documented/finalised
     "HAS_DIRECTORY_ENTRY",
     "HUB",

--- a/disnake/types/invite.py
+++ b/disnake/types/invite.py
@@ -30,6 +30,7 @@ class _InviteMetadata(TypedDict, total=False):
 
 class Invite(_InviteMetadata):
     code: str
+    flags: NotRequired[int]
     guild: NotRequired[InviteGuild]
     channel: InviteChannel
     inviter: NotRequired[PartialUser]

--- a/docs/api/invites.rst
+++ b/docs/api/invites.rst
@@ -34,6 +34,17 @@ PartialInviteChannel
 .. autoclass:: PartialInviteChannel()
     :members:
 
+Data Classes
+------------
+
+InviteFlags
+~~~~~~~~~~~
+
+.. attributetable:: InviteFlags
+
+.. autoclass:: InviteFlags()
+    :members:
+
 Enumerations
 ------------
 


### PR DESCRIPTION
## Summary

discord/discord-api-docs#6247

Official Discord client seem to check for whether a member is a guest by `assert`ing `not some_member.joined_at`, so we'll do the same.

According to docs ~~written by myself~~ invite flags is an optional but not nullable flag. Though if some invite doesn't have flags, it is functionally equivalent to `flags = 0`, so the flags property is kept out of the Invite's docstring's table.

While not technically being a breaking change (for a reason only Danny and God know `Member.joined_at` is already optional despite official docs stating that it is always present), this PR actually introduces a real case when it can be optional. I'm not sure whether this should be mentioned in changelog as a breaking change, so decide yourself.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
