### PR TITLE
docs: clarify `Member.current_timeout` expiry

### DIFF
--- a/disnake/member.py
+++ b/disnake/member.py
@@ -695,7 +695,9 @@ class Member(disnake.abc.Messageable, _UserTag):
 
     @property
     def current_timeout(self) -> Optional[datetime.datetime]:
-        """Optional[:class:`datetime.datetime`]: Returns the datetime when the timeout expires, if any.
+        """Optional[:class:`datetime.datetime`]: Returns the datetime when the timeout expires.
+
+        If the member is not timed out or the timeout has already expired, returns ``None``.
 
         .. versionadded:: 2.3
         """


### PR DESCRIPTION
## Summary

Tiny documentation change to clarify that `Member.current_timeout` also returns `None` when the current timeout value is in the past, allowing users to safely rely on this behavior.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
