### PR TITLE
auto deferred interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ coverage.xml
 __pypackages__/
 .pdm.toml
 pdm.lock
+/.vscode
 
 !test_bot/locale/*.json

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -139,6 +139,8 @@ class InvokableApplicationCommand(ABC):
         # We will use this attribute later in order to set the dm_permission.
         self._guild_only: bool = kwargs.get("guild_only", False)
         self.extras: Dict[str, Any] = kwargs.get("extras") or {}
+        self.auto_deferred: Optional[bool] = kwargs.get("auto_deferred")
+        self.auto_deferred_ephemeral: bool = kwargs.get("auto_deferred_ephemeral", False)
 
         if not isinstance(self.name, str):
             raise TypeError("Name of a command must be a string.")

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -391,6 +391,12 @@ class InteractionBot(InteractionBotBase, disnake.Client):
 
         .. versionadded:: 2.5
 
+    auto_deferred_interactions: :class:`bool`
+        TODO
+        Defaults to ``False``.
+
+        .. versionadded:: TODO
+
     Attributes
     ----------
     owner_id: Optional[:class:`int`]
@@ -461,6 +467,7 @@ class InteractionBot(InteractionBotBase, disnake.Client):
             member_cache_flags: Optional[MemberCacheFlags] = None,
             localization_provider: Optional[LocalizationProtocol] = None,
             strict_localization: bool = False,
+            auto_deferred_interactions: bool = False,
         ) -> None:
             ...
 
@@ -506,5 +513,6 @@ class AutoShardedInteractionBot(InteractionBotBase, disnake.AutoShardedClient):
             member_cache_flags: Optional[MemberCacheFlags] = None,
             localization_provider: Optional[LocalizationProtocol] = None,
             strict_localization: bool = False,
+            auto_deferred_interactions: bool = False,
         ) -> None:
             ...


### PR DESCRIPTION
## Summary
Option to automatically defer interactions.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
