### PR TITLE
feat: role flags

### DIFF
--- a/changelog/1069.feature.rst
+++ b/changelog/1069.feature.rst
@@ -1,1 +1,1 @@
-Add :attr:`Role.flags`.
+Add :class:`RoleFlags` type and :attr:`Role.flags`.

--- a/changelog/1069.feature.rst
+++ b/changelog/1069.feature.rst
@@ -1,0 +1,1 @@
+Add :attr:`Role.flags`.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -40,6 +40,7 @@ __all__ = (
     "ChannelFlags",
     "AutoModKeywordPresets",
     "MemberFlags",
+    "RoleFlags",
 )
 
 BF = TypeVar("BF", bound="BaseFlags")
@@ -2289,3 +2290,83 @@ class MemberFlags(BaseFlags):
     def started_onboarding(self):
         """:class:`bool`: Returns ``True`` if the member has started onboarding."""
         return 1 << 3
+
+
+class RoleFlags(BaseFlags):
+    """Wraps up Discord Role flags.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two RoleFlags instances are equal.
+        .. describe:: x != y
+
+            Checks if two RoleFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if an RoleFlags instance is a subset of another RoleFlags instance.
+        .. describe:: x >= y
+
+            Checks if an RoleFlags instance is a superset of another RoleFlags instance.
+        .. describe:: x < y
+
+            Checks if an RoleFlags instance is a strict subset of another RoleFlags instance.
+        .. describe:: x > y
+
+            Checks if an RoleFlags instance is a strict superset of another RoleFlags instance.
+        .. describe:: x | y, x |= y
+
+            Returns a new RoleFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
+        .. describe:: x & y, x &= y
+
+            Returns a new RoleFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
+        .. describe:: x ^ y, x ^= y
+
+            Returns a new RoleFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+        .. describe:: ~x
+
+            Returns a new RoleFlags instance with all flags from x inverted.
+        .. describe:: hash(x)
+
+            Returns the flag's hash.
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        Additionally supported are a few operations on class attributes.
+
+        .. describe:: RoleFlags.y | RoleFlags.z, RoleFlags(y=True) | RoleFlags.z
+
+            Returns a RoleFlags instance with all provided flags enabled.
+
+        .. describe:: ~RoleFlags.y
+
+            Returns a RoleFlags instance with all flags except ``y`` inverted from their default value.
+
+    .. versionadded:: 2.10
+
+    Attributes
+    ----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    __slots__ = ()
+
+    if TYPE_CHECKING:
+
+        @_generated
+        def __init__(self, *, in_prompt: bool = ...) -> None:
+            ...
+
+    @flag_value
+    def in_prompt(self):
+        """:class:`bool`: Returns ``True`` if the role can be selected by members in an onboarding prompt."""
+        return 1 << 0

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1872,6 +1872,7 @@ class HTTPClient:
             "mentionable",
             "icon",
             "unicode_emoji",
+            "flags",
         )
         payload = {k: v for k, v in fields.items() if k in valid_keys}
         return self.request(r, json=payload, reason=reason)

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from .asset import Asset
 from .colour import Colour
+from .flags import RoleFlags
 from .mixins import Hashable
 from .partial_emoji import PartialEmoji
 from .permissions import Permissions
@@ -216,6 +217,7 @@ class Role(Hashable):
         "_emoji",
         "guild",
         "tags",
+        "_flags",
         "_state",
     )
 
@@ -283,6 +285,8 @@ class Role(Hashable):
             self.tags = RoleTags(data["tags"])
         except KeyError:
             self.tags = None
+
+        self._flags: int = data.get("flags", 0)
 
     def is_default(self) -> bool:
         """Checks if the role is the default role.
@@ -393,6 +397,14 @@ class Role(Hashable):
         if self._emoji is None:
             return None
         return PartialEmoji(name=self._emoji)
+
+    @property
+    def flags(self) -> RoleFlags:
+        """:class:`RoleFlags`: Returns the role's flags.
+
+        .. versionadded:: 2.10
+        """
+        return RoleFlags._from_value(self._flags)
 
     @property
     def created_at(self) -> datetime.datetime:

--- a/disnake/types/role.py
+++ b/disnake/types/role.py
@@ -21,6 +21,7 @@ class Role(TypedDict):
     managed: bool
     mentionable: bool
     tags: NotRequired[RoleTags]
+    flags: int
 
 
 class RoleTags(TypedDict, total=False):

--- a/docs/api/roles.rst
+++ b/docs/api/roles.rst
@@ -26,6 +26,17 @@ RoleTags
 .. autoclass:: RoleTags()
     :members:
 
+Data Classes
+------------
+
+RoleFlags
+~~~~~~~~~
+
+.. attributetable:: RoleFlags
+
+.. autoclass:: RoleFlags()
+    :members:
+
 Events
 ------
 


### PR DESCRIPTION
## Summary

Adds `RoleFlags` type and `Role.flags`; currently only includes the `in_prompt` flag for onboarding.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
