### PR TITLE
add intents definition to minimal bot example

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -108,5 +108,8 @@ A quick example to showcase how events work:
         async def on_message(self, message):
             print(f'Message from {message.author}: {message.content}')
 
-    client = MyClient()
+    intents = disnake.Intents.default()
+    intents.message_content = True
+
+    client = MyClient(intents=intents)
     client.run('my token goes here')

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -23,7 +23,10 @@ It looks something like this:
 
     import disnake
 
-    client = disnake.Client()
+    intents = disnake.Intents.default()
+    intents.message_content = True
+
+    client = disnake.Client(intents=intents)
 
     @client.event
     async def on_ready():
@@ -46,20 +49,21 @@ There's a lot going on here, so let's walk you through it step by step.
 
 1. The first line just imports the library, if this raises a `ModuleNotFoundError` or `ImportError`
    then head on over to :ref:`installing` section to properly install.
-2. Next, we create an instance of a :class:`Client`. This client is our connection to Discord.
-3. We then use the :meth:`Client.event` decorator to register an event. This library has many events.
+2. Next, we must define the :class:`Intents` required by the client. Make sure to read :doc:`./intents` for additional information.
+3. Following that, we create an instance of a :class:`Client`. This client is our connection to Discord.
+4. We then use the :meth:`Client.event` decorator to register an event. This library has many events.
    Since this library is asynchronous, we do things in a "callback" style manner.
 
    A callback is essentially a function that is called when something happens. In our case,
    the :func:`on_ready` event is called when the bot has finished logging in and setting things
    up and the :func:`on_message` event is called when the bot has received a message.
-4. Since the :func:`on_message` event triggers for *every* message received, we have to make
+5. Since the :func:`on_message` event triggers for *every* message received, we have to make
    sure that we ignore messages from ourselves. We do this by checking if the :attr:`Message.author`
    is the same as the :attr:`Client.user`.
-5. Afterwards, we check if the :class:`Message.content` starts with ``'$hello'``. If it does,
+6. Afterwards, we check if the :class:`Message.content` starts with ``'$hello'``. If it does,
    then we send a message in the channel it was used in with ``'Hello!'``. This is a basic way of
    handling commands, which can be later automated with the :doc:`./ext/commands/index` framework.
-6. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
+7. Finally, we run the bot with our login token. If you need help getting your token or creating a bot,
    look in the :ref:`discord_intro` section.
 
 


### PR DESCRIPTION
## Summary

Minimal Bot example does not include the now required Intents definitions.
This PR updates the example to include Intents.default() + message_content so that example will work when copy/pasted by new users.

It also updates the steps to elaborate on the addition of Intents and includes instruction to read "A Primer to Gateway Intents"

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] This PR is **not** a code change (e.g. documentation, README, ...)
