### PR TITLE
feat: attachment flags

### DIFF
--- a/changelog/1073.feature.rst
+++ b/changelog/1073.feature.rst
@@ -1,0 +1,1 @@
+Add :class:`AttachmentFlags` and the :attr:`Attachment.flags` attribute.

--- a/changelog/1073.feature.rst
+++ b/changelog/1073.feature.rst
@@ -1,1 +1,1 @@
-Add :class:`AttachmentFlags` and the :attr:`Attachment.flags` attribute.
+Add :class:`AttachmentFlags` type and :attr:`Attachment.flags`.

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -2360,6 +2360,12 @@ class AttachmentFlags(BaseFlags):
 
     __slots__ = ()
 
+    if TYPE_CHECKING:
+
+        @_generated
+        def __init__(self, *, is_remix: bool = ...) -> None:
+            ...
+
     @flag_value
     def is_remix(self):
         """:class:`bool`: Returns ``True`` if the attachment has been edited using the Remix feature."""

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -40,6 +40,7 @@ __all__ = (
     "ChannelFlags",
     "AutoModKeywordPresets",
     "MemberFlags",
+    "AttachmentFlags",
 )
 
 BF = TypeVar("BF", bound="BaseFlags")
@@ -2289,3 +2290,77 @@ class MemberFlags(BaseFlags):
     def started_onboarding(self):
         """:class:`bool`: Returns ``True`` if the member has started onboarding."""
         return 1 << 3
+
+
+class AttachmentFlags(BaseFlags):
+    """Wraps up Discord Attachment flags.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two AttachmentFlags instances are equal.
+        .. describe:: x != y
+
+            Checks if two AttachmentFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if an AttachmentFlags instance is a subset of another AttachmentFlags instance.
+        .. describe:: x >= y
+
+            Checks if an AttachmentFlags instance is a superset of another AttachmentFlags instance.
+        .. describe:: x < y
+
+            Checks if an AttachmentFlags instance is a strict subset of another AttachmentFlags instance.
+        .. describe:: x > y
+
+            Checks if an AttachmentFlags instance is a strict superset of another AttachmentFlags instance.
+        .. describe:: x | y, x |= y
+
+            Returns a new AttachmentFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
+        .. describe:: x & y, x &= y
+
+            Returns a new AttachmentFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
+        .. describe:: x ^ y, x ^= y
+
+            Returns a new AttachmentFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+        .. describe:: ~x
+
+            Returns a new AttachmentFlags instance with all flags from x inverted.
+        .. describe:: hash(x)
+
+            Returns the flag's hash.
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        Additionally supported are a few operations on class attributes.
+
+        .. describe:: AttachmentFlags.y | AttachmentFlags.z, AttachmentFlags(y=True) | AttachmentFlags.z
+
+            Returns a AttachmentFlags instance with all provided flags enabled.
+
+        .. describe:: ~AttachmentFlags.y
+
+            Returns a AttachmentFlags instance with all flags except ``y`` inverted from their default value.
+
+    .. versionadded:: 2.10
+
+    Attributes
+    ----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    __slots__ = ()
+
+    @flag_value
+    def is_remix(self):
+        """:class:`bool`: Returns ``True`` if the attachment has been edited using the Remix feature."""
+        return 1 << 2

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -508,6 +508,8 @@ class Attachment(Hashable):
             result["duration_secs"] = self.duration
         if self.waveform is not None:
             result["waveform"] = b64encode(self.waveform).decode("ascii")
+        if self._flags:
+            result["flags"] = self._flags
         return result
 
 

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -29,7 +29,7 @@ from .emoji import Emoji
 from .enums import ChannelType, InteractionType, MessageType, try_enum, try_enum_to_int
 from .errors import HTTPException
 from .file import File
-from .flags import MessageFlags
+from .flags import AttachmentFlags, MessageFlags
 from .guild import Guild
 from .member import Member
 from .mixins import Hashable
@@ -302,6 +302,7 @@ class Attachment(Hashable):
         "description",
         "duration",
         "waveform",
+        "_flags",
     )
 
     def __init__(self, *, data: AttachmentPayload, state: ConnectionState) -> None:
@@ -320,6 +321,7 @@ class Attachment(Hashable):
         self.waveform: Optional[bytes] = (
             b64decode(waveform_data) if (waveform_data := data.get("waveform")) else None
         )
+        self._flags: int = data.get("flags", 0)
 
     def is_spoiler(self) -> bool:
         """Whether this attachment contains a spoiler.
@@ -333,6 +335,14 @@ class Attachment(Hashable):
 
     def __str__(self) -> str:
         return self.url or ""
+
+    @property
+    def flags(self) -> AttachmentFlags:
+        """:class:`AttachmentFlags`: Returns the attachment's flags.
+
+        .. versionadded:: 2.10
+        """
+        return AttachmentFlags._from_value(self._flags)
 
     async def save(
         self,

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -44,6 +44,7 @@ class Attachment(TypedDict):
     ephemeral: NotRequired[bool]
     duration_secs: NotRequired[float]
     waveform: NotRequired[str]
+    flags: NotRequired[int]
 
 
 MessageActivityType = Literal[1, 2, 3, 5]

--- a/docs/api/messages.rst
+++ b/docs/api/messages.rst
@@ -145,6 +145,14 @@ MessageFlags
 .. autoclass:: MessageFlags()
     :members:
 
+AttachmentFlags
+~~~~~~~~~~~~~~~
+
+.. attributetable:: AttachmentFlags
+
+.. autoclass:: AttachmentFlags()
+    :members:
+
 AllowedMentions
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Adds `AttachmentFlags` and `Attachment.flags`. Flags `1 << 0` and `1 << 1` also exist, but aren't part of the api docs PR yet.

https://github.com/discord/discord-api-docs/pull/6272/files

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
