### PR TITLE
fix(codemod): reinstate context module reference

### DIFF
--- a/scripts/codemods/base.py
+++ b/scripts/codemods/base.py
@@ -1,18 +1,40 @@
 # SPDX-License-Identifier: MIT
 
-import contextlib
 from abc import ABC
-from typing import ClassVar, Optional
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, ClassVar, Optional
 
 import libcst as cst
 import libcst.codemod as codemod
 
+if TYPE_CHECKING:
+    base_type = codemod.Codemod
+else:
+    base_type = object
 
-class NoMetadataWrapperMixin:
-    # stub the metadata wrapper, which deepcopies the entire module on initialization
-    # (`unsafe_skip_copy` exists but it can't be set in the general case)
-    # (I think this should be fine?)
-    _handle_metadata_reference = contextlib.nullcontext
+ctx_unsafe_skip_copy = ContextVar("ctx_unsafe_skip_copy", default=False)
+
+
+class NoMetadataWrapperMixin(base_type):
+    # Tag type for the metadata wrapper, which prevents it from
+    # deepcopying the entire module on initialization
+
+    @contextmanager
+    def _handle_metadata_reference(self, tree: cst.Module):
+        ctx_unsafe_skip_copy.set(True)
+        with super()._handle_metadata_reference(tree) as res:
+            ctx_unsafe_skip_copy.set(False)
+            yield res
+
+
+def patched_init(*args, _orig=cst.MetadataWrapper.__init__, **kwargs):
+    if ctx_unsafe_skip_copy.get():
+        kwargs["unsafe_skip_copy"] = True
+    return _orig(*args, **kwargs)
+
+
+cst.MetadataWrapper.__init__ = patched_init
 
 
 # similar to `VisitorBasedCodemodCommand`,


### PR DESCRIPTION
## Summary

followup to #1053, fixes `self.context.module` access in codemods

see https://github.com/DisnakeDev/disnake/actions/runs/5507790654/jobs/10038222160#step:7:97 for previous CI failure

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
