### PR TITLE
feat(webhook): improve thread support for webhook messages 

### DIFF
--- a/changelog/1077.feature.rst
+++ b/changelog/1077.feature.rst
@@ -1,0 +1,1 @@
+Add support for threads in :meth:`Webhook.fetch_message`, :meth:`~Webhook.edit_message`, and :meth:`~Webhook.delete_message`, as well as their sync counterparts.


### PR DESCRIPTION
## Summary

Adds a `thread` parameter to `Webhook.fetch_message`, `edit_message`, and `delete_message`, and handles this appropriately in `WebhookMessage.edit`/`.delete`.
Previously, threads were only fully supported in `Webhook.send`.

context: https://canary.discord.com/channels/808030843078836254/942319505915412500/1129444052035698768

https://github.com/discord/discord-api-docs/commit/528975f5c2519c8548eccfe5ee288938382f2141

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
