### PR TITLE
feat: add `RawReactionActionEvent.message_author_id`

### DIFF
--- a/changelog/1079.feature.rst
+++ b/changelog/1079.feature.rst
@@ -1,0 +1,1 @@
+Add :attr:`RawReactionActionEvent.message_author_id`.

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -6,7 +6,7 @@ import datetime
 from typing import TYPE_CHECKING, List, Literal, Optional, Set, Union, cast
 
 from .enums import ChannelType, try_enum
-from .utils import get_slots
+from .utils import _get_as_snowflake, get_slots
 
 if TYPE_CHECKING:
     from .member import Member
@@ -179,9 +179,25 @@ class RawReactionActionEvent(_RawReprMixin):
         ``REACTION_REMOVE`` for reaction removal.
 
         .. versionadded:: 1.3
+
+    message_author_id: Optional[:class:`int`]
+        The ID of the author who created the message that was reacted to.
+        Only available if `event_type` is `REACTION_ADD`.
+        May also be ``None`` if the message was created by a webhook.
+
+        .. versionadded:: 2.10
     """
 
-    __slots__ = ("message_id", "user_id", "channel_id", "guild_id", "emoji", "event_type", "member")
+    __slots__ = (
+        "message_id",
+        "user_id",
+        "channel_id",
+        "guild_id",
+        "emoji",
+        "event_type",
+        "member",
+        "message_author_id",
+    )
 
     def __init__(
         self,
@@ -199,6 +215,7 @@ class RawReactionActionEvent(_RawReprMixin):
             self.guild_id: Optional[int] = int(data["guild_id"])
         except KeyError:
             self.guild_id: Optional[int] = None
+        self.message_author_id: Optional[int] = _get_as_snowflake(data, "message_author_id")
 
 
 class RawReactionClearEvent(_RawReprMixin):

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -169,7 +169,7 @@ class RawReactionActionEvent(_RawReprMixin):
             This now also includes the correct :attr:`~PartialEmoji.animated` value when a reaction was removed.
 
     member: Optional[:class:`Member`]
-        The member who added the reaction. Only available if `event_type` is `REACTION_ADD` and the reaction is inside a guild.
+        The member who added the reaction. Only available if :attr:`event_type` is ``REACTION_ADD`` and the reaction is inside a guild.
 
         .. versionadded:: 1.3
 
@@ -182,7 +182,7 @@ class RawReactionActionEvent(_RawReprMixin):
 
     message_author_id: Optional[:class:`int`]
         The ID of the author who created the message that was reacted to.
-        Only available if `event_type` is `REACTION_ADD`.
+        Only available if :attr:`event_type` is ``REACTION_ADD``.
         May also be ``None`` if the message was created by a webhook.
 
         .. versionadded:: 2.10

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -181,7 +181,7 @@ class RawReactionActionEvent(_RawReprMixin):
         .. versionadded:: 1.3
 
     message_author_id: Optional[:class:`int`]
-        The ID of the author who created the message that was reacted to.
+        The ID of the author who created the message that got a reaction.
         Only available if :attr:`event_type` is ``REACTION_ADD``.
         May also be ``None`` if the message was created by a webhook.
 

--- a/disnake/types/gateway.py
+++ b/disnake/types/gateway.py
@@ -299,6 +299,7 @@ class _BaseReactionEvent(TypedDict):
 # https://discord.com/developers/docs/topics/gateway-events#message-reaction-add
 class MessageReactionAddEvent(_BaseReactionEvent):
     member: NotRequired[MemberWithUser]
+    message_author_id: NotRequired[Snowflake]
 
 
 # https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/095e858ee3838ebf343d408c8a6b31ed96e878e4
https://github.com/discord/discord-api-docs/commit/26b95485354b4d583b35f6dd5b149d1ab0ff42ae

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
