### PR TITLE
fix(guild): don't cache emojis/stickers/scheduled events if intent is disabled

### DIFF
--- a/changelog/1083.bugfix.rst
+++ b/changelog/1083.bugfix.rst
@@ -1,0 +1,1 @@
+Don't cache :attr:`Guild.emojis`, :attr:`~Guild.stickers`, or :attr:`~Guild.scheduled_events` if the corresponding intent is disabled.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -590,12 +590,13 @@ class Guild(Hashable):
                 stage_instance = StageInstance(guild=self, data=s, state=state)
                 self._stage_instances[stage_instance.id] = stage_instance
 
-        scheduled_events = guild.get("guild_scheduled_events")
-        if scheduled_events is not None:
-            self._scheduled_events = {}
-            for e in scheduled_events:
-                scheduled_event = GuildScheduledEvent(state=state, data=e)
-                self._scheduled_events[scheduled_event.id] = scheduled_event
+        if not from_gateway or state._intents.guild_scheduled_events:
+            scheduled_events = guild.get("guild_scheduled_events")
+            if scheduled_events is not None:
+                self._scheduled_events = {}
+                for e in scheduled_events:
+                    scheduled_event = GuildScheduledEvent(state=state, data=e)
+                    self._scheduled_events[scheduled_event.id] = scheduled_event
 
         cache_joined = self._state.member_cache_flags.joined
         self_id = self._state.self_id

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -364,7 +364,9 @@ class Guild(Hashable):
         3: _GuildLimit(emoji=250, stickers=60, bitrate=384e3, filesize=104857600),
     }
 
-    def __init__(self, *, data: GuildPayload, state: ConnectionState) -> None:
+    def __init__(
+        self, *, data: GuildPayload, state: ConnectionState, from_gateway: bool = False
+    ) -> None:
         self._channels: Dict[int, GuildChannel] = {}
         self._members: Dict[int, Member] = {}
         self._voice_states: Dict[int, VoiceState] = {}
@@ -372,7 +374,7 @@ class Guild(Hashable):
         self._stage_instances: Dict[int, StageInstance] = {}
         self._scheduled_events: Dict[int, GuildScheduledEvent] = {}
         self._state: ConnectionState = state
-        self._from_data(data)
+        self._from_data(data, from_gateway=from_gateway)
 
     def _add_channel(self, channel: GuildChannel, /) -> None:
         self._channels[channel.id] = channel
@@ -512,7 +514,7 @@ class Guild(Hashable):
         """
         return self._state._get_guild_command_named(self.id, name)
 
-    def _from_data(self, guild: GuildPayload) -> None:
+    def _from_data(self, guild: GuildPayload, *, from_gateway: bool = False) -> None:
         # according to Stan, this is always available even if the guild is unavailable
         # I don't have this guarantee when someone updates the guild.
         member_count = guild.get("member_count", None)
@@ -535,6 +537,7 @@ class Guild(Hashable):
         self._banner: Optional[str] = guild.get("banner")
         self.unavailable: bool = guild.get("unavailable", False)
         self.id: int = int(guild["id"])
+
         self._roles: Dict[int, Role] = {}
         state = self._state  # speed up attribute access
         for r in guild.get("roles", []):
@@ -542,12 +545,14 @@ class Guild(Hashable):
             self._roles[role.id] = role
 
         self.mfa_level: MFALevel = guild.get("mfa_level", 0)
-        self.emojis: Tuple[Emoji, ...] = tuple(
-            state.store_emoji(self, d) for d in guild.get("emojis", [])
-        )
-        self.stickers: Tuple[GuildSticker, ...] = tuple(
-            state.store_sticker(self, d) for d in guild.get("stickers", [])
-        )
+
+        self.emojis: Tuple[Emoji, ...] = ()
+        self.stickers: Tuple[GuildSticker, ...] = ()
+        # don't cache emojis/stickers if this is part of a gw event and the intent is disabled
+        if not from_gateway or state._intents.emojis_and_stickers:
+            self.emojis = tuple(state.store_emoji(self, d) for d in guild.get("emojis", []))
+            self.stickers = tuple(state.store_sticker(self, d) for d in guild.get("stickers", []))
+
         self.features: List[GuildFeature] = guild.get("features", [])
         self._splash: Optional[str] = guild.get("splash")
         self._system_channel_id: Optional[int] = utils._get_as_snowflake(guild, "system_channel_id")

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -549,6 +549,7 @@ class Guild(Hashable):
         self.emojis: Tuple[Emoji, ...] = ()
         self.stickers: Tuple[GuildSticker, ...] = ()
         # don't cache emojis/stickers if this is part of a gw event and the intent is disabled
+        # (we still want to store them on this guild object even with the intent disabled if obtained from `fetch_guild` etc.)
         if not from_gateway or state._intents.emojis_and_stickers:
             self.emojis = tuple(state.store_emoji(self, d) for d in guild.get("emojis", []))
             self.stickers = tuple(state.store_sticker(self, d) for d in guild.get("stickers", []))

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1366,8 +1366,8 @@ class ConnectionState:
             return
 
         before_stickers = guild.stickers
-        for emoji in before_stickers:
-            self._stickers.pop(emoji.id, None)
+        for sticker in before_stickers:
+            self._stickers.pop(sticker.id, None)
         guild.stickers = tuple(self.store_sticker(guild, d) for d in data["stickers"])
         self.dispatch("guild_stickers_update", guild, before_stickers, guild.stickers)
 

--- a/disnake/template.py
+++ b/disnake/template.py
@@ -46,7 +46,14 @@ class _PartialTemplateState:
     def member_cache_flags(self):
         return self.__state.member_cache_flags
 
-    def store_emoji(self, guild, packet):
+    @property
+    def _intents(self):
+        return self.__state._intents
+
+    def store_emoji(self, guild, data):
+        return None
+
+    def store_sticker(self, guild, data):
         return None
 
     def _get_voice_client(self, id):


### PR DESCRIPTION
## Summary

Discord sends some fields in `GUILD_CREATE`s that are otherwise gated by intents, previously resulting in the library caching (and never updating) `emojis`, `stickers`, and `scheduled_events` even with the intent disabled.

This PR fixes the caching behavior to only cache them if the corresponding intent is enabled. It shouldn't affect non-gw guilds like those from `fetch_guild` etc., which continue to populate the emoji/sticker attributes.

No documentation changes since it didn't seem necessary, but can be added if there's demand for it.

This was brought up here: https://canary.discord.com/channels/808030843078836254/942319505915412500/1130943549937029170

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
