### PR TITLE
feat(webhook): add `applied_tags` parameter

### DIFF
--- a/changelog/1085.feature.rst
+++ b/changelog/1085.feature.rst
@@ -1,0 +1,1 @@
+Add ``applied_tags`` parameter to :meth:`Webhook.send`.

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -492,7 +492,10 @@ def handle_message_parameters_dict(
     allowed_mentions: Optional[AllowedMentions] = MISSING,
     previous_allowed_mentions: Optional[AllowedMentions] = None,
     stickers: Sequence[Union[GuildSticker, StickerItem]] = MISSING,
+    # these parameters are exclusive to webhooks in forum channels
+    # XXX: consider moving serialization of these elsewhere?
     thread_name: Optional[str] = None,
+    applied_tags: Optional[Sequence[Snowflake]] = None,
 ) -> DictPayloadParameters:
     if files is not MISSING and file is not MISSING:
         raise TypeError("Cannot mix file and files keyword arguments.")
@@ -556,6 +559,8 @@ def handle_message_parameters_dict(
 
     if thread_name is not None:
         payload["thread_name"] = thread_name
+    if applied_tags:
+        payload["applied_tags"] = [t.id for t in applied_tags]
 
     return DictPayloadParameters(payload=payload, files=files)
 
@@ -579,7 +584,9 @@ def handle_message_parameters(
     allowed_mentions: Optional[AllowedMentions] = MISSING,
     previous_allowed_mentions: Optional[AllowedMentions] = None,
     stickers: Sequence[Union[GuildSticker, StickerItem]] = MISSING,
+    # these parameters are exclusive to webhooks in forum channels
     thread_name: Optional[str] = None,
+    applied_tags: Optional[Sequence[Snowflake]] = None,
 ) -> PayloadParameters:
     params = handle_message_parameters_dict(
         content=content,
@@ -600,6 +607,7 @@ def handle_message_parameters(
         previous_allowed_mentions=previous_allowed_mentions,
         stickers=stickers,
         thread_name=thread_name,
+        applied_tags=applied_tags,
     )
 
     if params.files:
@@ -1451,6 +1459,7 @@ class Webhook(BaseWebhook):
         components: Components[MessageUIComponent] = ...,
         thread: Snowflake = ...,
         thread_name: str = ...,
+        applied_tags: Sequence[Snowflake] = ...,
         wait: Literal[True],
         delete_after: float = ...,
     ) -> WebhookMessage:
@@ -1476,6 +1485,7 @@ class Webhook(BaseWebhook):
         components: Components[MessageUIComponent] = ...,
         thread: Snowflake = ...,
         thread_name: str = ...,
+        applied_tags: Sequence[Snowflake] = ...,
         wait: Literal[False] = ...,
         delete_after: float = ...,
     ) -> None:
@@ -1500,6 +1510,7 @@ class Webhook(BaseWebhook):
         components: Components[MessageUIComponent] = MISSING,
         thread: Snowflake = MISSING,
         thread_name: Optional[str] = None,
+        applied_tags: Sequence[Snowflake] = MISSING,
         wait: bool = False,
         delete_after: float = MISSING,
     ) -> Optional[WebhookMessage]:
@@ -1515,6 +1526,10 @@ class Webhook(BaseWebhook):
         If the ``embed`` parameter is provided, it must be of type :class:`Embed` and
         it must be a rich embed type. You cannot mix the ``embed`` parameter with the
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
+
+        To send a message in a thread, provide the ``thread`` parameter.
+        If this webhook is in a :class:`ForumChannel`, the ``thread_name`` parameter can
+        be used to create a new thread instead (optionally with ``applied_tags``).
 
         .. versionchanged:: 2.6
             Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
@@ -1587,6 +1602,11 @@ class Webhook(BaseWebhook):
                 representing the created thread, may be a :class:`PartialMessageable`.
 
             .. versionadded:: 2.6
+        applied_tags: Sequence[:class:`abc.Snowflake`]
+            If in a forum channel and creating a new thread (see ``thread_name`` above),
+            the tags to apply to the new thread. Maximum of 5.
+
+            .. versionadded:: 2.10
 
         wait: :class:`bool`
             Whether the server should wait before sending a response. This essentially
@@ -1632,7 +1652,7 @@ class Webhook(BaseWebhook):
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
             ``ephemeral`` was passed with the improper webhook type.
             There was no state attached with this webhook when giving it a view.
-            Both ``thread`` and ``thread_name`` were provided.
+            Both ``thread`` and ``thread_name``/``applied_tags`` were provided.
         WebhookTokenMissing
             There was no token associated with this webhook.
         ValueError
@@ -1666,8 +1686,8 @@ class Webhook(BaseWebhook):
                 view.timeout = 15 * 60.0
 
         thread_id: Optional[int] = None
-        if thread is not MISSING and thread_name is not None:
-            raise TypeError("only one of thread and thread_name can be provided.")
+        if thread is not MISSING and (thread_name is not None or applied_tags is not MISSING):
+            raise TypeError("Cannot use `thread_name` or `applied_tags` when `thread` is provided.")
         elif thread is not MISSING:
             thread_id = thread.id
 
@@ -1686,6 +1706,7 @@ class Webhook(BaseWebhook):
             view=view,
             components=components,
             thread_name=thread_name,
+            applied_tags=applied_tags,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
         )

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -493,7 +493,6 @@ def handle_message_parameters_dict(
     previous_allowed_mentions: Optional[AllowedMentions] = None,
     stickers: Sequence[Union[GuildSticker, StickerItem]] = MISSING,
     # these parameters are exclusive to webhooks in forum channels
-    # XXX: consider moving serialization of these elsewhere?
     thread_name: str = MISSING,
     applied_tags: Sequence[Snowflake] = MISSING,
 ) -> DictPayloadParameters:

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -494,8 +494,8 @@ def handle_message_parameters_dict(
     stickers: Sequence[Union[GuildSticker, StickerItem]] = MISSING,
     # these parameters are exclusive to webhooks in forum channels
     # XXX: consider moving serialization of these elsewhere?
-    thread_name: Optional[str] = None,
-    applied_tags: Optional[Sequence[Snowflake]] = None,
+    thread_name: str = MISSING,
+    applied_tags: Sequence[Snowflake] = MISSING,
 ) -> DictPayloadParameters:
     if files is not MISSING and file is not MISSING:
         raise TypeError("Cannot mix file and files keyword arguments.")
@@ -557,7 +557,7 @@ def handle_message_parameters_dict(
     if stickers is not MISSING:
         payload["sticker_ids"] = [s.id for s in stickers]
 
-    if thread_name is not None:
+    if thread_name:
         payload["thread_name"] = thread_name
     if applied_tags:
         payload["applied_tags"] = [t.id for t in applied_tags]
@@ -585,8 +585,8 @@ def handle_message_parameters(
     previous_allowed_mentions: Optional[AllowedMentions] = None,
     stickers: Sequence[Union[GuildSticker, StickerItem]] = MISSING,
     # these parameters are exclusive to webhooks in forum channels
-    thread_name: Optional[str] = None,
-    applied_tags: Optional[Sequence[Snowflake]] = None,
+    thread_name: str = MISSING,
+    applied_tags: Sequence[Snowflake] = MISSING,
 ) -> PayloadParameters:
     params = handle_message_parameters_dict(
         content=content,
@@ -1509,7 +1509,7 @@ class Webhook(BaseWebhook):
         view: View = MISSING,
         components: Components[MessageUIComponent] = MISSING,
         thread: Snowflake = MISSING,
-        thread_name: Optional[str] = None,
+        thread_name: str = MISSING,
         applied_tags: Sequence[Snowflake] = MISSING,
         wait: bool = False,
         delete_after: float = MISSING,
@@ -1686,9 +1686,11 @@ class Webhook(BaseWebhook):
                 view.timeout = 15 * 60.0
 
         thread_id: Optional[int] = None
-        if thread is not MISSING and (thread_name is not None or applied_tags is not MISSING):
-            raise TypeError("Cannot use `thread_name` or `applied_tags` when `thread` is provided.")
-        elif thread is not MISSING:
+        if thread is not MISSING:
+            if thread_name or applied_tags:
+                raise TypeError(
+                    "Cannot use `thread_name` or `applied_tags` when `thread` is provided."
+                )
             thread_id = thread.id
 
         params = handle_message_parameters(

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -926,7 +926,7 @@ class SyncWebhook(BaseWebhook):
         flags: MessageFlags = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         thread: Snowflake = MISSING,
-        thread_name: Optional[str] = None,
+        thread_name: str = MISSING,
         applied_tags: Sequence[Snowflake] = MISSING,
         wait: bool = False,
     ) -> Optional[SyncWebhookMessage]:
@@ -1046,9 +1046,11 @@ class SyncWebhook(BaseWebhook):
             content = MISSING
 
         thread_id: Optional[int] = None
-        if thread is not MISSING and (thread_name is not None or applied_tags is not MISSING):
-            raise TypeError("Cannot use `thread_name` or `applied_tags` when `thread` is provided.")
-        elif thread is not MISSING:
+        if thread is not MISSING:
+            if thread_name or applied_tags:
+                raise TypeError(
+                    "Cannot use `thread_name` or `applied_tags` when `thread` is provided."
+                )
             thread_id = thread.id
 
         params = handle_message_parameters(

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -13,7 +13,19 @@ import re
 import threading
 import time
 from errno import ECONNRESET
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 from urllib.parse import quote as urlquote
 
 from .. import utils
@@ -872,6 +884,7 @@ class SyncWebhook(BaseWebhook):
         allowed_mentions: AllowedMentions = ...,
         thread: Snowflake = ...,
         thread_name: str = ...,
+        applied_tags: Sequence[Snowflake] = ...,
         wait: Literal[True],
     ) -> SyncWebhookMessage:
         ...
@@ -893,6 +906,7 @@ class SyncWebhook(BaseWebhook):
         allowed_mentions: AllowedMentions = ...,
         thread: Snowflake = ...,
         thread_name: str = ...,
+        applied_tags: Sequence[Snowflake] = ...,
         wait: Literal[False] = ...,
     ) -> None:
         ...
@@ -913,6 +927,7 @@ class SyncWebhook(BaseWebhook):
         allowed_mentions: AllowedMentions = MISSING,
         thread: Snowflake = MISSING,
         thread_name: Optional[str] = None,
+        applied_tags: Sequence[Snowflake] = MISSING,
         wait: bool = False,
     ) -> Optional[SyncWebhookMessage]:
         """Sends a message using the webhook.
@@ -925,6 +940,10 @@ class SyncWebhook(BaseWebhook):
         If the ``embed`` parameter is provided, it must be of type :class:`Embed` and
         it must be a rich embed type. You cannot mix the ``embed`` parameter with the
         ``embeds`` parameter, which must be a :class:`list` of :class:`Embed` objects to send.
+
+        To send a message in a thread, provide the ``thread`` parameter.
+        If this webhook is in a :class:`ForumChannel`, the ``thread_name`` parameter can
+        be used to create a new thread instead (optionally with ``applied_tags``).
 
         .. versionchanged:: 2.6
             Raises :exc:`WebhookTokenMissing` instead of ``InvalidArgument``.
@@ -963,10 +982,16 @@ class SyncWebhook(BaseWebhook):
             .. versionadded:: 2.0
 
         thread_name: :class:`str`
-            If in a forum channel, and thread is not specified,
+            If in a forum channel, and ``thread`` is not specified,
             the name of the newly created thread.
 
             .. versionadded:: 2.6
+
+        applied_tags: Sequence[:class:`abc.Snowflake`]
+            If in a forum channel and creating a new thread (see ``thread_name`` above),
+            the tags to apply to the new thread. Maximum of 5.
+
+            .. versionadded:: 2.10
 
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This hides
@@ -999,7 +1024,7 @@ class SyncWebhook(BaseWebhook):
             The authorization token for the webhook is incorrect.
         TypeError
             You specified both ``embed`` and ``embeds`` or ``file`` and ``files``,
-            or both ``thread`` and ``thread_name`` were provided.
+            or both ``thread`` and ``thread_name``/``applied_tags`` were provided.
 
         ValueError
             The length of ``embeds`` was invalid
@@ -1021,8 +1046,8 @@ class SyncWebhook(BaseWebhook):
             content = MISSING
 
         thread_id: Optional[int] = None
-        if thread is not MISSING and thread_name is not None:
-            raise TypeError("only one of thread and thread_name can be provided.")
+        if thread is not MISSING and (thread_name is not None or applied_tags is not MISSING):
+            raise TypeError("Cannot use `thread_name` or `applied_tags` when `thread` is provided.")
         elif thread is not MISSING:
             thread_id = thread.id
 
@@ -1038,6 +1063,7 @@ class SyncWebhook(BaseWebhook):
             embed=embed,
             embeds=embeds,
             thread_name=thread_name,
+            applied_tags=applied_tags,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
         )


### PR DESCRIPTION
## Summary

Executing a webhook in a forum channel now supports setting `applied_tags` on thread creation (using `thread_name`).

https://github.com/discord/discord-api-docs/commit/4060a747f67f8a66ff85e1f34c1cc96f0a5a2c23

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
