### PR TITLE
feat(activity): fall back to `name` for custom activities

### DIFF
--- a/changelog/1087.feature.rst
+++ b/changelog/1087.feature.rst
@@ -1,0 +1,1 @@
+Make :attr:`CustomActivity.state` fall back to the provided :attr:`~CustomActivity.name`, simplifying setting a custom status.

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -754,6 +754,8 @@ class CustomActivity(BaseActivity):
         The custom activity's name.
     emoji: Optional[:class:`PartialEmoji`]
         The emoji to pass to the activity, if any.
+
+        This currently cannot be set by bots.
     """
 
     __slots__ = ("name", "emoji", "state")
@@ -768,7 +770,10 @@ class CustomActivity(BaseActivity):
     ) -> None:
         super().__init__(**kwargs)
         self.name: Optional[str] = name
-        self.state: Optional[str] = state
+        # fall back to `name`, since `state` is the relevant field for custom status (`name` is not shown)
+        self.state: Optional[str] = state or name
+
+        # The official client uses "Custom Status" as the name, the actual name is in `state`
         if self.name == "Custom Status":
             self.name = self.state
 

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -770,7 +770,7 @@ class CustomActivity(BaseActivity):
     ) -> None:
         super().__init__(**kwargs)
         self.name: Optional[str] = name
-        # fall back to `name`, since `state` is the relevant field for custom status (`name` is not shown)
+        # Fall back to `name`, since `state` is the relevant field for custom status (`name` is not shown)
         self.state: Optional[str] = state or name
 
         # The official client uses "Custom Status" as the name, the actual name is in `state`
@@ -867,7 +867,9 @@ def create_activity(
 
     activity: ActivityTypes
     game_type = try_enum(ActivityType, data.get("type", -1))
-    if game_type is ActivityType.playing and not ("application_id" in data or "session_id" in data):
+    if game_type is ActivityType.playing and not (
+        "application_id" in data or "session_id" in data or "state" in data
+    ):
         activity = Game(**data)  # type: ignore  # pyright bug(?)
     elif game_type is ActivityType.custom and "name" in data:
         activity = CustomActivity(**data)  # type: ignore

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -87,8 +87,8 @@ Where can I find usage examples?
 Example code can be found in the `examples folder <https://github.com/DisnakeDev/disnake/tree/master/examples>`_
 in the repository.
 
-How do I set the "Playing" status?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I set an activity/status?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``activity`` keyword argument may be passed in the :class:`Client` constructor or :meth:`Client.change_presence`, given an :class:`Activity` object.
 
@@ -100,15 +100,19 @@ The constructor may be used for static activities, while :meth:`Client.change_pr
 
     There is a high chance of disconnecting if presences are changed right after connecting.
 
-The status type (playing, listening, streaming, watching) can be set using the :class:`ActivityType` enum.
+The status type (playing, listening, streaming, watching, or custom) can be set using the :class:`ActivityType` enum.
 For memory optimisation purposes, some activities are offered in slimmed-down versions:
 
 - :class:`Game`
 - :class:`Streaming`
+- :class:`CustomActivity`
 
 Putting both of these pieces of info together, you get the following: ::
 
     client = disnake.Client(activity=disnake.Game(name='my game'))
+
+    # alternatively, a plain custom status:
+    client = disnake.Client(activity=disnake.CustomActivity(name='As seen on TV!'))
 
     # or, for watching:
     activity = disnake.Activity(name='my activity', type=disnake.ActivityType.watching)


### PR DESCRIPTION
## Summary

Bots can now [set a custom status](https://github.com/discord/discord-api-docs/commit/c3935ae1f5fe68228d06d0a9f247e330b1c92dbf) using the `state` field in type 4 activities.

This already works using `activity=CustomActivity(state="Now with 200% more bees!", name="Custom Status")`, but is unnecessarily complicated. `name` is required but not displayed, it just has to be non-empty.
To simplify things, we now just make `state` fall back to `name` if unset, such that `CustomActivity(name="...")` works as-is.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
