### PR TITLE
fix: don't pop key in `MessageReference.with_state`

### DIFF
--- a/disnake/message.py
+++ b/disnake/message.py
@@ -603,7 +603,7 @@ class MessageReference:
     def with_state(cls, state: ConnectionState, data: MessageReferencePayload) -> Self:
         self = cls.__new__(cls)
         self.message_id = utils._get_as_snowflake(data, "message_id")
-        self.channel_id = int(data.pop("channel_id"))
+        self.channel_id = int(data["channel_id"])
         self.guild_id = utils._get_as_snowflake(data, "guild_id")
         self.fail_if_not_exists = data.get("fail_if_not_exists", True)
         self._state = state
@@ -658,10 +658,9 @@ class MessageReference:
         return f"<MessageReference message_id={self.message_id!r} channel_id={self.channel_id!r} guild_id={self.guild_id!r}>"
 
     def to_dict(self) -> MessageReferencePayload:
-        result: MessageReferencePayload = (
-            {"message_id": self.message_id} if self.message_id is not None else {}
-        )
-        result["channel_id"] = self.channel_id
+        result: MessageReferencePayload = {"channel_id": self.channel_id}
+        if self.message_id is not None:
+            result["message_id"] = self.message_id
         if self.guild_id is not None:
             result["guild_id"] = self.guild_id
         if self.fail_if_not_exists is not None:

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -63,11 +63,11 @@ class MessageApplication(TypedDict):
     cover_image: NotRequired[str]
 
 
-class MessageReference(TypedDict, total=False):
-    message_id: Snowflake
+class MessageReference(TypedDict):
+    message_id: NotRequired[Snowflake]
     channel_id: Snowflake
-    guild_id: Snowflake
-    fail_if_not_exists: bool
+    guild_id: NotRequired[Snowflake]
+    fail_if_not_exists: NotRequired[bool]
 
 
 class RoleSubscriptionData(TypedDict):


### PR DESCRIPTION
## Summary

This doesn't affect 99.9% of cases, but there's no reason to mutate the data here regardless.
https://canary.discord.com/channels/808030843078836254/942319505915412500/1144016456447688835

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
