### PR TITLE
feat: add `created_at` to more models

### DIFF
--- a/changelog/1095.feature.rst
+++ b/changelog/1095.feature.rst
@@ -1,0 +1,1 @@
+Add ``created_at`` property to :attr:`AutoModRule <AutoModRule.created_at>`, :attr:`ForumTag <ForumTag.created_at>`, :attr:`Integration <Integration.created_at>`, :attr:`StageInstance <StageInstance.created_at>`, and :attr:`Team <Team.created_at>`.

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+import datetime
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -25,7 +25,7 @@ from .enums import (
     try_enum_to_int,
 )
 from .flags import AutoModKeywordPresets
-from .utils import MISSING, _get_as_snowflake
+from .utils import MISSING, _get_as_snowflake, snowflake_time
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -207,10 +207,10 @@ class AutoModTimeoutAction(AutoModAction):
 
     _metadata: AutoModTimeoutActionMetadata
 
-    def __init__(self, duration: Union[int, timedelta]) -> None:
+    def __init__(self, duration: Union[int, datetime.timedelta]) -> None:
         super().__init__(type=AutoModActionType.timeout)
 
-        if isinstance(duration, timedelta):
+        if isinstance(duration, datetime.timedelta):
             duration = int(duration.total_seconds())
         self._metadata["duration_seconds"] = duration
 
@@ -491,6 +491,14 @@ class AutoModRule:
             if (exempt_channels := data.get("exempt_channels"))
             else frozenset()
         )
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the rule's creation time in UTC.
+
+        .. versionadded:: 2.10
+        """
+        return snowflake_time(self.id)
 
     @property
     def actions(self) -> List[AutoModAction]:

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -7,7 +7,14 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 from .enums import ExpireBehaviour, try_enum
 from .user import User
-from .utils import MISSING, _get_as_snowflake, deprecated, parse_time, warn_deprecated
+from .utils import (
+    MISSING,
+    _get_as_snowflake,
+    deprecated,
+    parse_time,
+    snowflake_time,
+    warn_deprecated,
+)
 
 __all__ = (
     "IntegrationAccount",
@@ -98,6 +105,15 @@ class PartialIntegration:
         self.name: str = data["name"]
         self.account: IntegrationAccount = IntegrationAccount(data["account"])
         self.application_id: Optional[int] = _get_as_snowflake(data, "application_id")
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the integration's
+        (*not* the associated application's) creation time in UTC.
+
+        .. versionadded:: 2.10
+        """
+        return snowflake_time(self.id)
 
 
 class Integration(PartialIntegration):

--- a/disnake/stage_instance.py
+++ b/disnake/stage_instance.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING, Optional
 
 from .enums import StagePrivacyLevel, try_enum
 from .mixins import Hashable
-from .utils import MISSING, _get_as_snowflake, cached_slot_property, warn_deprecated
+from .utils import MISSING, _get_as_snowflake, cached_slot_property, snowflake_time, warn_deprecated
 
 __all__ = ("StageInstance",)
 
@@ -83,6 +84,14 @@ class StageInstance(Hashable):
 
     def __repr__(self) -> str:
         return f"<StageInstance id={self.id} guild={self.guild!r} channel_id={self.channel_id} topic={self.topic!r}>"
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the stage instance's creation time in UTC.
+
+        .. versionadded:: 2.10
+        """
+        return snowflake_time(self.id)
 
     @cached_slot_property("_cs_channel")
     def channel(self) -> Optional[StageChannel]:

--- a/disnake/team.py
+++ b/disnake/team.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING, List, Optional
 
 from . import utils
@@ -51,6 +52,14 @@ class Team:
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id} name={self.name}>"
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the team's creation time in UTC.
+
+        .. versionadded:: 2.10
+        """
+        return utils.snowflake_time(self.id)
 
     @property
     def icon(self) -> Optional[Asset]:

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -332,7 +332,7 @@ class Thread(Messageable, Hashable):
         """:class:`datetime.datetime`: Returns the thread's creation time in UTC.
 
         .. versionchanged:: 2.4
-            If create_timestamp is provided by discord, that will be used instead of the time in the ID.
+            If ``create_timestamp`` is provided by Discord, that will be used instead of the time in the ID.
         """
         return self.create_timestamp or snowflake_time(self.id)
 
@@ -1182,6 +1182,14 @@ class ForumTag(Hashable):
             f"<ForumTag id={self.id!r} name={self.name!r}"
             f" moderated={self.moderated!r} emoji={self.emoji!r}>"
         )
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the tag's creation time in UTC.
+
+        .. versionadded:: 2.10
+        """
+        return snowflake_time(self.id)
 
     def to_dict(self) -> PartialForumTagPayload:
         emoji_name, emoji_id = PartialEmoji._emoji_to_name_id(self.emoji)


### PR DESCRIPTION
## Summary

Noticed that `Team.created_at` didn't exist, and took the opportunity to add it in other places as well - `AutoModRule`, `ForumTag`, `PartialIntegration` (inherently applies to all subclasses), `StageInstance`, and `Team`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
