### PR TITLE
feat(auditlog): support `integration_type` field

### DIFF
--- a/changelog/1096.feature.rst
+++ b/changelog/1096.feature.rst
@@ -1,0 +1,1 @@
+Support ``integration_type`` field in :attr:`AuditLogEntry.extra` (for :attr:`~AuditLogAction.kick` and :attr:`~AuditLogAction.member_role_update` actions).

--- a/disnake/types/audit_log.py
+++ b/disnake/types/audit_log.py
@@ -300,6 +300,8 @@ AuditLogChange = Union[
 ]
 
 
+# All of these are technically only required for matching event types,
+# but they're typed as required keys for simplicity
 class AuditEntryInfo(TypedDict):
     delete_member_days: str
     members_removed: str
@@ -312,6 +314,7 @@ class AuditEntryInfo(TypedDict):
     application_id: Snowflake
     auto_moderation_rule_name: str
     auto_moderation_rule_trigger_type: str
+    integration_type: str
 
 
 class AuditLogEntry(TypedDict):

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -919,6 +919,11 @@ AuditLogAction
         the :class:`User` who got kicked. If the user is not found then it is
         a :class:`Object` with the user's ID.
 
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` may be
+        set to an unspecified proxy object with one attribute:
+
+        - ``integration_type``: A string representing the type of the integration which performed the action, if any.
+
         When this is the action, :attr:`~AuditLogEntry.changes` is empty.
 
     .. attribute:: member_prune
@@ -983,6 +988,11 @@ AuditLogAction
         When this is the action, the type of :attr:`~AuditLogEntry.target` is
         the :class:`Member` or :class:`User` who got the role. If the user is not found then it is
         a :class:`Object` with the user's ID.
+
+        When this is the action, the type of :attr:`~AuditLogEntry.extra` may be
+        set to an unspecified proxy object with one attribute:
+
+        - ``integration_type``: A string representing the type of the integration which performed the action, if any.
 
         Possible attributes for :class:`AuditLogDiff`:
 


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/e27f5215c72d779442c6fbd464c979626afcf854

n.b. The field isn't always provided; I've seen it with `guild_subscription` integrations, presumably the same goes for `youtube`/`twitch` integrations

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
