### PR TITLE
docs(audit_logs): misc typo/formatting fixes

### DIFF
--- a/changelog/1105.doc.rst
+++ b/changelog/1105.doc.rst
@@ -1,0 +1,1 @@
+Miscellaneous grammar/typo fixes for :doc:`api/audit_logs`.

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -534,9 +534,6 @@ class AuditLogEntry(Hashable):
     .. versionchanged:: 1.7
         Audit log entries are now comparable and hashable.
 
-    .. versionchanged:: 2.8
-        :attr:`user` can return :class:`Object` if the user is not found.
-
     Attributes
     ----------
     action: :class:`AuditLogAction`
@@ -544,6 +541,9 @@ class AuditLogEntry(Hashable):
     user: Optional[Union[:class:`Member`, :class:`User`, :class:`Object`]]
         The user who initiated this action. Usually :class:`Member`\\, unless gone
         then it's a :class:`User`.
+
+        .. versionchanged:: 2.8
+            May now be an :class:`Object` if the user could not be found.
     id: :class:`int`
         The entry ID.
     target: Any

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -514,7 +514,8 @@ class _AuditLogProxyKickOrMemberRoleAction:
 class AuditLogEntry(Hashable):
     """Represents an Audit Log entry.
 
-    You retrieve these via :meth:`Guild.audit_logs`.
+    You can retrieve these via :meth:`Guild.audit_logs`,
+    or via the :func:`on_audit_log_entry_create` event.
 
     .. container:: operations
 

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -97,7 +97,7 @@ AuditLogDiff
 
         .. describe:: iter(diff)
 
-            Returns an iterator over (attribute, value) tuple of this diff.
+            Returns an iterator over ``(attribute, value)`` tuples of this diff.
 
     .. attribute:: name
 

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -42,17 +42,17 @@ AuditLogChanges
         :attr:`~AuditLogEntry.category`\, the data retrieved by this
         attribute differs:
 
-        +----------------------------------------+---------------------------------------------------+
-        |                Category                |                    Description                    |
-        +----------------------------------------+---------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.create` | All attributes are set to ``None``.               |
-        +----------------------------------------+---------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.delete` | All attributes are set the value before deletion. |
-        +----------------------------------------+---------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.update` | All attributes are set the value before updating. |
-        +----------------------------------------+---------------------------------------------------+
-        | ``None``                               | No attributes are set.                            |
-        +----------------------------------------+---------------------------------------------------+
+        +----------------------------------------+------------------------------------------------------+
+        |                Category                |                    Description                       |
+        +----------------------------------------+------------------------------------------------------+
+        | :attr:`~AuditLogActionCategory.create` | All attributes are set to ``None``.                  |
+        +----------------------------------------+------------------------------------------------------+
+        | :attr:`~AuditLogActionCategory.delete` | All attributes are set to the value before deletion. |
+        +----------------------------------------+------------------------------------------------------+
+        | :attr:`~AuditLogActionCategory.update` | All attributes are set to the value before updating. |
+        +----------------------------------------+------------------------------------------------------+
+        | ``None``                               | No attributes are set.                               |
+        +----------------------------------------+------------------------------------------------------+
 
     .. attribute:: after
 
@@ -62,17 +62,17 @@ AuditLogChanges
         :attr:`~AuditLogEntry.category`\, the data retrieved by this
         attribute differs:
 
-        +----------------------------------------+--------------------------------------------------+
-        |                Category                |                   Description                    |
-        +----------------------------------------+--------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.create` | All attributes are set to the created value      |
-        +----------------------------------------+--------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.delete` | All attributes are set to ``None``               |
-        +----------------------------------------+--------------------------------------------------+
-        | :attr:`~AuditLogActionCategory.update` | All attributes are set the value after updating. |
-        +----------------------------------------+--------------------------------------------------+
-        | ``None``                               | No attributes are set.                           |
-        +----------------------------------------+--------------------------------------------------+
+        +----------------------------------------+-----------------------------------------------------+
+        |                Category                |                   Description                       |
+        +----------------------------------------+-----------------------------------------------------+
+        | :attr:`~AuditLogActionCategory.create` | All attributes are set to the created value.        |
+        +----------------------------------------+-----------------------------------------------------+
+        | :attr:`~AuditLogActionCategory.delete` | All attributes are set to ``None``.                 |
+        +----------------------------------------+-----------------------------------------------------+
+        | :attr:`~AuditLogActionCategory.update` | All attributes are set to the value after updating. |
+        +----------------------------------------+-----------------------------------------------------+
+        | ``None``                               | No attributes are set.                              |
+        +----------------------------------------+-----------------------------------------------------+
 
 AuditLogDiff
 ~~~~~~~~~~~~

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -936,7 +936,7 @@ AuditLogAction
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
         set to an unspecified proxy object with two attributes:
 
-        - ``delete_members_days``: An integer specifying how far the prune was.
+        - ``delete_member_days``: An integer specifying how far the prune was.
         - ``members_removed``: An integer specifying how many members were removed.
 
         When this is the action, :attr:`~AuditLogEntry.changes` is empty.


### PR DESCRIPTION
## Summary

title should be self-explanatory.

originally brought up in https://canary.discord.com/channels/808030843078836254/1151857056123453441

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
