### PR TITLE
refactor: deduplicate `owner_ids` logic 

### DIFF
--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -175,14 +175,14 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
         This can be provided as a parameter at creation.
 
     owner_id: Optional[:class:`int`]
-        The user ID that owns the bot. If this is not set and is then queried via
+        The ID of the user that owns the bot. If this is not set and is then queried via
         :meth:`.is_owner` then it is fetched automatically using
         :meth:`~.Bot.application_info`.
 
         This can be provided as a parameter at creation.
 
     owner_ids: Optional[Collection[:class:`int`]]
-        The user IDs that owns the bot. This is similar to :attr:`owner_id`.
+        The IDs of the users that own the bot. This is similar to :attr:`owner_id`.
         If this is not set and the application is team based, then it is
         fetched automatically using :meth:`~.Bot.application_info`.
         For performance reasons it is recommended to use a :class:`set`
@@ -394,14 +394,14 @@ class InteractionBot(InteractionBotBase, disnake.Client):
     Attributes
     ----------
     owner_id: Optional[:class:`int`]
-        The user ID that owns the bot. If this is not set and is then queried via
+        The ID of the user that owns the bot. If this is not set and is then queried via
         :meth:`.is_owner` then it is fetched automatically using
         :meth:`~.Bot.application_info`.
 
         This can be provided as a parameter at creation.
 
     owner_ids: Optional[Collection[:class:`int`]]
-        The user IDs that owns the bot. This is similar to :attr:`owner_id`.
+        The IDs of the users that own the bot. This is similar to :attr:`owner_id`.
         If this is not set and the application is team based, then it is
         fetched automatically using :meth:`~.Bot.application_info`.
         For performance reasons it is recommended to use a :class:`set`

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -111,11 +111,12 @@ class CommonBotBase(Generic[CogT]):
     async def login(self, token: str) -> None:
         await super().login(token=token)  # type: ignore
 
+        loop: asyncio.AbstractEventLoop = self.loop  # type: ignore
         if self.reload:
-            self.loop.create_task(self._watchdog())  # type: ignore
+            loop.create_task(self._watchdog())
 
         # prefetch
-        self.loop.create_task(self._fill_owners())  # type: ignore
+        loop.create_task(self._fill_owners())
 
     async def is_owner(self, user: Union[disnake.User, disnake.Member]) -> bool:
         """|coro|

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -80,9 +80,7 @@ class CommonBotBase(Generic[CogT]):
         if self.owner_id or self.owner_ids:
             return
 
-        await self.wait_until_first_connect()  # type: ignore
-
-        app = await self.application_info()  # type: ignore
+        app: disnake.AppInfo = await self.application_info()  # type: ignore
         if app.team:
             self.owners = set(app.team.members)
             self.owner_ids = {m.id for m in app.team.members}
@@ -111,11 +109,13 @@ class CommonBotBase(Generic[CogT]):
 
     @disnake.utils.copy_doc(disnake.Client.login)
     async def login(self, token: str) -> None:
-        self.loop.create_task(self._fill_owners())  # type: ignore
+        await super().login(token=token)  # type: ignore
 
         if self.reload:
             self.loop.create_task(self._watchdog())  # type: ignore
-        await super().login(token=token)  # type: ignore
+
+        # prefetch
+        self.loop.create_task(self._fill_owners())  # type: ignore
 
     async def is_owner(self, user: Union[disnake.User, disnake.Member]) -> bool:
         """|coro|
@@ -140,20 +140,13 @@ class CommonBotBase(Generic[CogT]):
         :class:`bool`
             Whether the user is the owner.
         """
+        if not self.owner_id and not self.owner_ids:
+            await self._fill_owners()
+
         if self.owner_id:
             return user.id == self.owner_id
-        elif self.owner_ids:
-            return user.id in self.owner_ids
         else:
-            app = await self.application_info()  # type: ignore
-            if app.team:
-                self.owners = set(app.team.members)
-                self.owner_ids = ids = {m.id for m in app.team.members}
-                return user.id in ids
-            else:
-                self.owner = app.owner
-                self.owner_id = owner_id = app.owner.id
-                return user.id == owner_id
+            return user.id in self.owner_ids
 
     def add_cog(self, cog: Cog, *, override: bool = False) -> None:
         """Adds a "cog" to the bot.

--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -123,7 +123,7 @@ class CommonBotBase(Generic[CogT]):
         Checks if a :class:`~disnake.User` or :class:`~disnake.Member` is the owner of
         this bot.
 
-        If an :attr:`owner_id` is not set, it is fetched automatically
+        If :attr:`owner_id` and :attr:`owner_ids` are not set, they are fetched automatically
         through the use of :meth:`~.Bot.application_info`.
 
         .. versionchanged:: 1.3


### PR DESCRIPTION
## Summary

Removes some duplication related to fetching `owner_id(s)` in `Bot._fill_owners` and `Bot.is_owner`.
Waiting for connect isn't necessary anymore if we do the login first, which puts http into a usable state.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
