### PR TITLE
ci: print libcst diff

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -135,6 +135,9 @@ jobs:
         nox -s codemod -- run-all
         if [ -n "$(git status --porcelain)" ]; then
           echo "::error::Please run 'nox -s codemod -- run-all' locally and commit the changes." >&2;
+          echo "::group::git diff"
+          git diff
+          echo "::endgroup::"
           exit 1;
         else
           exit 0;


### PR DESCRIPTION
## Summary

tiny QoL change to print the git diff in case the libcst CI step changed something

Example:
![image](https://github.com/DisnakeDev/disnake/assets/8530778/7593aa28-a791-4d6b-8d71-f60bc9e104c0)


## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
