### PR TITLE
fix(ui): don't require `cls` argument in select decorators to be positional

### DIFF
--- a/changelog/1111.bugfix.rst
+++ b/changelog/1111.bugfix.rst
@@ -1,0 +1,1 @@
+Allow ``cls`` argument in select menu decorators (e.g. :func`ui.string_select`) to be specified by keyword instead of being positional-only.

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -295,7 +295,7 @@ def button(
     ----------
     cls: Type[:class:`Button`]
         The button subclass to create an instance of. If provided, the following parameters
-        described below do no apply. Instead, this decorator will accept the same keywords
+        described below do not apply. Instead, this decorator will accept the same keywords
         as the passed cls does.
 
         .. versionadded:: 2.6

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -168,9 +168,7 @@ def channel_select(
 
 
 def channel_select(
-    cls: Type[Object[S_co, P]] = ChannelSelect[Any],
-    /,
-    **kwargs: Any,
+    cls: Type[Object[S_co, P]] = ChannelSelect[Any], **kwargs: Any
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
     """A decorator that attaches a channel select menu to a component.
 

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -185,7 +185,7 @@ def channel_select(
     ----------
     cls: Type[:class:`ChannelSelect`]
         The select subclass to create an instance of. If provided, the following parameters
-        described below do no apply. Instead, this decorator will accept the same keywords
+        described below do not apply. Instead, this decorator will accept the same keywords
         as the passed cls does.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -144,9 +144,7 @@ def mentionable_select(
 
 
 def mentionable_select(
-    cls: Type[Object[S_co, P]] = MentionableSelect[Any],
-    /,
-    **kwargs: Any,
+    cls: Type[Object[S_co, P]] = MentionableSelect[Any], **kwargs: Any
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
     """A decorator that attaches a mentionable (user/member/role) select menu to a component.
 

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -161,7 +161,7 @@ def mentionable_select(
     ----------
     cls: Type[:class:`MentionableSelect`]
         The select subclass to create an instance of. If provided, the following parameters
-        described below do no apply. Instead, this decorator will accept the same keywords
+        described below do not apply. Instead, this decorator will accept the same keywords
         as the passed cls does.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -142,9 +142,7 @@ def role_select(
 
 
 def role_select(
-    cls: Type[Object[S_co, P]] = RoleSelect[Any],
-    /,
-    **kwargs: Any,
+    cls: Type[Object[S_co, P]] = RoleSelect[Any], **kwargs: Any
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
     """A decorator that attaches a role select menu to a component.
 

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -159,7 +159,7 @@ def role_select(
     ----------
     cls: Type[:class:`RoleSelect`]
         The select subclass to create an instance of. If provided, the following parameters
-        described below do no apply. Instead, this decorator will accept the same keywords
+        described below do not apply. Instead, this decorator will accept the same keywords
         as the passed cls does.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -286,7 +286,7 @@ def string_select(
     ----------
     cls: Type[:class:`StringSelect`]
         The select subclass to create an instance of. If provided, the following parameters
-        described below do no apply. Instead, this decorator will accept the same keywords
+        described below do not apply. Instead, this decorator will accept the same keywords
         as the passed cls does.
 
         .. versionadded:: 2.6

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -268,9 +268,7 @@ def string_select(
 
 
 def string_select(
-    cls: Type[Object[S_co, P]] = StringSelect[Any],
-    /,
-    **kwargs: Any,
+    cls: Type[Object[S_co, P]] = StringSelect[Any], **kwargs: Any
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
     """A decorator that attaches a string select menu to a component.
 

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -143,9 +143,7 @@ def user_select(
 
 
 def user_select(
-    cls: Type[Object[S_co, P]] = UserSelect[Any],
-    /,
-    **kwargs: Any,
+    cls: Type[Object[S_co, P]] = UserSelect[Any], **kwargs: Any
 ) -> Callable[[ItemCallbackType[S_co]], DecoratedItem[S_co]]:
     """A decorator that attaches a user select menu to a component.
 

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -160,7 +160,7 @@ def user_select(
     ----------
     cls: Type[:class:`UserSelect`]
         The select subclass to create an instance of. If provided, the following parameters
-        described below do no apply. Instead, this decorator will accept the same keywords
+        described below do not apply. Instead, this decorator will accept the same keywords
         as the passed cls does.
     placeholder: Optional[:class:`str`]
         The placeholder text that is shown if nothing is selected, if any.

--- a/docs/api/ui.rst
+++ b/docs/api/ui.rst
@@ -128,7 +128,7 @@ TextInput
 Functions
 ---------
 
-.. autofunction:: button(cls=Button, *, style=ButtonStyle.secondary, label=None, disabled=False, custom_id=..., url=None, emoji=None, row=None)
+.. autofunction:: button(cls=Button, *, custom_id=..., style=ButtonStyle.secondary, label=None, disabled=False, url=None, emoji=None, row=None)
     :decorator:
 
 .. autofunction:: string_select(cls=StringSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, options=..., disabled=False, row=None)

--- a/tests/ui/test_decorators.py
+++ b/tests/ui/test_decorators.py
@@ -44,7 +44,7 @@ class TestDecorator:
             assert func.__discord_ui_model_type__ is ui.StringSelect
             assert func.__discord_ui_model_kwargs__ == {"custom_id": "123"}
 
-    # from here on out we're only testing the button decorator,
+    # from here on out we're mostly only testing the button decorator,
     # as @ui.string_select etc. works identically
 
     @pytest.mark.parametrize("cls", [_CustomButton, _CustomButton[Any]])
@@ -64,7 +64,18 @@ class TestDecorator:
             this_should_not_work="h",  # type: ignore
         )
 
-    @pytest.mark.parametrize("cls", [123, int, ui.StringSelect])
-    def test_cls_invalid(self, cls) -> None:
-        with pytest.raises(TypeError, match=r"cls argument must be"):
-            ui.button(cls=cls)  # type: ignore
+    @pytest.mark.parametrize(
+        ("decorator", "invalid_cls"),
+        [
+            (ui.button, ui.StringSelect),
+            (ui.string_select, ui.Button),
+            (ui.user_select, ui.Button),
+            (ui.role_select, ui.Button),
+            (ui.mentionable_select, ui.Button),
+            (ui.channel_select, ui.Button),
+        ],
+    )
+    def test_cls_invalid(self, decorator, invalid_cls) -> None:
+        for cls in [123, int, invalid_cls]:
+            with pytest.raises(TypeError, match=r"cls argument must be"):
+                decorator(cls=cls)


### PR DESCRIPTION
## Summary

This PR allows the `cls` parameter in select decorators to be provided as a keyword argument again (`@string_select(cls=x, ...)`), whereas it previously had to be specified as positional (`@string_select(x, ...)`).
This regressed in 7467fe83f4bb6ce3fcb8a90b636a13f116ebceb2 and made the `cls` argument not work as expected when provided via keyword.

https://canary.discord.com/channels/808030843078836254/913779868985090089/1149758316126408744 (cc @Enegg)

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
