### PR TITLE
feat: application subscriptions

### DIFF
--- a/changelog/1113.feature.rst
+++ b/changelog/1113.feature.rst
@@ -1,0 +1,5 @@
+Support application subscriptions (see the :ddocs:`official docs <monetization/overview>` for more info).
+- New types: :class:`SKU`, :class:`Entitlement`
+- New :attr:`Interaction.entitlements` attribute, and :meth:`InteractionResponse.send_premium_required` response type.
+- New events: :func:`on_entitlement_create`, :func:`on_entitlement_update`, :func:`on_entitlement_delete`.
+- New :class:`Client` methods: :meth:`~Client.skus`, :meth:`~Client.entitlements`, :meth:`~Client.create_test_entitlement`.

--- a/changelog/1113.feature.rst
+++ b/changelog/1113.feature.rst
@@ -1,5 +1,4 @@
 Support application subscriptions (see the :ddocs:`official docs <monetization/overview>` for more info).
-- New types: :class:`SKU`, :class:`Entitlement`
+- New types: :class:`SKU`, :class:`Entitlement`.
 - New :attr:`Interaction.entitlements` attribute, and :meth:`InteractionResponse.require_premium` response type.
 - New events: :func:`on_entitlement_create`, :func:`on_entitlement_update`, :func:`on_entitlement_delete`.
-- New :class:`Client` methods: :meth:`~Client.skus`, :meth:`~Client.entitlements`, :meth:`~Client.create_entitlement`.

--- a/changelog/1113.feature.rst
+++ b/changelog/1113.feature.rst
@@ -2,4 +2,4 @@ Support application subscriptions (see the :ddocs:`official docs <monetization/o
 - New types: :class:`SKU`, :class:`Entitlement`
 - New :attr:`Interaction.entitlements` attribute, and :meth:`InteractionResponse.send_premium_required` response type.
 - New events: :func:`on_entitlement_create`, :func:`on_entitlement_update`, :func:`on_entitlement_delete`.
-- New :class:`Client` methods: :meth:`~Client.skus`, :meth:`~Client.entitlements`, :meth:`~Client.create_test_entitlement`.
+- New :class:`Client` methods: :meth:`~Client.skus`, :meth:`~Client.entitlements`, :meth:`~Client.create_entitlement`.

--- a/changelog/1113.feature.rst
+++ b/changelog/1113.feature.rst
@@ -1,5 +1,5 @@
 Support application subscriptions (see the :ddocs:`official docs <monetization/overview>` for more info).
-- New types: :class:`SKU`, :class:`Entitlement`
+- New types: :class:`SKU`, :class:`Entitlement`.
 - New :attr:`Interaction.entitlements` attribute, and :meth:`InteractionResponse.require_premium` response type.
 - New events: :func:`on_entitlement_create`, :func:`on_entitlement_update`, :func:`on_entitlement_delete`.
 - New :class:`Client` methods: :meth:`~Client.skus`, :meth:`~Client.entitlements`, :meth:`~Client.create_entitlement`.

--- a/changelog/1113.feature.rst
+++ b/changelog/1113.feature.rst
@@ -1,4 +1,5 @@
 Support application subscriptions (see the :ddocs:`official docs <monetization/overview>` for more info).
-- New types: :class:`SKU`, :class:`Entitlement`.
+- New types: :class:`SKU`, :class:`Entitlement`
 - New :attr:`Interaction.entitlements` attribute, and :meth:`InteractionResponse.require_premium` response type.
 - New events: :func:`on_entitlement_create`, :func:`on_entitlement_update`, :func:`on_entitlement_delete`.
+- New :class:`Client` methods: :meth:`~Client.skus`, :meth:`~Client.entitlements`, :meth:`~Client.create_entitlement`.

--- a/changelog/1113.feature.rst
+++ b/changelog/1113.feature.rst
@@ -1,5 +1,5 @@
 Support application subscriptions (see the :ddocs:`official docs <monetization/overview>` for more info).
 - New types: :class:`SKU`, :class:`Entitlement`
-- New :attr:`Interaction.entitlements` attribute, and :meth:`InteractionResponse.send_premium_required` response type.
+- New :attr:`Interaction.entitlements` attribute, and :meth:`InteractionResponse.require_premium` response type.
 - New events: :func:`on_entitlement_create`, :func:`on_entitlement_update`, :func:`on_entitlement_delete`.
 - New :class:`Client` methods: :meth:`~Client.skus`, :meth:`~Client.entitlements`, :meth:`~Client.create_entitlement`.

--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -37,6 +37,7 @@ from .components import *
 from .custom_warnings import *
 from .embeds import *
 from .emoji import *
+from .entitlement import *
 from .enums import *
 from .errors import *
 from .file import *

--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -60,6 +60,7 @@ from .raw_models import *
 from .reaction import *
 from .role import *
 from .shard import *
+from .sku import *
 from .stage_instance import *
 from .sticker import *
 from .team import *

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -65,6 +65,7 @@ from .invite import Invite
 from .iterators import GuildIterator
 from .mentions import AllowedMentions
 from .object import Object
+from .sku import SKU
 from .stage_instance import StageInstance
 from .state import ConnectionState
 from .sticker import GuildSticker, StandardSticker, StickerPack, _sticker_factory
@@ -2973,3 +2974,24 @@ class Client:
             self.application_id, payload
         )
         return [ApplicationRoleConnectionMetadata._from_data(record) for record in data]
+
+    async def skus(self) -> List[SKU]:
+        """|coro|
+
+        Retrieves the :class:`.SKU`\\s for the application.
+
+        To manage application subscription entitlements, you should use the SKU
+        with :attr:`.SKUType.subscription`.
+
+        Raises
+        ------
+        HTTPException
+            Retrieving the SKUs failed.
+
+        Returns
+        -------
+        List[:class:`.SKU`]
+            The list of SKUs.
+        """
+        data = await self.http.get_skus(self.application_id)
+        return [SKU(data=d) for d in data]

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -3014,8 +3014,8 @@ class Client:
 
         .. note::
 
-            This method is an API call. To get the entitlements of the invoking user in interactions,
-            consider using :attr:`.Interaction.entitlements`.
+            This method is an API call. To get the entitlements of the invoking user/guild
+            in interactions, consider using :attr:`.Interaction.entitlements`.
 
         If ``before`` is specified, entitlements are returned in reverse order,
         i.e. starting with the highest ID.

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -2999,7 +2999,6 @@ class Client:
         data = await self.http.get_skus(self.application_id)
         return [SKU(data=d) for d in data]
 
-    # TODO: consider adding `abc.User.entitlements` and/or `Guild.entitlements` iterators as shortcuts?
     def entitlements(
         self,
         *,
@@ -3010,6 +3009,7 @@ class Client:
         guild: Optional[Snowflake] = None,
         skus: Optional[Sequence[Snowflake]] = None,
         exclude_ended: bool = False,
+        oldest_first: bool = False,
     ) -> EntitlementIterator:
         """Retrieves an :class:`.AsyncIterator` that enables receiving entitlements for the application.
 
@@ -3018,8 +3018,8 @@ class Client:
             This method is an API call. To get the entitlements of the invoking user/guild
             in interactions, consider using :attr:`.Interaction.entitlements`.
 
-        If ``before`` is specified, entitlements are returned in reverse order,
-        i.e. starting with the highest ID.
+        Entries are returned in order from newest to oldest by default;
+        pass ``oldest_first=True`` to reverse the iteration order.
 
         All parameters are optional.
 
@@ -3034,8 +3034,12 @@ class Client:
             Defaults to ``100``.
         before: Union[:class:`.abc.Snowflake`, :class:`datetime.datetime`]
             Retrieves entitlements created before this date or object.
+            If a datetime is provided, it is recommended to use a UTC aware datetime.
+            If the datetime is naive, it is assumed to be local time.
         after: Union[:class:`.abc.Snowflake`, :class:`datetime.datetime`]
             Retrieve entitlements created after this date or object.
+            If a datetime is provided, it is recommended to use a UTC aware datetime.
+            If the datetime is naive, it is assumed to be local time.
         user: Optional[:class:`.abc.Snowflake`]
             The user to retrieve entitlements for.
         guild: Optional[:class:`.abc.Snowflake`]
@@ -3044,6 +3048,8 @@ class Client:
             The SKUs for which entitlements are retrieved.
         exclude_ended: :class:`bool`
             Whether to exclude ended/expired entitlements. Defaults to ``False``.
+        oldest_first: :class:`bool`
+            If set to ``True``, return entries in oldest->newest order. Defaults to ``False``.
 
         Raises
         ------
@@ -3065,6 +3071,7 @@ class Client:
             guild_id=guild.id if guild is not None else None,
             sku_ids=[sku.id for sku in skus] if skus else None,
             exclude_ended=exclude_ended,
+            oldest_first=oldest_first,
         )
 
     async def create_entitlement(

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -33,7 +33,7 @@ from typing import (
 
 import aiohttp
 
-from . import utils
+from . import abc, utils
 from .activity import ActivityTypes, BaseActivity, create_activity
 from .app_commands import (
     APIMessageCommand,
@@ -47,6 +47,7 @@ from .application_role_connection import ApplicationRoleConnectionMetadata
 from .backoff import ExponentialBackoff
 from .channel import PartialMessageable, _threaded_channel_factory
 from .emoji import Emoji
+from .entitlement import Entitlement
 from .enums import ApplicationCommandType, ChannelType, Event, Status
 from .errors import (
     ConnectionClosed,
@@ -63,9 +64,10 @@ from .guild_preview import GuildPreview
 from .http import HTTPClient
 from .i18n import LocalizationProtocol, LocalizationStore
 from .invite import Invite
-from .iterators import GuildIterator
+from .iterators import EntitlementIterator, GuildIterator
 from .mentions import AllowedMentions
 from .object import Object
+from .sku import SKU
 from .stage_instance import StageInstance
 from .state import ConnectionState
 from .sticker import GuildSticker, StandardSticker, StickerPack, _sticker_factory
@@ -2989,3 +2991,133 @@ class Client:
             self.application_id, payload
         )
         return [ApplicationRoleConnectionMetadata._from_data(record) for record in data]
+
+    async def skus(self) -> List[SKU]:
+        """|coro|
+
+        Retrieves the :class:`.SKU`\\s for the application.
+
+        To manage application subscription entitlements, you should use the SKU
+        with :attr:`.SKUType.subscription`.
+
+        .. versionadded:: 2.10
+
+        Raises
+        ------
+        HTTPException
+            Retrieving the SKUs failed.
+
+        Returns
+        -------
+        List[:class:`.SKU`]
+            The list of SKUs.
+        """
+        data = await self.http.get_skus(self.application_id)
+        return [SKU(data=d) for d in data]
+
+    def entitlements(
+        self,
+        *,
+        limit: Optional[int] = 100,
+        before: Optional[SnowflakeTime] = None,
+        after: Optional[SnowflakeTime] = None,
+        user: Optional[Snowflake] = None,
+        guild: Optional[Snowflake] = None,
+        skus: Optional[Sequence[Snowflake]] = None,
+        exclude_ended: bool = False,
+        oldest_first: bool = False,
+    ) -> EntitlementIterator:
+        """Retrieves an :class:`.AsyncIterator` that enables receiving entitlements for the application.
+
+        .. note::
+
+            This method is an API call. To get the entitlements of the invoking user/guild
+            in interactions, consider using :attr:`.Interaction.entitlements`.
+
+        Entries are returned in order from newest to oldest by default;
+        pass ``oldest_first=True`` to reverse the iteration order.
+
+        All parameters are optional.
+
+        .. versionadded:: 2.10
+
+        Parameters
+        ----------
+        limit: Optional[:class:`int`]
+            The number of entitlements to retrieve.
+            If ``None``, retrieves every entitlement.
+            Note, however, that this would make it a slow operation.
+            Defaults to ``100``.
+        before: Union[:class:`.abc.Snowflake`, :class:`datetime.datetime`]
+            Retrieves entitlements created before this date or object.
+            If a datetime is provided, it is recommended to use a UTC aware datetime.
+            If the datetime is naive, it is assumed to be local time.
+        after: Union[:class:`.abc.Snowflake`, :class:`datetime.datetime`]
+            Retrieve entitlements created after this date or object.
+            If a datetime is provided, it is recommended to use a UTC aware datetime.
+            If the datetime is naive, it is assumed to be local time.
+        user: Optional[:class:`.abc.Snowflake`]
+            The user to retrieve entitlements for.
+        guild: Optional[:class:`.abc.Snowflake`]
+            The guild to retrieve entitlements for.
+        skus: Optional[Sequence[:class:`.abc.Snowflake`]]
+            The SKUs for which entitlements are retrieved.
+        exclude_ended: :class:`bool`
+            Whether to exclude ended/expired entitlements. Defaults to ``False``.
+        oldest_first: :class:`bool`
+            If set to ``True``, return entries in oldest->newest order. Defaults to ``False``.
+
+        Raises
+        ------
+        HTTPException
+            Retrieving the entitlements failed.
+
+        Yields
+        ------
+        :class:`.Entitlement`
+            The entitlements for the given parameters.
+        """
+        return EntitlementIterator(
+            self.application_id,
+            state=self._connection,
+            limit=limit,
+            before=before,
+            after=after,
+            user_id=user.id if user is not None else None,
+            guild_id=guild.id if guild is not None else None,
+            sku_ids=[sku.id for sku in skus] if skus else None,
+            exclude_ended=exclude_ended,
+            oldest_first=oldest_first,
+        )
+
+    async def create_entitlement(
+        self, sku: Snowflake, owner: Union[abc.User, Guild]
+    ) -> Entitlement:
+        """|coro|
+
+        Creates a new test :class:`.Entitlement` for the given user or guild, with no expiry.
+
+        Parameters
+        ----------
+        sku: :class:`.abc.Snowflake`
+            The :class:`.SKU` to grant the entitlement for.
+        owner: Union[:class:`.abc.User`, :class:`.Guild`]
+            The user or guild to grant the entitlement to.
+
+        Raises
+        ------
+        HTTPException
+            Creating the entitlement failed.
+
+        Returns
+        -------
+        :class:`.Entitlement`
+            The newly created entitlement.
+        """
+        data = await self.http.create_test_entitlement(
+            self.application_id,
+            sku_id=sku.id,
+            owner_id=owner.id,
+            owner_type=2 if isinstance(owner, abc.User) else 1,
+        )
+        return Entitlement(data=data, state=self._connection)

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -3095,6 +3095,6 @@ class Client:
             self.application_id,
             sku_id=sku.id,
             owner_id=owner.id,
-            owner_type=1 if isinstance(owner, abc.User) else 2,
+            owner_type=2 if isinstance(owner, abc.User) else 1,
         )
         return Entitlement(data=data, state=self._connection)

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -2983,6 +2983,8 @@ class Client:
         To manage application subscription entitlements, you should use the SKU
         with :attr:`.SKUType.subscription`.
 
+        .. versionadded:: 2.10
+
         Raises
         ------
         HTTPException

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -3067,13 +3067,12 @@ class Client:
             exclude_ended=exclude_ended,
         )
 
-    # TODO: naming (create_entitlement?)
-    async def create_test_entitlement(
+    async def create_entitlement(
         self, sku: Snowflake, owner: Union[abc.User, Guild]
     ) -> Entitlement:
         """|coro|
 
-        Creates a new :class:`.Entitlement` for the given user or guild, with no expiry.
+        Creates a new test :class:`.Entitlement` for the given user or guild, with no expiry.
 
         Parameters
         ----------

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -23,8 +23,8 @@ class Entitlement(Hashable):
     """Represents an entitlement.
 
     This can be retrieved using :meth:`Client.entitlements`, from
-    :attr:`Interaction.entitlements` when using interactions, or from the
-    :func:`on_entitlement_create`/:func:`on_entitlement_update` events.
+    :attr:`Interaction.entitlements` when using interactions, or from
+    events (e.g. :func:`on_entitlement_create`).
 
     Note that some entitlements may have ended already; consider using
     :meth:`is_active` to check whether a given entitlement is considered valid at the current time,

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -22,11 +22,15 @@ __all__ = ("Entitlement",)
 class Entitlement(Hashable):
     """Represents an entitlement.
 
-    This is usually retrieved from :attr:`Interaction.entitlements` when using interactions,
-    or provided by events (e.g. :func:`on_entitlement_create`).
+    This is usually retrieved using :meth:`Client.entitlements`, from
+    :attr:`Interaction.entitlements` when using interactions, or provided by
+    events (e.g. :func:`on_entitlement_create`).
 
     Note that some entitlements may have ended already; consider using
-    :meth:`is_active` to check whether a given entitlement is considered active at the current time.
+    :meth:`is_active` to check whether a given entitlement is considered active at the current time,
+    or use ``exclude_ended=True`` when fetching entitlements using :meth:`Client.entitlements`.
+
+    You may create new entitlements for testing purposes using :meth:`Client.create_entitlement`.
 
     .. container:: operations
 
@@ -145,3 +149,20 @@ class Entitlement(Hashable):
             return False
 
         return True
+
+    async def delete(self) -> None:
+        """|coro|
+
+        Deletes the entitlement.
+
+        This is only valid for test entitlements; you cannot use this to
+        delete entitlements that users purchased.
+
+        Raises
+        ------
+        NotFound
+            The entitlement does not exist.
+        HTTPException
+            Deleting the entitlement failed.
+        """
+        await self._state.http.delete_test_entitlement(self.application_id, self.id)

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -32,7 +32,7 @@ class Entitlement(Hashable):
 
     You may create new entitlements for testing purposes using :meth:`Client.create_entitlement`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -22,15 +22,11 @@ __all__ = ("Entitlement",)
 class Entitlement(Hashable):
     """Represents an entitlement.
 
-    This is usually retrieved using :meth:`Client.entitlements`, from
-    :attr:`Interaction.entitlements` when using interactions, or provided by
-    events (e.g. :func:`on_entitlement_create`).
+    This is usually retrieved from :attr:`Interaction.entitlements` when using interactions,
+    or provided by events (e.g. :func:`on_entitlement_create`).
 
     Note that some entitlements may have ended already; consider using
-    :meth:`is_active` to check whether a given entitlement is considered active at the current time,
-    or use ``exclude_ended=True`` when fetching entitlements using :meth:`Client.entitlements`.
-
-    You may create new entitlements for testing purposes using :meth:`Client.create_entitlement`.
+    :meth:`is_active` to check whether a given entitlement is considered active at the current time.
 
     .. container:: operations
 
@@ -149,20 +145,3 @@ class Entitlement(Hashable):
             return False
 
         return True
-
-    async def delete(self) -> None:
-        """|coro|
-
-        Deletes the entitlement.
-
-        This is only valid for test entitlements; you cannot use this to
-        delete entitlements that users purchased.
-
-        Raises
-        ------
-        NotFound
-            The entitlement does not exist.
-        HTTPException
-            Deleting the entitlement failed.
-        """
-        await self._state.http.delete_test_entitlement(self.application_id, self.id)

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -30,7 +30,7 @@ class Entitlement(Hashable):
     :meth:`is_active` to check whether a given entitlement is considered active at the current time,
     or use ``exclude_ended=True`` when fetching entitlements using :meth:`Client.entitlements`.
 
-    You may create new entitlements for testing purposes using :meth:`Client.create_test_entitlement`.
+    You may create new entitlements for testing purposes using :meth:`Client.create_entitlement`.
 
     .. container:: operations
 

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -22,13 +22,15 @@ __all__ = ("Entitlement",)
 class Entitlement(Hashable):
     """Represents an entitlement.
 
-    This can be retrieved using :meth:`Client.entitlements`, from
-    :attr:`Interaction.entitlements` when using interactions, or from
+    This is usually retrieved using :meth:`Client.entitlements`, from
+    :attr:`Interaction.entitlements` when using interactions, or provided by
     events (e.g. :func:`on_entitlement_create`).
 
     Note that some entitlements may have ended already; consider using
-    :meth:`is_active` to check whether a given entitlement is considered valid at the current time,
+    :meth:`is_active` to check whether a given entitlement is considered active at the current time,
     or use ``exclude_ended=True`` when fetching entitlements using :meth:`Client.entitlements`.
+
+    You may create new entitlements for testing purposes using :meth:`Client.create_test_entitlement`.
 
     .. container:: operations
 
@@ -139,3 +141,20 @@ class Entitlement(Hashable):
         if self.ends_at is not None and now >= self.ends_at:
             return False
         return True
+
+    async def delete(self) -> None:
+        """|coro|
+
+        Deletes the entitlement.
+
+        This is only valid for test entitlements; you cannot use this to
+        delete entitlements that users purchased.
+
+        Raises
+        ------
+        NotFound
+            The entitlement does not exist.
+        HTTPException
+            Deleting the entitlement failed.
+        """
+        await self._state.http.delete_test_entitlement(self.application_id, self.id)

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -116,7 +116,7 @@ class Entitlement(Hashable):
 
     @property
     def created_at(self) -> datetime.datetime:
-        """:class:`datetime.datetime`: Returns the SKU's creation time in UTC."""
+        """:class:`datetime.datetime`: Returns the entitlement's creation time in UTC."""
         return snowflake_time(self.id)
 
     @property

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -22,6 +22,10 @@ __all__ = ("Entitlement",)
 class Entitlement(Hashable):
     """Represents an entitlement.
 
+    This can be retrieved using :meth:`Client.entitlements`, from
+    :attr:`Interaction.entitlements` when using interactions, or from the
+    :func:`on_entitlement_create`/:func:`on_entitlement_update` events.
+
     .. container:: operations
 
         .. describe:: x == y

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING, Optional
+
+from .enums import EntitlementType, try_enum
+from .mixins import Hashable
+from .utils import _get_as_snowflake, parse_time, utcnow
+
+if TYPE_CHECKING:
+    from .guild import Guild
+    from .state import ConnectionState
+    from .types.entitlement import Entitlement as EntitlementPayload
+    from .user import User
+
+
+__all__ = ("Entitlement",)
+
+
+class Entitlement(Hashable):
+    """Represents an entitlement.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two :class:`Entitlement`\\s are equal.
+
+        .. describe:: x != y
+
+            Checks if two :class:`Entitlement`\\s are not equal.
+
+        .. describe:: hash(x)
+
+            Returns the entitlement's hash.
+
+    .. versionadded:: 2.10
+
+    Attributes
+    ----------
+    id: :class:`int`
+        The entitlement's ID.
+    type: :class:`EntitlementType`
+        The entitlement's type.
+    sku_id: :class:`int`
+        The ID of the associated SKU.
+    user_id: Optional[:class:`int`]
+        The ID of the user that is granted access to the entitlement's SKU.
+    guild_id: Optional[:class:`int`]
+        The ID of the guild that is granted access to the entitlement's SKU.
+    application_id: :class:`int`
+        The parent application's ID.
+    starts_at: Optional[:class:`datetime.datetime`]
+        The time at which the entitlement starts being valid.
+        Set to ``None`` when this is a test entitlement.
+    ends_at: Optional[:class:`datetime.datetime`]
+        The time at which the entitlement stops being valid.
+        Set to ``None`` when this is a test entitlement.
+    """
+
+    __slots__ = (
+        "_state",
+        "id",
+        "sku_id",
+        "user_id",
+        "guild_id",
+        "application_id",
+        "type",
+        "starts_at",
+        "ends_at",
+    )
+
+    def __init__(self, *, data: EntitlementPayload, state: ConnectionState) -> None:
+        self._state: ConnectionState = state
+
+        self.id: int = int(data["id"])
+        self.sku_id: int = int(data["sku_id"])
+        self.user_id: Optional[int] = _get_as_snowflake(data, "user_id")
+        self.guild_id: Optional[int] = _get_as_snowflake(data, "guild_id")
+        self.application_id: int = int(data["application_id"])
+        self.type: EntitlementType = try_enum(EntitlementType, data["type"])
+        self.starts_at: Optional[datetime.datetime] = parse_time(data.get("starts_at"))
+        self.ends_at: Optional[datetime.datetime] = parse_time(data.get("ends_at"))
+
+    def __repr__(self) -> str:
+        # presumably one of these is set
+        if self.user_id:
+            grant_repr = f"user_id={self.user_id!r}"
+        else:
+            grant_repr = f"guild_id={self.guild_id!r}"
+        return (
+            f"<Entitlement id={self.id!r} sku_id={self.sku_id!r} type={self.type!r} {grant_repr}>"
+        )
+
+    @property
+    def guild(self) -> Optional[Guild]:
+        """Optional[:class:`Guild`]: The guild that is granted access to
+        this entitlement's SKU, if applicable.
+        """
+        return self._state._get_guild(self.guild_id)
+
+    @property
+    def user(self) -> Optional[User]:
+        """Optional[:class:`User`]: The user that is granted access to
+        this entitlement's SKU, if applicable.
+        """
+        return self._state.get_user(self.user_id)
+
+    # TODO: naming - (is_)valid/active/expired ?
+    @property
+    def is_valid(self) -> bool:
+        now = utcnow()
+        if self.starts_at is not None and now < self.starts_at:
+            return False
+        if self.ends_at is not None and now >= self.ends_at:
+            return False
+        return True

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional
 
 from .enums import EntitlementType, try_enum
 from .mixins import Hashable
-from .utils import _get_as_snowflake, parse_time, utcnow
+from .utils import _get_as_snowflake, parse_time, snowflake_time, utcnow
 
 if TYPE_CHECKING:
     from .guild import Guild
@@ -113,6 +113,11 @@ class Entitlement(Hashable):
         return (
             f"<Entitlement id={self.id!r} sku_id={self.sku_id!r} type={self.type!r} {grant_repr}>"
         )
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the SKU's creation time in UTC."""
+        return snowflake_time(self.id)
 
     @property
     def guild(self) -> Optional[Guild]:

--- a/disnake/entitlement.py
+++ b/disnake/entitlement.py
@@ -66,6 +66,8 @@ class Entitlement(Hashable):
         See also :attr:`guild`.
     application_id: :class:`int`
         The parent application's ID.
+    deleted: :class:`bool`
+        Whether the entitlement was deleted.
     starts_at: Optional[:class:`datetime.datetime`]
         The time at which the entitlement starts being active.
         Set to ``None`` when this is a test entitlement.
@@ -84,6 +86,7 @@ class Entitlement(Hashable):
         "guild_id",
         "application_id",
         "type",
+        "deleted",
         "starts_at",
         "ends_at",
     )
@@ -97,6 +100,7 @@ class Entitlement(Hashable):
         self.guild_id: Optional[int] = _get_as_snowflake(data, "guild_id")
         self.application_id: int = int(data["application_id"])
         self.type: EntitlementType = try_enum(EntitlementType, data["type"])
+        self.deleted: bool = data.get("deleted", False)
         self.starts_at: Optional[datetime.datetime] = parse_time(data.get("starts_at"))
         self.ends_at: Optional[datetime.datetime] = parse_time(data.get("ends_at"))
 
@@ -135,11 +139,15 @@ class Entitlement(Hashable):
 
         :return type: :class:`bool`
         """
+        if self.deleted:
+            return False
+
         now = utcnow()
         if self.starts_at is not None and now < self.starts_at:
             return False
         if self.ends_at is not None and now >= self.ends_at:
             return False
+
         return True
 
     async def delete(self) -> None:

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -1243,6 +1243,15 @@ class Event(Enum):
     """Called when someone begins typing a message regardless of whether `Intents.members` and `Intents.guilds` are enabled.
     Represents the :func:`on_raw_typing` event.
     """
+    entitlement_create = "entitlement_create"
+    """Called when a user subscribes to an SKU, creating a new :class:`Entitlement`.
+    Represents the :func:`on_entitlement_create` event."""
+    entitlement_update = "entitlement_update"
+    """Called when a user's subscription renews.
+    Represents the :func:`on_entitlement_update` event."""
+    entitlement_delete = "entitlement_delete"
+    """Called when a user's entitlement is deleted.
+    Represents the :func:`on_entitlement_delete` event."""
     # ext.commands events
     command = "command"
     """Called when a command is found and is about to be invoked.

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -605,14 +605,13 @@ class InteractionType(Enum):
 
 class InteractionResponseType(Enum):
     pong = 1
-    # ack = 2 (deprecated)
-    # channel_message = 3 (deprecated)
-    channel_message = 4  # (with source)
-    deferred_channel_message = 5  # (with source)
-    deferred_message_update = 6  # for components
-    message_update = 7  # for components
-    application_command_autocomplete_result = 8  # for autocomplete
-    modal = 9  # for modals
+    channel_message = 4
+    deferred_channel_message = 5
+    deferred_message_update = 6
+    message_update = 7
+    application_command_autocomplete_result = 8
+    modal = 9
+    premium_required = 10
 
 
 class VideoQualityMode(Enum):

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -67,6 +67,7 @@ __all__ = (
     "Event",
     "ApplicationRoleConnectionMetadataType",
     "OnboardingPromptType",
+    "SKUType",
 )
 
 
@@ -1306,6 +1307,11 @@ class ApplicationRoleConnectionMetadataType(Enum):
 class OnboardingPromptType(Enum):
     multiple_choice = 0
     dropdown = 1
+
+
+class SKUType(Enum):
+    subscription = 5
+    subscription_group = 6
 
 
 T = TypeVar("T")

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -68,6 +68,7 @@ __all__ = (
     "ApplicationRoleConnectionMetadataType",
     "OnboardingPromptType",
     "SKUType",
+    "EntitlementType",
 )
 
 
@@ -1312,6 +1313,10 @@ class OnboardingPromptType(Enum):
 class SKUType(Enum):
     subscription = 5
     subscription_group = 6
+
+
+class EntitlementType(Enum):
+    application_subscription = 8
 
 
 T = TypeVar("T")

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -42,6 +42,7 @@ __all__ = (
     "MemberFlags",
     "RoleFlags",
     "AttachmentFlags",
+    "SKUFlags",
 )
 
 BF = TypeVar("BF", bound="BaseFlags")
@@ -2451,3 +2452,90 @@ class AttachmentFlags(BaseFlags):
     def is_remix(self):
         """:class:`bool`: Returns ``True`` if the attachment has been edited using the Remix feature."""
         return 1 << 2
+
+
+class SKUFlags(BaseFlags):
+    """Wraps up Discord SKU flags.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two SKUFlags instances are equal.
+        .. describe:: x != y
+
+            Checks if two SKUFlags instances are not equal.
+        .. describe:: x <= y
+
+            Checks if an SKUFlags instance is a subset of another SKUFlags instance.
+        .. describe:: x >= y
+
+            Checks if an SKUFlags instance is a superset of another SKUFlags instance.
+        .. describe:: x < y
+
+            Checks if an SKUFlags instance is a strict subset of another SKUFlags instance.
+        .. describe:: x > y
+
+            Checks if an SKUFlags instance is a strict superset of another SKUFlags instance.
+        .. describe:: x | y, x |= y
+
+            Returns a new SKUFlags instance with all enabled flags from both x and y.
+            (Using ``|=`` will update in place).
+        .. describe:: x & y, x &= y
+
+            Returns a new SKUFlags instance with only flags enabled on both x and y.
+            (Using ``&=`` will update in place).
+        .. describe:: x ^ y, x ^= y
+
+            Returns a new SKUFlags instance with only flags enabled on one of x or y, but not both.
+            (Using ``^=`` will update in place).
+        .. describe:: ~x
+
+            Returns a new SKUFlags instance with all flags from x inverted.
+        .. describe:: hash(x)
+
+            Returns the flag's hash.
+        .. describe:: iter(x)
+
+            Returns an iterator of ``(name, value)`` pairs. This allows it
+            to be, for example, constructed as a dict or a list of pairs.
+            Note that aliases are not shown.
+
+        Additionally supported are a few operations on class attributes.
+
+        .. describe:: SKUFlags.y | SKUFlags.z, SKUFlags(y=True) | SKUFlags.z
+
+            Returns a SKUFlags instance with all provided flags enabled.
+
+        .. describe:: ~SKUFlags.y
+
+            Returns a SKUFlags instance with all flags except ``y`` inverted from their default value.
+
+    .. versionadded:: 2.10
+
+    Attributes
+    ----------
+    value: :class:`int`
+        The raw value. You should query flags via the properties
+        rather than using this raw value.
+    """
+
+    __slots__ = ()
+
+    if TYPE_CHECKING:
+
+        @_generated
+        def __init__(
+            self, *, guild_subscription: bool = ..., user_subscription: bool = ...
+        ) -> None:
+            ...
+
+    @flag_value
+    def guild_subscription(self):
+        """:class:`bool`: Returns ``True`` if the SKU is an application subscription applied to a guild."""
+        return 1 << 7
+
+    @flag_value
+    def user_subscription(self):
+        """:class:`bool`: Returns ``True`` if the SKU is an application subscription applied to a user."""
+        return 1 << 8

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -2457,7 +2457,7 @@ class AttachmentFlags(BaseFlags):
 class SKUFlags(BaseFlags):
     """Wraps up Discord SKU flags.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -2526,9 +2526,18 @@ class SKUFlags(BaseFlags):
 
         @_generated
         def __init__(
-            self, *, guild_subscription: bool = ..., user_subscription: bool = ...
+            self,
+            *,
+            available: bool = ...,
+            guild_subscription: bool = ...,
+            user_subscription: bool = ...,
         ) -> None:
             ...
+
+    @flag_value
+    def available(self):
+        """:class:`bool`: Returns ``True`` if the SKU can be purchased."""
+        return 1 << 2
 
     @flag_value
     def guild_subscription(self):

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2322,7 +2322,7 @@ class HTTPClient:
         sku_id: Snowflake,
         owner_id: Snowflake,
         *,
-        owner_type: Literal[1, 2],  # 1: user, 2: guild
+        owner_type: Literal[1, 2],  # 1: guild, 2: user
     ) -> Response[entitlement.Entitlement]:
         payload: Dict[str, Any] = {
             "sku_id": sku_id,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2287,14 +2287,13 @@ class HTTPClient:
         self,
         application_id: Snowflake,
         *,
-        # TODO: what happens when both are specified?
+        # if both are specified, `after` takes priority and `before` gets ignored
         before: Optional[Snowflake] = None,
         after: Optional[Snowflake] = None,
         limit: int = 100,
         user_id: Optional[Snowflake] = None,
         guild_id: Optional[Snowflake] = None,
         sku_ids: Optional[SnowflakeList] = None,
-        # TODO: what's the default for this in the API?
         exclude_ended: bool = False,
     ) -> Response[List[entitlement.Entitlement]]:
         params: Dict[str, Any] = {

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -60,7 +60,6 @@ if TYPE_CHECKING:
         components,
         embed,
         emoji,
-        entitlement,
         gateway,
         guild,
         guild_scheduled_event,
@@ -71,7 +70,6 @@ if TYPE_CHECKING:
         message,
         onboarding,
         role,
-        sku,
         sticker,
         template,
         threads,
@@ -2275,80 +2273,6 @@ class HTTPClient:
 
     def get_guild_onboarding(self, guild_id: Snowflake) -> Response[onboarding.Onboarding]:
         return self.request(Route("GET", "/guilds/{guild_id}/onboarding", guild_id=guild_id))
-
-    # SKUs/Entitlements
-
-    def get_skus(self, application_id: Snowflake) -> Response[List[sku.SKU]]:
-        return self.request(
-            Route("GET", "/applications/{application_id}/skus", application_id=application_id)
-        )
-
-    def get_entitlements(
-        self,
-        application_id: Snowflake,
-        *,
-        # if both are specified, `after` takes priority and `before` gets ignored
-        before: Optional[Snowflake] = None,
-        after: Optional[Snowflake] = None,
-        limit: int = 100,
-        user_id: Optional[Snowflake] = None,
-        guild_id: Optional[Snowflake] = None,
-        sku_ids: Optional[SnowflakeList] = None,
-        exclude_ended: bool = False,
-    ) -> Response[List[entitlement.Entitlement]]:
-        params: Dict[str, Any] = {
-            "limit": limit,
-            "exclude_ended": int(exclude_ended),
-        }
-        if before is not None:
-            params["before"] = before
-        if after is not None:
-            params["after"] = after
-        if user_id is not None:
-            params["user_id"] = user_id
-        if guild_id is not None:
-            params["guild_id"] = guild_id
-        if sku_ids:
-            params["sku_ids"] = ",".join(map(str, sku_ids))
-
-        r = Route(
-            "GET", "/applications/{application_id}/entitlements", application_id=application_id
-        )
-        return self.request(r, params=params)
-
-    def create_test_entitlement(
-        self,
-        application_id: Snowflake,
-        sku_id: Snowflake,
-        owner_id: Snowflake,
-        *,
-        owner_type: Literal[1, 2],  # 1: guild, 2: user
-    ) -> Response[entitlement.Entitlement]:
-        payload: Dict[str, Any] = {
-            "sku_id": sku_id,
-            "owner_id": owner_id,
-            "owner_type": owner_type,
-        }
-        return self.request(
-            Route(
-                "POST", "/applications/{application_id}/entitlements", application_id=application_id
-            ),
-            json=payload,
-        )
-
-    def delete_test_entitlement(
-        self,
-        application_id: Snowflake,
-        entitlement_id: Snowflake,
-    ) -> Response[None]:
-        return self.request(
-            Route(
-                "DELETE",
-                "/applications/{application_id}/entitlements/{entitlement_id}",
-                application_id=application_id,
-                entitlement_id=entitlement_id,
-            )
-        )
 
     # Application commands (global)
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
         components,
         embed,
         emoji,
+        entitlement,
         gateway,
         guild,
         guild_scheduled_event,
@@ -2280,6 +2281,40 @@ class HTTPClient:
         return self.request(
             Route("GET", "/applications/{application_id}/skus", application_id=application_id)
         )
+
+    def get_entitlements(
+        self,
+        application_id: Snowflake,
+        *,
+        # TODO: what happens when both are specified?
+        before: Optional[Snowflake] = None,
+        after: Optional[Snowflake] = None,
+        limit: int = 100,
+        user_id: Optional[Snowflake] = None,
+        guild_id: Optional[Snowflake] = None,
+        sku_ids: Optional[SnowflakeList] = None,
+        # TODO: what's the default for this in the API?
+        exclude_ended: bool = False,
+    ) -> Response[List[entitlement.Entitlement]]:
+        params: Dict[str, Any] = {
+            "limit": limit,
+            "exclude_ended": int(exclude_ended),
+        }
+        if before is not None:
+            params["before"] = before
+        if after is not None:
+            params["after"] = after
+        if user_id is not None:
+            params["user_id"] = user_id
+        if guild_id is not None:
+            params["guild_id"] = guild_id
+        if sku_ids:
+            params["sku_ids"] = ",".join(map(str, sku_ids))
+
+        r = Route(
+            "GET", "/applications/{application_id}/entitlements", application_id=application_id
+        )
+        return self.request(r, params=params)
 
     # Application commands (global)
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
         message,
         onboarding,
         role,
+        sku,
         sticker,
         template,
         threads,
@@ -2272,6 +2273,13 @@ class HTTPClient:
 
     def get_guild_onboarding(self, guild_id: Snowflake) -> Response[onboarding.Onboarding]:
         return self.request(Route("GET", "/guilds/{guild_id}/onboarding", guild_id=guild_id))
+
+    # SKUs/Entitlements
+
+    def get_skus(self, application_id: Snowflake) -> Response[List[sku.SKU]]:
+        return self.request(
+            Route("GET", "/applications/{application_id}/skus", application_id=application_id)
+        )
 
     # Application commands (global)
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2316,6 +2316,40 @@ class HTTPClient:
         )
         return self.request(r, params=params)
 
+    def create_test_entitlement(
+        self,
+        application_id: Snowflake,
+        sku_id: Snowflake,
+        owner_id: Snowflake,
+        *,
+        owner_type: Literal[1, 2],  # 1: user, 2: guild
+    ) -> Response[entitlement.Entitlement]:
+        payload: Dict[str, Any] = {
+            "sku_id": sku_id,
+            "owner_id": owner_id,
+            "owner_type": owner_type,
+        }
+        return self.request(
+            Route(
+                "POST", "/applications/{application_id}/entitlements", application_id=application_id
+            ),
+            json=payload,
+        )
+
+    def delete_test_entitlement(
+        self,
+        application_id: Snowflake,
+        entitlement_id: Snowflake,
+    ) -> Response[None]:
+        return self.request(
+            Route(
+                "DELETE",
+                "/applications/{application_id}/entitlements/{entitlement_id}",
+                application_id=application_id,
+                entitlement_id=entitlement_id,
+            )
+        )
+
     # Application commands (global)
 
     def get_global_commands(

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -330,16 +330,6 @@ class Interaction(Generic[ClientT]):
 
         Fetches the original interaction response message associated with the interaction.
 
-        Here is a table with response types and their associated original response:
-
-        .. csv-table::
-            :header: "Response type", "Original response"
-
-            :meth:`InteractionResponse.send_message`, "The message you sent"
-            :meth:`InteractionResponse.edit_message`, "The message you edited"
-            :meth:`InteractionResponse.defer`, "The message with thinking state (bot is thinking...)"
-            "Other response types", "None"
-
         Repeated calls to this will return a cached value.
 
         .. versionchanged:: 2.6
@@ -1404,6 +1394,35 @@ class InteractionResponse:
 
         if modal is not None:
             parent._state.store_modal(parent.author.id, modal)
+
+    async def send_premium_required(self) -> None:
+        """|coro|
+
+        Responds to this interaction with a message containing an upgrade button.
+
+        Only available for applications with monetization enabled.
+
+        Raises
+        ------
+        HTTPException
+            Sending the response has failed.
+        InteractionResponded
+            This interaction has already been responded to before.
+        """
+        if self._response_type is not None:
+            raise InteractionResponded(self._parent)
+
+        parent = self._parent
+        adapter = async_context.get()
+        response_type = InteractionResponseType.premium_required
+        await adapter.create_interaction_response(
+            parent.id,
+            parent.token,
+            session=parent._session,
+            type=response_type.value,
+        )
+
+        self._response_type = response_type
 
 
 class _InteractionMessageState:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1410,7 +1410,7 @@ class InteractionResponse:
         if modal is not None:
             parent._state.store_modal(parent.author.id, modal)
 
-    async def send_premium_required(self) -> None:
+    async def require_premium(self) -> None:
         """|coro|
 
         Responds to this interaction with a message containing an upgrade button.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -22,6 +22,7 @@ from typing import (
 from .. import utils
 from ..app_commands import OptionChoice
 from ..channel import PartialMessageable, _threaded_guild_channel_factory
+from ..entitlement import Entitlement
 from ..enums import (
     ChannelType,
     ComponentType,
@@ -145,6 +146,11 @@ class Interaction(Generic[ClientT]):
         The token to continue the interaction. These are valid for 15 minutes.
     client: :class:`Client`
         The interaction client.
+    entitlements: List[:class:`Entitlement`]
+        The entitlements for the invoking user and guild,
+        representing access to an application subscription.
+
+        .. versionadded:: 2.10
     """
 
     __slots__: Tuple[str, ...] = (
@@ -160,6 +166,7 @@ class Interaction(Generic[ClientT]):
         "locale",
         "guild_locale",
         "client",
+        "entitlements",
         "_app_permissions",
         "_permissions",
         "_state",
@@ -185,18 +192,20 @@ class Interaction(Generic[ClientT]):
         self.token: str = data["token"]
         self.version: int = data["version"]
         self.application_id: int = int(data["application_id"])
-        self._app_permissions: int = int(data.get("app_permissions", 0))
 
         self.channel_id: int = int(data["channel_id"])
         self.guild_id: Optional[int] = utils._get_as_snowflake(data, "guild_id")
+
         self.locale: Locale = try_enum(Locale, data["locale"])
         guild_locale = data.get("guild_locale")
         self.guild_locale: Optional[Locale] = (
             try_enum(Locale, guild_locale) if guild_locale else None
         )
+
+        self._app_permissions: int = int(data.get("app_permissions", 0))
+        self._permissions: Optional[int] = None
         # one of user and member will always exist
         self.author: Union[User, Member] = MISSING
-        self._permissions = None
 
         if self.guild_id and (member := data.get("member")):
             guild: Guild = self.guild or Object(id=self.guild_id)  # type: ignore
@@ -208,6 +217,12 @@ class Interaction(Generic[ClientT]):
             self._permissions = int(member.get("permissions", 0))
         elif user := data.get("user"):
             self.author = self._state.store_user(user)
+
+        self.entitlements: List[Entitlement] = (
+            [Entitlement(data=e, state=state) for e in entitlements_data]
+            if (entitlements_data := data.get("entitlements"))
+            else []
+        )
 
     @property
     def bot(self) -> ClientT:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1417,6 +1417,8 @@ class InteractionResponse:
 
         Only available for applications with monetization enabled.
 
+        .. versionadded:: 2.10
+
         Raises
         ------
         HTTPException

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1419,6 +1419,17 @@ class InteractionResponse:
 
         .. versionadded:: 2.10
 
+        Example
+        -------
+        Require an application subscription for a command: ::
+
+            @bot.slash_command()
+            async def cool_command(inter: disnake.ApplicationCommandInteraction):
+                if not inter.entitlements:
+                    await inter.response.require_premium()
+                    return  # skip remaining code
+                ...
+
         Raises
         ------
         HTTPException

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -22,7 +22,6 @@ from .app_commands import application_command_factory
 from .audit_logs import AuditLogEntry
 from .automod import AutoModRule
 from .bans import BanEntry
-from .entitlement import Entitlement
 from .errors import NoMoreItems
 from .guild_scheduled_event import GuildScheduledEvent
 from .integrations import PartialIntegration
@@ -38,7 +37,6 @@ __all__ = (
     "GuildIterator",
     "MemberIterator",
     "GuildScheduledEventUserIterator",
-    "EntitlementIterator",
 )
 
 if TYPE_CHECKING:
@@ -53,7 +51,6 @@ if TYPE_CHECKING:
         AuditLogEntry as AuditLogEntryPayload,
         AuditLogEvent,
     )
-    from .types.entitlement import Entitlement as EntitlementPayload
     from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.guild_scheduled_event import (
         GuildScheduledEventUser as GuildScheduledEventUserPayload,
@@ -1024,119 +1021,4 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
             if self.limit is not None:
                 self.limit -= retrieve
             self.after = Object(id=int(data[-1]["user"]["id"]))
-        return data
-
-
-# The endpoint for this paginates like audit logs,
-# i.e. descending when no parameter or `before` is given,
-# and ascending when `after` is given.
-class EntitlementIterator(_AsyncIterator["Entitlement"]):
-    def __init__(
-        self,
-        application_id: int,
-        *,
-        state: ConnectionState,
-        limit: Optional[int],
-        user_id: Optional[int] = None,
-        guild_id: Optional[int] = None,
-        sku_ids: Optional[List[int]] = None,
-        before: Optional[Union[Snowflake, datetime.datetime]] = None,
-        after: Optional[Union[Snowflake, datetime.datetime]] = None,
-        exclude_ended: bool = False,
-        oldest_first: bool = False,
-    ) -> None:
-        if isinstance(before, datetime.datetime):
-            before = Object(id=time_snowflake(before, high=False))
-        if isinstance(after, datetime.datetime):
-            after = Object(id=time_snowflake(after, high=True))
-
-        self.application_id: int = application_id
-        self.limit: Optional[int] = limit
-        self.before: Optional[Snowflake] = before
-        self.after: Snowflake = after or OLDEST_OBJECT
-        self.user_id: Optional[int] = user_id
-        self.guild_id: Optional[int] = guild_id
-        self.sku_ids: Optional[List[int]] = sku_ids
-        self.exclude_ended: bool = exclude_ended
-
-        self.state: ConnectionState = state
-        self.request = state.http.get_entitlements
-
-        self.entitlements: asyncio.Queue[Entitlement] = asyncio.Queue()
-
-        self._filter: Optional[Callable[[EntitlementPayload], bool]] = None
-        if oldest_first:
-            self._strategy = self._after_strategy
-            if self.before:
-                self._filter = lambda m: int(m["id"]) < self.before.id  # type: ignore
-        else:
-            self._strategy = self._before_strategy
-            if self.after and self.after != OLDEST_OBJECT:
-                self._filter = lambda m: int(m["id"]) > self.after.id
-
-    async def next(self) -> Entitlement:
-        if self.entitlements.empty():
-            await self._fill()
-
-        try:
-            return self.entitlements.get_nowait()
-        except asyncio.QueueEmpty:
-            raise NoMoreItems from None
-
-    def _get_retrieve(self) -> bool:
-        limit = self.limit
-        if limit is None or limit > 100:
-            retrieve = 100
-        else:
-            retrieve = limit
-        self.retrieve: int = retrieve
-        return retrieve > 0
-
-    async def _fill(self) -> None:
-        if not self._get_retrieve():
-            return
-
-        data = await self._strategy(self.retrieve)
-        if len(data) < 100:
-            self.limit = 0  # terminate loop
-
-        if self._filter:
-            data = filter(self._filter, data)
-
-        for entitlement in data:
-            await self.entitlements.put(Entitlement(data=entitlement, state=self.state))
-
-    async def _before_strategy(self, retrieve: int) -> List[EntitlementPayload]:
-        before = self.before.id if self.before else None
-        data = await self.request(
-            self.application_id,
-            before=before,
-            limit=retrieve,
-            user_id=self.user_id,
-            guild_id=self.guild_id,
-            exclude_ended=self.exclude_ended,
-        )
-
-        if len(data):
-            if self.limit is not None:
-                self.limit -= retrieve
-            self.before = Object(id=int(data[-1]["id"]))
-        return data
-
-    async def _after_strategy(self, retrieve: int) -> List[EntitlementPayload]:
-        after = self.after.id
-        data = await self.request(
-            self.application_id,
-            after=after,
-            limit=retrieve,
-            user_id=self.user_id,
-            guild_id=self.guild_id,
-            exclude_ended=self.exclude_ended,
-        )
-
-        if len(data):
-            if self.limit is not None:
-                self.limit -= retrieve
-            # endpoint returns items in ascending order when `after` is used
-            self.after = Object(id=int(data[-1]["id"]))
         return data

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -22,6 +22,7 @@ from .app_commands import application_command_factory
 from .audit_logs import AuditLogEntry
 from .automod import AutoModRule
 from .bans import BanEntry
+from .entitlement import Entitlement
 from .errors import NoMoreItems
 from .guild_scheduled_event import GuildScheduledEvent
 from .integrations import PartialIntegration
@@ -37,6 +38,7 @@ __all__ = (
     "GuildIterator",
     "MemberIterator",
     "GuildScheduledEventUserIterator",
+    "EntitlementIterator",
 )
 
 if TYPE_CHECKING:
@@ -51,6 +53,7 @@ if TYPE_CHECKING:
         AuditLogEntry as AuditLogEntryPayload,
         AuditLogEvent,
     )
+    from .types.entitlement import Entitlement as EntitlementPayload
     from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.guild_scheduled_event import (
         GuildScheduledEventUser as GuildScheduledEventUserPayload,
@@ -944,7 +947,7 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
             self._strategy = self._after_strategy
             self.reverse = False
 
-    async def next(self) -> Message:
+    async def next(self) -> Union[User, Member]:
         if self.users.empty():
             await self.fill_users()
 
@@ -1021,4 +1024,118 @@ class GuildScheduledEventUserIterator(_AsyncIterator[Union["User", "Member"]]):
             if self.limit is not None:
                 self.limit -= retrieve
             self.after = Object(id=int(data[-1]["user"]["id"]))
+        return data
+
+
+class EntitlementIterator(_AsyncIterator["Entitlement"]):
+    def __init__(
+        self,
+        application_id: int,
+        *,
+        state: ConnectionState,
+        limit: Optional[int],
+        user_id: Optional[int] = None,
+        guild_id: Optional[int] = None,
+        sku_ids: Optional[List[int]] = None,
+        before: Optional[Union[Snowflake, datetime.datetime]] = None,
+        after: Optional[Union[Snowflake, datetime.datetime]] = None,
+        exclude_ended: bool = False,
+    ) -> None:
+        if isinstance(before, datetime.datetime):
+            before = Object(id=time_snowflake(before, high=False))
+        if isinstance(after, datetime.datetime):
+            after = Object(id=time_snowflake(after, high=True))
+
+        self.application_id: int = application_id
+        self.limit: Optional[int] = limit
+        self.before: Optional[Snowflake] = before
+        self.after: Optional[Snowflake] = after
+        self.user_id: Optional[int] = user_id
+        self.guild_id: Optional[int] = guild_id
+        self.sku_ids: Optional[List[int]] = sku_ids
+        self.exclude_ended: bool = exclude_ended
+
+        self.state: ConnectionState = state
+        self.request = state.http.get_entitlements
+
+        self.entitlements: asyncio.Queue[Entitlement] = asyncio.Queue()
+
+        self._filter: Optional[Callable[[EntitlementPayload], bool]] = None
+        if self.before is not None:
+            self._strategy = self._before_strategy
+            if self.after is not None:
+                self._filter = lambda e: int(e["id"]) > self.after.id  # type: ignore
+            # reverse if using `before` strategy, since chunks are always received in
+            # ascending order (200-299, 100-199, 0-99) regardless of before/after
+            self.reverse = True
+        else:
+            self._strategy = self._after_strategy
+            self.reverse = False
+
+    async def next(self) -> Entitlement:
+        if self.entitlements.empty():
+            await self._fill()
+
+        try:
+            return self.entitlements.get_nowait()
+        except asyncio.QueueEmpty:
+            raise NoMoreItems from None
+
+    def _get_retrieve(self) -> bool:
+        limit = self.limit
+        if limit is None or limit > 100:
+            retrieve = 100
+        else:
+            retrieve = limit
+        self.retrieve: int = retrieve
+        return retrieve > 0
+
+    async def _fill(self) -> None:
+        if not self._get_retrieve():
+            return
+
+        data = await self._strategy(self.retrieve)
+        if len(data) < 100:
+            self.limit = 0  # terminate loop
+
+        if self.reverse:
+            data = reversed(data)
+        if self._filter:
+            data = filter(self._filter, data)
+
+        for entitlement in data:
+            await self.entitlements.put(Entitlement(data=entitlement, state=self.state))
+
+    async def _before_strategy(self, retrieve: int) -> List[EntitlementPayload]:
+        before = self.before.id if self.before else None
+        data = await self.request(
+            self.application_id,
+            before=before,
+            limit=retrieve,
+            user_id=self.user_id,
+            guild_id=self.guild_id,
+            exclude_ended=self.exclude_ended,
+        )
+
+        if len(data):
+            if self.limit is not None:
+                self.limit -= retrieve
+            self.before = Object(id=int(data[0]["id"]))
+        return data
+
+    async def _after_strategy(self, retrieve: int) -> List[EntitlementPayload]:
+        after = self.after.id if self.after else None
+        data = await self.request(
+            self.application_id,
+            after=after,
+            limit=retrieve,
+            user_id=self.user_id,
+            guild_id=self.guild_id,
+            exclude_ended=self.exclude_ended,
+        )
+
+        if len(data):
+            if self.limit is not None:
+                self.limit -= retrieve
+            self.after = Object(id=int(data[-1]["id"]))
         return data

--- a/disnake/sku.py
+++ b/disnake/sku.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 
 from .enums import SKUType, try_enum
 from .flags import SKUFlags
 from .mixins import Hashable
+from .utils import snowflake_time
 
 if TYPE_CHECKING:
     from .types.sku import SKU as SKUPayload
@@ -69,6 +71,11 @@ class SKU(Hashable):
 
     def __repr__(self) -> str:
         return f"<SKU id={self.id!r} type={self.type!r} name={self.name!r}>"
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """:class:`datetime.datetime`: Returns the SKU's creation time in UTC."""
+        return snowflake_time(self.id)
 
     @property
     def flags(self) -> SKUFlags:

--- a/disnake/sku.py
+++ b/disnake/sku.py
@@ -22,7 +22,7 @@ class SKU(Hashable):
 
     This can be retrieved using :meth:`Client.skus`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/sku.py
+++ b/disnake/sku.py
@@ -79,8 +79,5 @@ class SKU(Hashable):
 
     @property
     def flags(self) -> SKUFlags:
-        """:class:`SKUFlags`: Returns the SKU's flags.
-
-        .. versionadded:: 2.10
-        """
+        """:class:`SKUFlags`: Returns the SKU's flags."""
         return SKUFlags._from_value(self._flags)

--- a/disnake/sku.py
+++ b/disnake/sku.py
@@ -18,6 +18,8 @@ __all__ = ("SKU",)
 class SKU(Hashable):
     """Represents an SKU.
 
+    This can be retrieved using :meth:`Client.skus`.
+
     .. container:: operations
 
         .. describe:: x == y

--- a/disnake/sku.py
+++ b/disnake/sku.py
@@ -18,8 +18,6 @@ __all__ = ("SKU",)
 class SKU(Hashable):
     """Represents an SKU.
 
-    This can be retrieved using :meth:`Client.skus`.
-
     .. container:: operations
 
         .. describe:: x == y

--- a/disnake/sku.py
+++ b/disnake/sku.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .enums import SKUType, try_enum
+from .flags import SKUFlags
+from .mixins import Hashable
+
+if TYPE_CHECKING:
+    from .types.sku import SKU as SKUPayload
+
+
+__all__ = ("SKU",)
+
+
+class SKU(Hashable):
+    """Represents an SKU.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two :class:`SKU`\\s are equal.
+
+        .. describe:: x != y
+
+            Checks if two :class:`SKU`\\s are not equal.
+
+        .. describe:: hash(x)
+
+            Returns the SKU's hash.
+
+        .. describe:: str(x)
+
+            Returns the SKU's name.
+
+    .. versionadded:: 2.10
+
+    Attributes
+    ----------
+    id: :class:`int`
+        The SKU's ID.
+    type: :class:`SKUType`
+        The SKU's type.
+    application_id: :class:`int`
+        The parent application's ID.
+    name: :class:`str`
+        The SKU's name.
+    slug: :class:`str`
+        The SKU's URL slug, system-generated based on :attr:`name`.
+    """
+
+    __slots__ = ("id", "type", "application_id", "name", "slug", "_flags")
+
+    def __init__(self, *, data: SKUPayload) -> None:
+        self.id: int = int(data["id"])
+        self.type: SKUType = try_enum(SKUType, data["type"])
+        self.application_id: int = int(data["application_id"])
+        self.name: str = data["name"]
+        self.slug: str = data["slug"]
+        self._flags: int = data.get("flags", 0)
+
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return f"<SKU id={self.id!r} type={self.type!r} name={self.name!r}>"
+
+    @property
+    def flags(self) -> SKUFlags:
+        """:class:`SKUFlags`: Returns the SKU's flags.
+
+        .. versionadded:: 2.10
+        """
+        return SKUFlags._from_value(self._flags)

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -45,6 +45,7 @@ from .channel import (
     _guild_channel_factory,
 )
 from .emoji import Emoji
+from .entitlement import Entitlement
 from .enums import ApplicationCommandType, ChannelType, ComponentType, MessageType, Status, try_enum
 from .flags import ApplicationFlags, Intents, MemberCacheFlags
 from .guild import Guild
@@ -1904,6 +1905,21 @@ class ConnectionState:
             webhooks={},
         )
         self.dispatch("audit_log_entry_create", entry)
+
+    # TODO: these are untested (like everything else, tbqh); the _UPDATE and _DELETE contents are undocumented
+    # TODO: do these get called for test entitlements?
+    # TODO: presumably no intents required?
+    def parse_entitlement_create(self, data: gateway.EntitlementCreate) -> None:
+        entitlement = Entitlement(data=data, state=self)
+        self.dispatch("entitlement_create", entitlement)
+
+    def parse_entitlement_update(self, data: gateway.EntitlementUpdate) -> None:
+        entitlement = Entitlement(data=data, state=self)
+        self.dispatch("entitlement_update", entitlement)
+
+    def parse_entitlement_delete(self, data: gateway.EntitlementDelete) -> None:
+        entitlement = Entitlement(data=data, state=self)
+        self.dispatch("entitlement_delete", entitlement)
 
     def _get_reaction_user(
         self, channel: MessageableChannel, user_id: int

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1906,8 +1906,6 @@ class ConnectionState:
         )
         self.dispatch("audit_log_entry_create", entry)
 
-    # TODO: do these get called for test entitlements?
-    # TODO: presumably no intents required?
     def parse_entitlement_create(self, data: gateway.EntitlementCreate) -> None:
         entitlement = Entitlement(data=data, state=self)
         self.dispatch("entitlement_create", entitlement)

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1906,7 +1906,6 @@ class ConnectionState:
         )
         self.dispatch("audit_log_entry_create", entry)
 
-    # TODO: these are untested (like everything else, tbqh); the _UPDATE and _DELETE contents are undocumented
     # TODO: do these get called for test entitlements?
     # TODO: presumably no intents required?
     def parse_entitlement_create(self, data: gateway.EntitlementCreate) -> None:

--- a/disnake/types/entitlement.py
+++ b/disnake/types/entitlement.py
@@ -16,6 +16,6 @@ class Entitlement(TypedDict):
     guild_id: NotRequired[Snowflake]
     application_id: Snowflake
     type: EntitlementType
-    consumed: bool  # always false in this case
+    deleted: bool
     starts_at: NotRequired[str]
     ends_at: NotRequired[str]

--- a/disnake/types/entitlement.py
+++ b/disnake/types/entitlement.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+
+from typing import Literal, TypedDict
+
+from typing_extensions import NotRequired
+
+from .snowflake import Snowflake
+
+EntitlementType = Literal[8]
+
+
+class Entitlement(TypedDict):
+    id: Snowflake
+    sku_id: Snowflake
+    user_id: NotRequired[Snowflake]
+    guild_id: NotRequired[Snowflake]
+    application_id: Snowflake
+    type: EntitlementType
+    consumed: bool  # always false in this case
+    starts_at: NotRequired[str]
+    ends_at: NotRequired[str]

--- a/disnake/types/gateway.py
+++ b/disnake/types/gateway.py
@@ -12,6 +12,7 @@ from .audit_log import AuditLogEntry
 from .automod import AutoModAction, AutoModRule, AutoModTriggerType
 from .channel import Channel, GuildChannel, StageInstance
 from .emoji import Emoji, PartialEmoji
+from .entitlement import Entitlement
 from .guild import Guild, UnavailableGuild
 from .guild_scheduled_event import GuildScheduledEvent
 from .integration import BaseIntegration
@@ -624,3 +625,15 @@ class AutoModerationActionExecutionEvent(TypedDict):
     content: NotRequired[str]
     matched_content: NotRequired[Optional[str]]
     matched_keyword: NotRequired[Optional[str]]
+
+
+# https://discord.com/developers/docs/monetization/entitlements#new-entitlement
+EntitlementCreate = Entitlement
+
+
+# https://discord.com/developers/docs/monetization/entitlements#updated-entitlement
+EntitlementUpdate = Entitlement
+
+
+# https://discord.com/developers/docs/monetization/entitlements#deleted-entitlement
+EntitlementDelete = Entitlement

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -313,7 +313,7 @@ class InteractionAutocompleteCallbackData(TypedDict):
     choices: List[ApplicationCommandOptionChoice]
 
 
-InteractionResponseType = Literal[1, 4, 5, 6, 7]
+InteractionResponseType = Literal[1, 4, 5, 6, 7, 10]
 
 InteractionCallbackData = Union[
     InteractionApplicationCommandCallbackData,

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -265,7 +265,7 @@ class _BaseUserInteraction(_BaseInteraction):
     app_permissions: NotRequired[str]
     guild_id: NotRequired[Snowflake]
     guild_locale: NotRequired[str]
-    entitlements: List[Entitlement]
+    entitlements: NotRequired[List[Entitlement]]
     # one of these two will always exist, according to docs
     member: NotRequired[MemberWithUser]
     user: NotRequired[User]

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -9,6 +9,7 @@ from typing_extensions import NotRequired
 from .channel import ChannelType
 from .components import Component, Modal
 from .embed import Embed
+from .entitlement import Entitlement
 from .i18n import LocalizationDict
 from .member import Member, MemberWithUser
 from .role import Role
@@ -264,6 +265,7 @@ class _BaseUserInteraction(_BaseInteraction):
     app_permissions: NotRequired[str]
     guild_id: NotRequired[Snowflake]
     guild_locale: NotRequired[str]
+    entitlements: List[Entitlement]
     # one of these two will always exist, according to docs
     member: NotRequired[MemberWithUser]
     user: NotRequired[User]

--- a/disnake/types/sku.py
+++ b/disnake/types/sku.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+
+from typing import Literal, TypedDict
+
+from .snowflake import Snowflake
+
+SKUType = Literal[5, 6]
+
+
+class SKU(TypedDict):
+    id: Snowflake
+    type: SKUType
+    application_id: Snowflake
+    name: str
+    slug: str
+    flags: int
+    # there are more fields, but they aren't documented and mostly uninteresting

--- a/docs/api/entitlements.rst
+++ b/docs/api/entitlements.rst
@@ -34,3 +34,10 @@ EntitlementType
     .. attribute:: application_subscription
 
         Represents an entitlement for an application subscription.
+
+Events
+------
+
+- :func:`on_entitlement_create(entitlement) <disnake.on_entitlement_create>`
+- :func:`on_entitlement_update(entitlement) <disnake.on_entitlement_update>`
+- :func:`on_entitlement_delete(entitlement) <disnake.on_entitlement_delete>`

--- a/docs/api/entitlements.rst
+++ b/docs/api/entitlements.rst
@@ -1,0 +1,36 @@
+.. SPDX-License-Identifier: MIT
+
+.. currentmodule:: disnake
+
+Entitlements
+============
+
+This section documents everything related to entitlements, which represent access to :doc:`skus`.
+
+Discord Models
+---------------
+
+Entitlement
+~~~~~~~~~~~
+
+.. attributetable:: Entitlement
+
+.. autoclass:: Entitlement()
+    :members:
+
+
+Enumerations
+------------
+
+EntitlementType
+~~~~~~~~~~~~~~~
+
+.. class:: EntitlementType
+
+    Represents the type of an entitlement.
+
+    .. versionadded:: 2.10
+
+    .. attribute:: application_subscription
+
+        Represents an entitlement for an application subscription.

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -1451,7 +1451,8 @@ This section documents events related to entitlements, which are used for applic
 
     Called when an entitlement is created.
 
-    This is usually caused by a user subscribing to an SKU.
+    This is usually caused by a user subscribing to an SKU,
+    or when a new test entitlement is created (see :meth:`Client.create_entitlement`).
 
     .. versionadded:: 2.10
 

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -1458,8 +1458,9 @@ This section documents events related to entitlements, which are related to appl
 
 .. function:: on_entitlement_update(entitlement)
 
-    Called when a user's subscription renews.
-    The :attr:`Entitlement.ends_at` attribute reflects the new expiration date.
+    Called when a user's entitlement is updated,
+    for example when the subscription gets renewed (in which case
+    the :attr:`Entitlement.ends_at` attribute reflects the new expiration date).
 
     .. versionadded:: 2.10
 

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -1442,6 +1442,42 @@ This section documents events related to Discord chat messages.
     :param data: The raw event payload data.
     :type data: :class:`RawTypingEvent`
 
+Entitlements
+~~~~~~~~~~~~
+
+This section documents events related to entitlements, which are related to application subscriptions.
+
+.. function:: on_entitlement_create(entitlement)
+
+    Called when a user subscribes to an SKU, creating a new :class:`Entitlement`.
+
+    .. versionadded:: 2.10
+
+    :param entitlement: The entitlement that was created.
+    :type entitlement: :class:`Entitlement`
+
+.. function:: on_entitlement_update(entitlement)
+
+    Called when a user's subscription renews.
+    The :attr:`Entitlement.ends_at` attribute reflects the new expiration date.
+
+    .. versionadded:: 2.10
+
+    :param entitlement: The entitlement that was updated.
+    :type entitlement: :class:`Entitlement`
+
+.. function:: on_entitlement_delete(entitlement)
+
+    Called when a user's entitlement is deleted.
+
+    .. note::
+        This does not get called when an entitlement expires;
+        it only occurs in case of refunds or due to manual removal.
+
+    .. versionadded:: 2.10
+
+    :param entitlement: The entitlement that was deleted.
+    :type entitlement: :class:`Entitlement`
 
 Enumerations
 ------------

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -1451,8 +1451,7 @@ This section documents events related to entitlements, which are used for applic
 
     Called when an entitlement is created.
 
-    This is usually caused by a user subscribing to an SKU,
-    or when a new test entitlement is created (see :meth:`Client.create_entitlement`).
+    This is usually caused by a user subscribing to an SKU.
 
     .. versionadded:: 2.10
 

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -1445,11 +1445,14 @@ This section documents events related to Discord chat messages.
 Entitlements
 ~~~~~~~~~~~~
 
-This section documents events related to entitlements, which are related to application subscriptions.
+This section documents events related to entitlements, which are used for application subscriptions.
 
 .. function:: on_entitlement_create(entitlement)
 
-    Called when a user subscribes to an SKU, creating a new :class:`Entitlement`.
+    Called when an entitlement is created.
+
+    This is usually caused by a user subscribing to an SKU,
+    or when a new test entitlement is created (see :meth:`Client.create_entitlement`).
 
     .. versionadded:: 2.10
 
@@ -1458,9 +1461,10 @@ This section documents events related to entitlements, which are related to appl
 
 .. function:: on_entitlement_update(entitlement)
 
-    Called when a user's entitlement is updated,
-    for example when the subscription gets renewed (in which case
-    the :attr:`Entitlement.ends_at` attribute reflects the new expiration date).
+    Called when an entitlement is updated.
+
+    This happens e.g. when a user's subscription gets renewed (in which case the
+    :attr:`Entitlement.ends_at` attribute reflects the new expiration date).
 
     .. versionadded:: 2.10
 
@@ -1469,11 +1473,11 @@ This section documents events related to entitlements, which are related to appl
 
 .. function:: on_entitlement_delete(entitlement)
 
-    Called when a user's entitlement is deleted.
+    Called when an entitlement is deleted.
 
     .. note::
         This does not get called when an entitlement expires;
-        it only occurs in case of refunds or due to manual removal.
+        it only occurs e.g. in case of refunds or due to manual removal.
 
     .. versionadded:: 2.10
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -101,6 +101,7 @@ Documents
     clients
     components
     emoji
+    entitlements
     events
     exceptions
     guilds

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -114,6 +114,7 @@ Documents
     misc
     permissions
     roles
+    skus
     stage_instances
     stickers
     users

--- a/docs/api/interactions.rst
+++ b/docs/api/interactions.rst
@@ -247,6 +247,7 @@ InteractionResponseType
         See also :meth:`InteractionResponse.send_modal`
 
         .. versionadded:: 2.4
+
     .. attribute:: premium_required
 
         Responds to the interaction with a message containing an upgrade button.

--- a/docs/api/interactions.rst
+++ b/docs/api/interactions.rst
@@ -216,7 +216,7 @@ InteractionResponseType
         See also :meth:`InteractionResponse.pong`
     .. attribute:: channel_message
 
-        Respond to the interaction with a message.
+        Responds to the interaction with a message.
 
         See also :meth:`InteractionResponse.send_message`
     .. attribute:: deferred_channel_message
@@ -245,6 +245,16 @@ InteractionResponseType
         Responds to the interaction by displaying a modal.
 
         See also :meth:`InteractionResponse.send_modal`
+
+        .. versionadded:: 2.4
+    .. attribute:: premium_required
+
+        Responds to the interaction with a message containing an upgrade button.
+        Only available for applications with monetization enabled.
+
+        See also :meth:`InteractionResponse.send_premium_required`
+
+        .. versionadded:: 2.10
 
 Events
 ------

--- a/docs/api/interactions.rst
+++ b/docs/api/interactions.rst
@@ -252,7 +252,7 @@ InteractionResponseType
         Responds to the interaction with a message containing an upgrade button.
         Only available for applications with monetization enabled.
 
-        See also :meth:`InteractionResponse.send_premium_required`
+        See also :meth:`InteractionResponse.require_premium`
 
         .. versionadded:: 2.10
 

--- a/docs/api/skus.rst
+++ b/docs/api/skus.rst
@@ -1,0 +1,53 @@
+.. SPDX-License-Identifier: MIT
+
+.. currentmodule:: disnake
+
+SKUs
+====
+
+This section documents everything related to SKUs, which represent items being
+sold on Discord, like application subscriptions.
+
+Discord Models
+---------------
+
+SKU
+~~~
+
+.. attributetable:: SKU
+
+.. autoclass:: SKU()
+    :members:
+
+
+Data Classes
+------------
+
+SKUFlags
+~~~~~~~~
+
+.. attributetable:: SKUFlags
+
+.. autoclass:: SKUFlags()
+    :members:
+
+
+Enumerations
+------------
+
+SKUType
+~~~~~~~
+
+.. class:: SKUType
+
+    Represents the type of an SKU.
+
+    .. versionadded:: 2.10
+
+    .. attribute:: subscription
+
+        Represents a recurring subscription.
+
+    .. attribute:: subscription_group
+
+        Represents a system-generated group for each :attr:`subscription` SKU.

--- a/docs/api/skus.rst
+++ b/docs/api/skus.rst
@@ -7,6 +7,7 @@ SKUs
 
 This section documents everything related to SKUs, which represent items being
 sold on Discord, like application subscriptions.
+See the :ddocs:`official docs <monetization/overview>` for more info.
 
 Discord Models
 ---------------


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/b97fad33bf2ff7633df32c1a8a206b53aa9fe568 (+ https://github.com/discord/discord-api-docs/commit/b8feadd75e782537545c715fbd71ab4048132363)

~~Since this feature is US-only, I'm unable to test most of it; still working on that part.
Nevertheless, all documented functionality is implemented. The `SKU`/`Entitlement` models have been tested using the example structs provided by the docs, but that's really it.~~  Tested all implemented functionality now.

There are a few `TODO`s scattered across the code regarding testing and naming some things; feedback for those would be appreciated. The api docs are lacking in a few aspects (gateway events, in particular, are somewhat of a guessing game), but most of it is fairly straightforward.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
