### PR TITLE
refactor: unify slash/prefix command signature evaluation

### DIFF
--- a/changelog/1116.misc.rst
+++ b/changelog/1116.misc.rst
@@ -1,1 +1,1 @@
-Rewrite slash command signature evaluation to use the same mechanism as prefix command signatures. This should not have an impact on user code, but streamlines future changes.
+|commands| Rewrite slash command signature evaluation to use the same mechanism as prefix command signatures. This should not have an impact on user code, but streamlines future changes.

--- a/changelog/1116.misc.rst
+++ b/changelog/1116.misc.rst
@@ -1,0 +1,1 @@
+Rewrite slash command signature evaluation to use the same mechanism as prefix command signatures. This should not have an impact on user code, but streamlines future changes.

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -27,7 +27,12 @@ from typing import (
 )
 
 import disnake
-from disnake.utils import _generated, _overload_with_permissions
+from disnake.utils import (
+    _generated,
+    _overload_with_permissions,
+    get_signature_parameters,
+    unwrap_function,
+)
 
 from ._types import _BaseCommand
 from .cog import Cog
@@ -112,42 +117,6 @@ if TYPE_CHECKING:
     ]
 else:
     P = TypeVar("P")
-
-
-def unwrap_function(function: Callable[..., Any]) -> Callable[..., Any]:
-    partial = functools.partial
-    while True:
-        if hasattr(function, "__wrapped__"):
-            function = function.__wrapped__
-        elif isinstance(function, partial):
-            function = function.func
-        else:
-            return function
-
-
-def get_signature_parameters(
-    function: Callable[..., Any], globalns: Dict[str, Any]
-) -> Dict[str, inspect.Parameter]:
-    signature = inspect.signature(function)
-    params = {}
-    cache: Dict[str, Any] = {}
-    eval_annotation = disnake.utils.evaluate_annotation
-    for name, parameter in signature.parameters.items():
-        annotation = parameter.annotation
-        if annotation is parameter.empty:
-            params[name] = parameter
-            continue
-        if annotation is None:
-            params[name] = parameter.replace(annotation=type(None))
-            continue
-
-        annotation = eval_annotation(annotation, globalns, globalns, cache)
-        if annotation is Greedy:
-            raise TypeError("Unparameterized Greedy[...] is disallowed in signature.")
-
-        params[name] = parameter.replace(annotation=annotation)
-
-    return params
 
 
 def wrap_callback(coro):
@@ -410,7 +379,11 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         except AttributeError:
             globalns = {}
 
-        self.params = get_signature_parameters(function, globalns)
+        params = get_signature_parameters(function, globalns)
+        for param in params.values():
+            if param.annotation is Greedy:
+                raise TypeError("Unparameterized Greedy[...] is disallowed in signature.")
+        self.params = params
 
     def add_check(self, func: Check) -> None:
         """Adds a check to the command.

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -759,7 +759,9 @@ class ParamInfo:
         if isinstance(converter, (types.FunctionType, types.MethodType)):
             converter_func = converter
         else:
-            # if converter isn't a function/method, it should be a callable object/type
+            # if converter isn't a function/method, assume it's a callable object/type
+            # (we need `__call__` here to get the correct global namespace later, since
+            # classes do not have `__globals__`)
             converter_func = converter.__call__
         _, parameters = isolate_self(get_signature_parameters(converter_func))
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -10,6 +10,7 @@ import inspect
 import itertools
 import math
 import sys
+import types
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
@@ -755,7 +756,12 @@ class ParamInfo:
         return True
 
     def parse_converter_annotation(self, converter: Callable, fallback_annotation: Any) -> None:
-        _, parameters = isolate_self(get_signature_parameters(converter))
+        if isinstance(converter, (types.FunctionType, types.MethodType)):
+            converter_func = converter
+        else:
+            # if converter isn't a function/method, it should be a callable object/type
+            converter_func = converter.__call__
+        _, parameters = isolate_self(get_signature_parameters(converter_func))
 
         if len(parameters) != 1:
             raise TypeError(

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1252,6 +1252,21 @@ def get_signature_parameters(
     return params
 
 
+def get_signature_return(function: Callable[..., Any]) -> Any:
+    signature = inspect.signature(function)
+
+    # same as parameters above, but for the return annotation
+    ret = signature.return_annotation
+    if ret is not _inspect_empty:
+        if ret is None:
+            ret = type(None)
+        else:
+            globalns = _get_function_globals(function)
+            ret = evaluate_annotation(ret, globalns, globalns, {})
+
+    return ret
+
+
 TimestampStyle = Literal["f", "F", "d", "D", "t", "T", "R"]
 
 

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -71,7 +71,7 @@ class TestParamInfo:
         def func(a: int) -> None:
             ...
 
-        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        (cog, inter), parameters = params.isolate_self(params.get_signature_parameters(func))
         assert cog is None
         assert inter is None
         assert parameters == ({"a": mock.ANY})
@@ -80,7 +80,7 @@ class TestParamInfo:
         def func(i: disnake.ApplicationCommandInteraction, a: int) -> None:
             ...
 
-        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        (cog, inter), parameters = params.isolate_self(params.get_signature_parameters(func))
         assert cog is None
         assert inter is not None
         assert parameters == ({"a": mock.ANY})
@@ -89,7 +89,7 @@ class TestParamInfo:
         def func(self, i: disnake.ApplicationCommandInteraction, a: int) -> None:
             ...
 
-        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        (cog, inter), parameters = params.isolate_self(params.get_signature_parameters(func))
         assert cog is not None
         assert inter is not None
         assert parameters == ({"a": mock.ANY})
@@ -98,7 +98,7 @@ class TestParamInfo:
         def func(i: disnake.ApplicationCommandInteraction[commands.Bot], a: int) -> None:
             ...
 
-        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        (cog, inter), parameters = params.isolate_self(params.get_signature_parameters(func))
         assert cog is None
         assert inter is not None
         assert parameters == ({"a": mock.ANY})
@@ -109,7 +109,7 @@ class TestParamInfo:
         ) -> None:
             ...
 
-        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        (cog, inter), parameters = params.isolate_self(params.get_signature_parameters(func))
         assert cog is None
         assert inter is not None
         assert parameters == ({"a": mock.ANY})


### PR DESCRIPTION
## Summary

This PR makes slash command signature evaluation use the existing prefix command mechanisms (notably, `utils.evaluate_annotation`), instead of relying on `typing.get_type_hints` which has historically been somewhat [inconsistent](https://docs.python.org/3.11/whatsnew/3.11.html#typing).

There aren't any immediate issues with the previous code; this change is in preparation for Python 3.12 adjustments in the near future. Right now, this *shouldn't* have any effect in practice.
It may look complicated, but it's really just moving around different parts of the code to new locations and dropping `commands.params.signature()` in favour of `utils.get_signature_parameters()`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
