### PR TITLE
ci: start testing with python 3.12

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -131,8 +131,6 @@ jobs:
 
     # run the libcst parsers and check for changes
     - name: libcst codemod
-      env:
-        LIBCST_PARSER_TYPE: "native"
       run: |
         nox -s codemod -- run-all
         if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
@@ -147,7 +147,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         experimental: [false]
       fail-fast: true

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -72,7 +72,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: pdm install -d -Gspeed -Gdocs -Gvoice
+      run: |
+        pdm update --pre aiohttp  # XXX: temporarily install aiohttp prerelease for 3.12
+        pdm install -d -Gspeed -Gdocs -Gvoice
 
     - name: Add .venv/bin to PATH
       run: dirname "$(pdm info --python)" >> $GITHUB_PATH
@@ -167,11 +169,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: pdm install -dG test  # needed for coverage
+      run: |
+        pdm update --pre aiohttp  # XXX: temporarily install aiohttp prerelease for 3.12
+        pdm install -dG test  # needed for coverage
 
     - name: Test package install
       run: |
-        python -m pip install .
+        python -m pip install --pre .  # XXX: temporarily install aiohttp prerelease for 3.12; remove --pre flag again later
 
     - name: Run pytest
       id: run_tests

--- a/changelog/1117.misc.rst
+++ b/changelog/1117.misc.rst
@@ -1,0 +1,1 @@
+Start testing with Python 3.12 in CI.

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,8 +24,6 @@ os.environ.update(
         "PDM_IGNORE_SAVED_PYTHON": "1",
     },
 )
-# support the python parser in case the native parser isn't available
-os.environ.setdefault("LIBCST_PARSER_TYPE", "native")
 
 
 nox.options.error_on_external_run = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -202,7 +202,7 @@ def pyright(session: nox.Session) -> None:
         pass
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 @nox.parametrize(
     "extras",
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ tools = [
 ]
 codemod = [
     # run codemods on the respository (mostly automated typing)
-    "libcst~=0.4.9",
+    "libcst~=1.1.0",
     "black==23.9.1",
     "autotyping==23.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,12 +83,12 @@ codemod = [
 typing = [
     # this is not pyright itself, but the python wrapper
     "pyright==1.1.291",
-    "typing-extensions~=4.5.0",
+    "typing-extensions~=4.8.0",
     # only used for type-checking, version does not matter
     "pytz",
 ]
 test = [
-    "pytest~=7.2.1",
+    "pytest~=7.4.2",
     "pytest-cov~=4.0.0",
     "pytest-asyncio~=0.20.3",
     "looptime~=0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ runner = "pdm run"
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary

Adds 3.12 to the CI version matrix, and updates libcst, pytest, and typing_extensions to the latest versions as they weren't compatible before.
As a temporary workaround, this installs the current aiohttp 3.9.0b0 prerelease, but only in CI; all currently released stable versions don't build on 3.12 yet. 

No code changes specifically for 3.12 in this PR, I'm keeping those separate for another PR.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
