### PR TITLE
fix(commands): resolve unstringified annotation before caching

### DIFF
--- a/changelog/1120.bugfix.rst
+++ b/changelog/1120.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Fix edge case in evaluation of multiple identical annotations with forwardrefs in a single signature.

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1134,13 +1134,14 @@ def evaluate_annotation(
     if implicit_str and isinstance(tp, str):
         if tp in cache:
             return cache[tp]
-        evaluated = (
-            eval(  # noqa: PGH001, S307 # this is how annotations are supposed to be unstringifed
-                tp, globals, locals
-            )
-        )
+
+        # this is how annotations are supposed to be unstringifed
+        evaluated = eval(tp, globals, locals)  # noqa: PGH001, S307
+        # recurse to resolve nested args further
+        evaluated = evaluate_annotation(evaluated, globals, locals, cache)
+
         cache[tp] = evaluated
-        return evaluate_annotation(evaluated, globals, locals, cache)
+        return evaluated
 
     if hasattr(tp, "__args__"):
         implicit_str = True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -758,8 +758,8 @@ def test_normalise_optional_params(params, expected) -> None:
         ("Tuple[dict, List[Literal[42, 99]]]", Tuple[dict, List[Literal[42, 99]]], True),
         # 3.10 union syntax
         pytest.param(
-            "int | Literal[False]",
-            Union[int, Literal[False]],
+            "int | float",
+            Union[int, float],
             True,
             marks=pytest.mark.skipif(sys.version_info < (3, 10), reason="syntax requires py3.10"),
         ),


### PR DESCRIPTION
## Summary

`utils.evaluate_annotation` uses a (per-signature) cache to speed up resolving forwardrefs.
This would previously cache the `eval`'d result *before* continuing to resolve it, meaning subsequent calls with the same stringified annotation return the (incomplete) cached result.

```py
from __future__ import annotations

@bot.command()
async def cachetest(ctx: commands.Context, a: Union['int', 'str'], b: Union['int', 'str']) -> None:
    ...

# In both cases, we resolve the outer forwardref ("Union[...]" -> Union[...]),
# but only resolve the inner ones in the first call:
#
# 'ctx': <Parameter "ctx: disnake.ext.commands.context.Context">
# 'a': <Parameter "a: Union[int, str]">
# 'b': <Parameter "b: Union[ForwardRef('int'), ForwardRef('str')]">
```

The same thing happens with other unique `evaluate_annotation` behaviors, like turning `UnionType`s into `Union`s.

The correct behavior here is to cache *after* we've done all the remaining steps.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
