### PR TITLE
fix(commands): handle interactions in union types correctly

### DIFF
--- a/changelog/1121.feature.rst
+++ b/changelog/1121.feature.rst
@@ -1,0 +1,1 @@
+Make :class:`Interaction` and subtypes accept the bot type as a generic parameter to denote the type returned by the :attr:`~Interaction.bot` and :attr:`~Interaction.client` properties.

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -31,7 +31,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    get_args,
     get_origin,
     get_type_hints,
 )
@@ -114,9 +113,9 @@ def issubclass_(obj: Any, tp: Union[TypeT, Tuple[TypeT, ...]]) -> TypeGuard[Type
         return False
     elif not isinstance(obj, type):
         # Assume we have a type hint
-        if get_origin(obj) in (Union, UnionType, Optional):
-            obj = get_args(obj)
-            return any(isinstance(o, type) and issubclass(o, tp) for o in obj)
+        if get_origin(obj) in (Union, UnionType):
+            # If we have a Union, try matching any of its args
+            return any(issubclass_(o, tp) for o in obj.__args__)
         else:
             # Other type hint specializations are not supported
             return False

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -10,6 +10,7 @@ import pytest
 import disnake
 from disnake import Member, Role, User
 from disnake.ext import commands
+from disnake.ext.commands import params
 
 OptionType = disnake.OptionType
 
@@ -65,6 +66,33 @@ class TestParamInfo:
             arg_mock = mock.Mock(arg_type)
             with pytest.raises(commands.errors.MemberNotFound):
                 await info.verify_type(mock.Mock(), arg_mock)
+
+    def test_isolate_self(self) -> None:
+        def func(a: int) -> None:
+            ...
+
+        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        assert cog is None
+        assert inter is None
+        assert parameters == ({"a": mock.ANY})
+
+    def test_isolate_self_inter(self) -> None:
+        def func(i: disnake.ApplicationCommandInteraction, a: int) -> None:
+            ...
+
+        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        assert cog is None
+        assert inter is not None
+        assert parameters == ({"a": mock.ANY})
+
+    def test_isolate_self_cog_inter(self) -> None:
+        def func(self, i: disnake.ApplicationCommandInteraction, a: int) -> None:
+            ...
+
+        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        assert cog is not None
+        assert inter is not None
+        assert parameters == ({"a": mock.ANY})
 
 
 # this uses `Range` for testing `_BaseRange`, `String` should work equally
@@ -189,7 +217,6 @@ class TestRangeStringParam:
         assert info.max_value is None
         assert info.type == annotation.underlying_type
 
-    # uses lambdas since new union syntax isn't supported on all versions
     @pytest.mark.parametrize(
         "annotation_str",
         [

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -103,6 +103,17 @@ class TestParamInfo:
         assert inter is not None
         assert parameters == ({"a": mock.ANY})
 
+    def test_isolate_self_union(self) -> None:
+        def func(
+            i: Union[commands.Context, disnake.ApplicationCommandInteraction[commands.Bot]], a: int
+        ) -> None:
+            ...
+
+        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        assert cog is None
+        assert inter is not None
+        assert parameters == ({"a": mock.ANY})
+
 
 # this uses `Range` for testing `_BaseRange`, `String` should work equally
 class TestBaseRange:

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -94,6 +94,15 @@ class TestParamInfo:
         assert inter is not None
         assert parameters == ({"a": mock.ANY})
 
+    def test_isolate_self_generic(self) -> None:
+        def func(i: disnake.ApplicationCommandInteraction[commands.Bot], a: int) -> None:
+            ...
+
+        (cog, inter), parameters = params.isolate_self(params.signature(func))
+        assert cog is None
+        assert inter is not None
+        assert parameters == ({"a": mock.ANY})
+
 
 # this uses `Range` for testing `_BaseRange`, `String` should work equally
 class TestBaseRange:


### PR DESCRIPTION
## Summary

Changes the lenient `issubclass_` we're using for parts of slash parsing to also support `issubclass_(X[T], X)`, instead of using `issubclass_(get_origin(...), ...)`.
This fixes cases where the interaction annotation is a `Union`, which worked fine before #1037 where I missed this in review.

### Code
```py
@bot.slash_command()
async def test(inter: Union[disnake.ApplicationCommandInteraction, commands.Context]) -> None:
    ...

#   File "disnake/ext/commands/params.py", line 766, in parse_annotation
#     raise TypeError(
# TypeError: Unions for anything else other than channels or a mentionable are not supported
```

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
