### PR TITLE
fix(threads): move runtime import required for `Thread.permissions_for`

### DIFF
--- a/changelog/1123.bugfix.rst
+++ b/changelog/1123.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :meth:`Thread.permissions_for` not working in some cases due to an incorrect import.

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -12,6 +12,7 @@ from .errors import ClientException
 from .flags import ChannelFlags
 from .mixins import Hashable
 from .partial_emoji import PartialEmoji, _EmojiTag
+from .permissions import Permissions
 from .utils import MISSING, _get_as_snowflake, _unique, parse_time, snowflake_time
 
 __all__ = (
@@ -31,7 +32,6 @@ if TYPE_CHECKING:
     from .guild import Guild
     from .member import Member
     from .message import Message, PartialMessage
-    from .permissions import Permissions
     from .role import Role
     from .state import ConnectionState
     from .types.snowflake import SnowflakeList


### PR DESCRIPTION
## Summary

Fixes #1123.

In the future, we should look into enabling https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch to catch these earlier. Historically those rules have been rather buggy, but they might be more mature now.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
