### PR TITLE
feat(lint): enable ruff `TCH` (flake8-type-checking) rules

### DIFF
--- a/disnake/ext/commands/common_bot_base.py
+++ b/disnake/ext/commands/common_bot_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import collections.abc
+import importlib.machinery
 import importlib.util
 import logging
 import os
@@ -19,8 +20,6 @@ from . import errors
 from .cog import Cog
 
 if TYPE_CHECKING:
-    import importlib.machinery
-
     from ._types import CoroFunc
     from .bot import AutoShardedBot, AutoShardedInteractionBot, Bot, InteractionBot
     from .help import HelpCommand

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -14,11 +14,12 @@ from sphinx.locale import _
 from sphinx.util.docutils import SphinxDirective
 
 if TYPE_CHECKING:
-    from _types import SphinxExtensionMeta
     from sphinx.application import Sphinx
     from sphinx.environment import BuildEnvironment
     from sphinx.util.typing import OptionSpec
     from sphinx.writers.html import HTMLTranslator
+
+    from ._types import SphinxExtensionMeta
 
 
 class attributetable(nodes.General, nodes.Element):

--- a/docs/extensions/builder.py
+++ b/docs/extensions/builder.py
@@ -8,11 +8,12 @@ from typing import TYPE_CHECKING, Any
 from sphinx.environment.adapters.indexentries import IndexEntries
 
 if TYPE_CHECKING:
-    from _types import SphinxExtensionMeta
     from docutils import nodes
     from sphinx.application import Sphinx
     from sphinx.config import Config
     from sphinx.writers.html5 import HTML5Translator
+
+    from ._types import SphinxExtensionMeta
 
 if TYPE_CHECKING:
     translator_base = HTML5Translator

--- a/docs/extensions/exception_hierarchy.py
+++ b/docs/extensions/exception_hierarchy.py
@@ -7,9 +7,10 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 
 if TYPE_CHECKING:
-    from _types import SphinxExtensionMeta
     from sphinx.application import Sphinx
     from sphinx.writers.html import HTMLTranslator
+
+    from ._types import SphinxExtensionMeta
 
 
 class exception_hierarchy(nodes.General, nodes.Element):

--- a/docs/extensions/fulltoc.py
+++ b/docs/extensions/fulltoc.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, cast
 
-from _types import SphinxExtensionMeta
 from docutils import nodes
 from sphinx import addnodes
 
@@ -39,6 +38,8 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from sphinx.builders.html import StandaloneHTMLBuilder
     from sphinx.environment import BuildEnvironment
+
+    from ._types import SphinxExtensionMeta
 
 # {prefix: index_doc} mapping
 # Any document that matches `prefix` will use `index_doc`'s toctree instead.

--- a/docs/extensions/nitpick_file_ignorer.py
+++ b/docs/extensions/nitpick_file_ignorer.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING
 from sphinx.util import logging as sphinx_logging
 
 if TYPE_CHECKING:
-    from _types import SphinxExtensionMeta
     from sphinx.application import Sphinx
+
+    from ._types import SphinxExtensionMeta
 
 
 class NitpickFileIgnorer(logging.Filter):

--- a/docs/extensions/redirects.py
+++ b/docs/extensions/redirects.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict
+from typing import TYPE_CHECKING, Dict
 
-from _types import SphinxExtensionMeta
 from sphinx.application import Sphinx
 from sphinx.util.fileutil import copy_asset_file
+
+if TYPE_CHECKING:
+    from ._types import SphinxExtensionMeta
 
 SCRIPT_PATH = "_templates/api_redirect.js_t"
 

--- a/docs/extensions/resourcelinks.py
+++ b/docs/extensions/resourcelinks.py
@@ -10,11 +10,12 @@ from docutils import nodes, utils
 from sphinx.util.nodes import split_explicit_title
 
 if TYPE_CHECKING:
-    from _types import SphinxExtensionMeta
     from docutils.nodes import Node, system_message
     from docutils.parsers.rst.states import Inliner
     from sphinx.application import Sphinx
     from sphinx.util.typing import RoleFunction
+
+    from ._types import SphinxExtensionMeta
 
 
 def make_link_role(resource_links: Dict[str, str]) -> RoleFunction:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ select = [
     # "RET", # flake8-return
     # "SIM", # flake8-simplify
     "TID251", # flake8-tidy-imports, replaces S404
-    # "TCH", # flake8-type-checking
+    "TCH",    # flake8-type-checking
     "RUF",    # ruff specific exceptions
     "PT",     # flake8-pytest-style
     "Q",      # flake8-quotes
@@ -197,6 +197,13 @@ ignore = [
 
     # outer loop variables are overwritten by inner assignment target, these are mostly intentional
     "PLW2901",
+
+    # ignore imports that could be moved into type-checking blocks
+    # (no real advantage other than possibly avoiding cycles,
+    # but can be dangerous in places where we need to parse signatures)
+    "TCH001",
+    "TCH002",
+    "TCH003",
 
     # temporary disables, to fix later
     "D205",   # blank line required between summary and description

--- a/tests/ext/commands/test_core.py
+++ b/tests/ext/commands/test_core.py
@@ -1,19 +1,9 @@
 # SPDX-License-Identifier: MIT
 
-from typing import TYPE_CHECKING
+from typing_extensions import assert_type
 
 from disnake.ext import commands
 from tests.helpers import reveal_type
-
-if TYPE_CHECKING:
-    from typing_extensions import assert_type
-
-    # NOTE: using undocumented `expected_text` parameter of pyright instead of `assert_type`,
-    # as `assert_type` can't handle bound ParamSpecs
-    reveal_type(
-        42,  # type: ignore
-        expected_text="str",  # type: ignore
-    )
 
 
 class CustomContext(commands.Context):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,6 +16,15 @@ else:
         raise RuntimeError
 
 
+if TYPE_CHECKING:
+    # NOTE: using undocumented `expected_text` parameter of pyright instead of `assert_type`,
+    # as `assert_type` can't handle bound ParamSpecs
+    reveal_type(
+        42,  # type: ignore  # suppress "revealed type is ..." output
+        expected_text="str",  # type: ignore  # ensure the functionality we want still works as expected
+    )
+
+
 CallableT = TypeVar("CallableT", bound=Callable)
 
 

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -4,16 +4,19 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
+from typing_extensions import assert_type
 
 import disnake
-from disnake.ui import ActionRow, Button, StringSelect, TextInput, WrappedComponent
+from disnake.ui import (
+    ActionRow,
+    Button,
+    MessageUIComponent,
+    ModalUIComponent,
+    StringSelect,
+    TextInput,
+    WrappedComponent,
+)
 from disnake.ui.action_row import components_to_dict, components_to_rows
-
-if TYPE_CHECKING:
-    from typing_extensions import assert_type
-
-    from disnake.ui import MessageUIComponent, ModalUIComponent
-
 
 button1 = Button()
 button2 = Button()
@@ -133,9 +136,8 @@ class TestActionRow:
         row_msg = ActionRow.with_message_components()
         assert list(row_msg.children) == []
 
-        if TYPE_CHECKING:
-            assert_type(row_modal, ActionRow[ModalUIComponent])
-            assert_type(row_msg, ActionRow[MessageUIComponent])
+        assert_type(row_modal, ActionRow[ModalUIComponent])
+        assert_type(row_msg, ActionRow[MessageUIComponent])
 
     def test_rows_from_message(self) -> None:
         rows = [


### PR DESCRIPTION
## Summary

Enables ruff's `TCH` rules ([flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch)) -- see #1124.

`TCH001`-`TCH003` are left disabled for now, since those are not trivial to take care of in some places. The important one in our case is `TCH004` anyway.

The code changes in this PR are to satisfy the new rules, they weren't actual issues (unlike #1124). As mentioned, `TCH004` isn't perfect and has a couple edge cases, particularly when it comes to submodule imports.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
