### PR TITLE
docs: make `Supported Operations` container collapsible

### DIFF
--- a/changelog/1126.doc.rst
+++ b/changelog/1126.doc.rst
@@ -1,0 +1,1 @@
+Make all "Supported Operations" container elements collapsible.

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -404,7 +404,7 @@ class Game(BaseActivity):
 
     This is typically displayed via **Playing** on the official Discord client.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -487,7 +487,7 @@ class Streaming(BaseActivity):
 
     This is typically displayed via **Streaming** on the official Discord client.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -597,7 +597,7 @@ class Streaming(BaseActivity):
 class Spotify(_BaseActivity):
     """Represents a Spotify listening activity from Discord.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -770,7 +770,7 @@ class Spotify(_BaseActivity):
 class CustomActivity(BaseActivity):
     """Represents a Custom activity from Discord.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -164,7 +164,7 @@ class AssetMixin:
 class Asset(AssetMixin):
     """Represents a CDN asset on Discord.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: str(x)
 

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -517,7 +517,7 @@ class AuditLogEntry(Hashable):
     You can retrieve these via :meth:`Guild.audit_logs`,
     or via the :func:`on_audit_log_entry_create` event.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -103,7 +103,7 @@ async def _single_delete_strategy(messages: Iterable[Message]) -> None:
 class TextChannel(disnake.abc.Messageable, disnake.abc.GuildChannel, Hashable):
     """Represents a Discord guild text channel.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1217,7 +1217,7 @@ class VocalGuildChannel(disnake.abc.Connectable, disnake.abc.GuildChannel, Hasha
 class VoiceChannel(disnake.abc.Messageable, VocalGuildChannel):
     """Represents a Discord guild voice channel.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1871,7 +1871,7 @@ class StageChannel(disnake.abc.Messageable, VocalGuildChannel):
 
     .. versionadded:: 1.7
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -2696,7 +2696,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
 
     These are useful to group channels to logical compartments.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -3145,7 +3145,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
 
     .. versionadded:: 2.5
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -4184,7 +4184,7 @@ class ForumChannel(disnake.abc.GuildChannel, Hashable):
 class DMChannel(disnake.abc.Messageable, Hashable):
     """Represents a Discord direct message channel.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -4347,7 +4347,7 @@ class DMChannel(disnake.abc.Messageable, Hashable):
 class GroupChannel(disnake.abc.Messageable, Hashable):
     """Represents a Discord group channel.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -4506,7 +4506,7 @@ class PartialMessageable(disnake.abc.Messageable, Hashable):
 
     .. versionadded:: 2.0
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/colour.py
+++ b/disnake/colour.py
@@ -22,7 +22,7 @@ class Colour:
 
     There is an alias for this called Color.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -112,7 +112,7 @@ if TYPE_CHECKING:
 class Embed:
     """Represents a Discord embed.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/emoji.py
+++ b/disnake/emoji.py
@@ -28,7 +28,7 @@ class Emoji(_EmojiTag, AssetMixin):
     Depending on the way this object was created, some of the attributes can
     have a value of ``None``.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/ext/commands/flag_converter.py
+++ b/disnake/ext/commands/flag_converter.py
@@ -435,7 +435,7 @@ class FlagConverter(metaclass=FlagsMeta):
     how this converter works, check the appropriate
     :ref:`documentation <ext_commands_flag_converter>`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: iter(x)
 

--- a/disnake/ext/commands/flags.py
+++ b/disnake/ext/commands/flags.py
@@ -25,7 +25,7 @@ class CommandSyncFlags(BaseFlags):
 
     .. versionadded:: 2.7
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/ext/commands/help.py
+++ b/disnake/ext/commands/help.py
@@ -48,7 +48,7 @@ __all__ = (
 class Paginator:
     """A class that aids in paginating code blocks for Discord messages.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: len(x)
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -329,7 +329,7 @@ class SystemChannelFlags(BaseFlags, inverted=True):
     to enable or disable.
     Arguments are applied in order, similar to :class:`Permissions`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -491,7 +491,7 @@ class MessageFlags(BaseFlags):
 
     See :class:`SystemChannelFlags`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -681,7 +681,7 @@ class MessageFlags(BaseFlags):
 class PublicUserFlags(BaseFlags):
     """Wraps up the Discord User Public flags.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -930,7 +930,7 @@ class Intents(BaseFlags):
 
     .. versionadded:: 1.5
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1617,7 +1617,7 @@ class MemberCacheFlags(BaseFlags):
 
     .. versionadded:: 1.5
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1793,7 +1793,7 @@ class MemberCacheFlags(BaseFlags):
 class ApplicationFlags(BaseFlags):
     """Wraps up the Discord Application flags.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1968,7 +1968,7 @@ class ApplicationFlags(BaseFlags):
 class ChannelFlags(BaseFlags):
     """Wraps up the Discord Channel flags.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -2081,7 +2081,7 @@ class ChannelFlags(BaseFlags):
 class AutoModKeywordPresets(ListBaseFlags):
     """Wraps up the pre-defined auto moderation keyword lists, provided by Discord.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -2194,7 +2194,7 @@ class AutoModKeywordPresets(ListBaseFlags):
 class MemberFlags(BaseFlags):
     """Wraps up Discord Member flags.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -2296,7 +2296,7 @@ class MemberFlags(BaseFlags):
 class RoleFlags(BaseFlags):
     """Wraps up Discord Role flags.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -2376,7 +2376,7 @@ class RoleFlags(BaseFlags):
 class AttachmentFlags(BaseFlags):
     """Wraps up Discord Attachment flags.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -130,7 +130,7 @@ class Guild(Hashable):
 
     This is referred to as a "server" in the official Discord UI.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -77,7 +77,7 @@ class GuildScheduledEvent(Hashable):
 
     .. versionadded:: 2.3
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/invite.py
+++ b/disnake/invite.py
@@ -48,7 +48,7 @@ class PartialInviteChannel:
     guild the :class:`Invite` resolves to.
 
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -137,7 +137,7 @@ class PartialInviteGuild:
     This model will be given when the user is not part of the
     guild the :class:`Invite` resolves to.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -256,7 +256,7 @@ class Invite(Hashable):
     Depending on the way this object was created, some of the attributes can
     have a value of ``None`` (see table below).
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -212,7 +212,7 @@ class Member(disnake.abc.Messageable, _UserTag):
 
     This implements a lot of the functionality of :class:`User`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -220,7 +220,7 @@ async def _edit_handler(
 class Attachment(Hashable):
     """Represents an attachment from Discord.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: str(x)
 
@@ -766,7 +766,7 @@ def flatten_handlers(cls):
 class Message(Hashable):
     """Represents a message from Discord.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -2177,7 +2177,7 @@ class PartialMessage(Hashable):
 
     .. versionadded:: 1.6
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/object.py
+++ b/disnake/object.py
@@ -29,7 +29,7 @@ class Object(Hashable):
     receive this class rather than the actual data class. These cases are
     extremely rare.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/partial_emoji.py
+++ b/disnake/partial_emoji.py
@@ -38,7 +38,7 @@ class PartialEmoji(_EmojiTag, AssetMixin):
     - "Raw" data events such as :func:`on_raw_reaction_add`
     - Custom emoji that the bot cannot see from e.g. :attr:`Message.reactions`
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -76,7 +76,7 @@ class Permissions(BaseFlags):
         You can now use keyword arguments to initialize :class:`Permissions`
         similar to :meth:`update`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1036,7 +1036,7 @@ class PermissionOverwrite:
     The values supported by this are the same as :class:`Permissions`
     with the added possibility of it being set to ``None``.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/reaction.py
+++ b/disnake/reaction.py
@@ -22,7 +22,7 @@ class Reaction:
     Depending on the way this object was created, some of the attributes can
     have a value of ``None``.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/role.py
+++ b/disnake/role.py
@@ -140,7 +140,7 @@ class RoleTags:
 class Role(Hashable):
     """Represents a Discord role in a :class:`Guild`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/stage_instance.py
+++ b/disnake/stage_instance.py
@@ -24,7 +24,7 @@ class StageInstance(Hashable):
 
     .. versionadded:: 2.0
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -44,7 +44,7 @@ class StickerPack(Hashable):
     .. versionchanged:: 2.8
         :attr:`cover_sticker_id`, :attr:`cover_sticker` and :attr:`banner` are now optional.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: str(x)
 
@@ -163,7 +163,7 @@ class StickerItem(_StickerTag):
 
     .. versionadded:: 2.0
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: str(x)
 
@@ -226,7 +226,7 @@ class Sticker(_StickerTag):
 
     .. versionadded:: 1.6
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: str(x)
 
@@ -283,7 +283,7 @@ class StandardSticker(Sticker):
 
     .. versionadded:: 2.0
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: str(x)
 
@@ -362,7 +362,7 @@ class GuildSticker(Sticker):
 
     .. versionadded:: 2.0
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: str(x)
 

--- a/disnake/team.py
+++ b/disnake/team.py
@@ -77,7 +77,7 @@ class Team:
 class TeamMember(BaseUser):
     """Represents a team member in a team.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/threads.py
+++ b/disnake/threads.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 class Thread(Messageable, Hashable):
     """Represents a Discord thread.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1018,7 +1018,7 @@ class Thread(Messageable, Hashable):
 class ThreadMember(Hashable):
     """Represents a Discord thread member.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -1092,7 +1092,7 @@ class ThreadMember(Hashable):
 class ForumTag(Hashable):
     """Represents a tag for threads in forum channels.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -91,7 +91,7 @@ TextInputCompatibleActionRowT = TypeVar(
 class ActionRow(Generic[UIComponentT]):
     """Represents a UI action row. Useful for lower level component manipulation.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x[i]
 

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -281,7 +281,7 @@ class BaseUser(_UserTag):
 class ClientUser(BaseUser):
     """Represents your Discord user.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -419,7 +419,7 @@ class ClientUser(BaseUser):
 class User(BaseUser, disnake.abc.Messageable):
     """Represents a Discord user.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/voice_region.py
+++ b/disnake/voice_region.py
@@ -14,7 +14,7 @@ __all__ = ("VoiceRegion",)
 class VoiceRegion:
     """Represents a Discord voice region.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -1034,7 +1034,7 @@ class Webhook(BaseWebhook):
 
     For a synchronous counterpart, see :class:`SyncWebhook`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -510,7 +510,7 @@ class SyncWebhook(BaseWebhook):
 
     For an asynchronous counterpart, see :class:`Webhook`.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/widget.py
+++ b/disnake/widget.py
@@ -34,7 +34,7 @@ __all__ = (
 class WidgetChannel:
     """Represents a "partial" widget channel.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -89,7 +89,7 @@ class WidgetChannel:
 class WidgetMember(BaseUser):
     """Represents a "partial" member of the widget's guild.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -262,7 +262,7 @@ class WidgetSettings:
 class Widget:
     """Represents a :class:`Guild` widget.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1313,21 +1313,20 @@ rect.highlighted {
     fill: var(--highlighted-text);
 }
 
-.container.operations {
+details.operations {
   padding: 10px;
   border: 1px solid var(--codeblock-border);
   margin-bottom: 20px;
 }
 
-.container.operations::before {
-  content: 'Supported Operations';
-  color: var(--main-big-headers-text);
-  display: block;
-  padding-bottom: 0.5em;
+details.operations dl {
+  margin-top: 15px;
+  margin-bottom: 15px;
 }
 
-.container.operations > dl.describe > dt {
-  background-color: var(--api-entry-background);
+details.operations > summary::after {
+  content: 'Supported Operations';
+  color: var(--main-big-headers-text);
 }
 
 .table-wrapper {

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -93,7 +93,7 @@ AuditLogDiff
     on the action being done, check the documentation for :class:`AuditLogAction`,
     otherwise check the documentation below for all attributes that are possible.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: iter(diff)
 

--- a/docs/api/guilds.rst
+++ b/docs/api/guilds.rst
@@ -131,7 +131,7 @@ VerificationLevel
     Specifies a :class:`Guild`\'s verification level, which is the criteria in
     which a member must meet before being able to send messages to the guild.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. versionadded:: 2.0
 
@@ -180,9 +180,7 @@ NotificationLevel
 
     Specifies whether a :class:`Guild` has notifications on for all messages or mentions only by default.
 
-    .. container:: operations
-
-        .. versionadded:: 2.0
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -219,9 +217,7 @@ ContentFilter
     learning algorithms that Discord uses to detect if an image contains
     NSFW content.
 
-    .. container:: operations
-
-        .. versionadded:: 2.0
+    .. collapse:: operations
 
         .. describe:: x == y
 
@@ -261,7 +257,7 @@ NSFWLevel
 
     .. versionadded:: 2.0
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/docs/api/messages.rst
+++ b/docs/api/messages.rst
@@ -188,14 +188,14 @@ MessageType
     Specifies the type of :class:`Message`. This is used to denote if a message
     is to be interpreted as a system message or a regular message.
 
-    .. container:: operations
+    .. collapse:: operations
 
-      .. describe:: x == y
+        .. describe:: x == y
 
-          Checks if two messages are equal.
-      .. describe:: x != y
+            Checks if two messages are equal.
+        .. describe:: x != y
 
-          Checks if two messages are not equal.
+            Checks if two messages are not equal.
 
     .. attribute:: default
 

--- a/docs/api/misc.rst
+++ b/docs/api/misc.rst
@@ -18,7 +18,7 @@ AsyncIterator
     Represents the "AsyncIterator" concept. Note that no such class exists,
     it is purely abstract.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: async for x in y
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "exception_hierarchy",
     "attributetable",
     "resourcelinks",
+    "collapse",
     "nitpick_file_ignorer",
 ]
 

--- a/docs/extensions/collapse.py
+++ b/docs/extensions/collapse.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+    from sphinx.util.typing import OptionSpec
+    from sphinx.writers.html import HTMLTranslator
+
+    from ._types import SphinxExtensionMeta
+
+
+class collapse(nodes.General, nodes.Element):
+    pass
+
+
+def visit_collapse_node(self: HTMLTranslator, node: nodes.Element) -> None:
+    attrs = {"open": ""} if node["open"] else {}
+    self.body.append(self.starttag(node, "details", **attrs))
+    self.body.append("<summary></summary>")
+
+
+def depart_collapse_node(self: HTMLTranslator, node: nodes.Element) -> None:
+    self.body.append("</details>\n")
+
+
+class CollapseDirective(Directive):
+    has_content = True
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+
+    option_spec: ClassVar[OptionSpec] = {"open": directives.flag}
+
+    def run(self):
+        self.assert_has_content()
+        node = collapse(
+            "\n".join(self.content),
+            open="open" in self.options,
+        )
+
+        classes = directives.class_option(self.arguments[0] if self.arguments else "")
+        node["classes"].extend(classes)
+
+        self.state.nested_parse(self.content, self.content_offset, node)
+        return [node]
+
+
+def setup(app: Sphinx) -> SphinxExtensionMeta:
+    app.add_node(collapse, html=(visit_collapse_node, depart_collapse_node))
+    app.add_directive("collapse", CollapseDirective)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
## Summary

Makes the "Supported Operations" container element in the documentation collapsible ([example](https://disnake--1126.org.readthedocs.build/en/1126/api/users.html#memberflags)), and collapses it by default to reduce clutter (especially in flag classes, which have about a dozen operations each).

old vs. new:
![waow](https://github.com/DisnakeDev/disnake/assets/8530778/4930d63c-7d72-4595-9c02-3e8a0384ff21)

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
