### PR TITLE
Fix of Another blind spot of command sync algorithm #1108

### DIFF
--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -830,9 +830,13 @@ class InteractionBotBase(CommonBotBase):
         # Same process but for each specified guild individually.
         # Notice that we're not doing this for every single guild for optimisation purposes.
         # See the note in :meth:`_cache_application_commands` about guild app commands.
+        guild_ids_to_check = set(guild_cmds.keys())
+        for guild_id in self._connection._guild_application_commands.keys():
+            guild_ids_to_check.add(guild_id)
         if self._command_sync_flags.sync_guild_commands:
-            for guild_id, cmds in guild_cmds.items():
+            for guild_id in guild_ids_to_check:
                 current_guild_cmds = self._connection._guild_application_commands.get(guild_id, {})
+                cmds = guild_cmds.get(guild_id, {})
                 diff = _app_commands_diff(cmds, current_guild_cmds.values())
                 if not self._command_sync_flags.allow_command_deletion:
                     # because allow_command_deletion is disabled, we want to never automatically delete a command


### PR DESCRIPTION
## Summary
Fix of Another blind spot of command sync algorithm #1108

## Checklist

- [ x] If code changes were made, then they have been tested
    - [ x] I have updated the documentation to reflect the changes
    - [ x] I have formatted the code properly by running `pdm lint`
    - [ x] I have type-checked the code by running `pdm pyright`
- [x ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
We need to check ids from both guild_cmds and self._connection._guild_application_commands.keys(), otherwise on deletion, we cant find any ids in local commands, and cycle doesnt procceed any values 