### PR TITLE
docs: add v2.9.1 changelog to latest docs

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,6 +17,22 @@ in specific versions. Please see :ref:`version_guarantees` for more information.
 
 .. towncrier release notes start
 
+.. _vp2p9p1:
+
+v2.9.1
+------
+
+Bug Fixes
+~~~~~~~~~
+- Allow ``cls`` argument in select menu decorators (e.g. :func:`ui.string_select`) to be specified by keyword instead of being positional-only. (:issue:`1111`)
+- |commands| Fix edge case in evaluation of multiple identical annotations with forwardrefs in a single signature. (:issue:`1120`)
+- Fix :meth:`Thread.permissions_for` not working in some cases due to an incorrect import. (:issue:`1123`)
+
+Documentation
+~~~~~~~~~~~~~
+- Miscellaneous grammar/typo fixes for :doc:`api/audit_logs`. (:issue:`1105`)
+
+
 .. _vp2p9p0:
 
 v2.9.0


### PR DESCRIPTION
## Summary

i forgor.
This is a copy of the changelog from stable docs to latest docs - one of the few parts of the release process that aren't automated yet, and probably won't be in the near future.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
