### PR TITLE
fix: avoid incorrect warning about broken localizations in cogs

### DIFF
--- a/changelog/1133.bugfix.rst
+++ b/changelog/1133.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Fix erroneous :class:`LocalizationWarning`\s when using localized slash command parameters in cogs.

--- a/disnake/i18n.py
+++ b/disnake/i18n.py
@@ -245,6 +245,10 @@ class LocalizationValue:
         return self._data
 
     def __eq__(self, other) -> bool:
+        # if both are pending, compare keys instead
+        if self._data is MISSING and other._data is MISSING:
+            return self._key == other._key
+
         d1 = self.data
         d2 = other.data
         # consider values equal if they're both falsy, or actually equal

--- a/disnake/i18n.py
+++ b/disnake/i18n.py
@@ -236,8 +236,9 @@ class LocalizationValue:
     def data(self) -> Optional[Dict[str, str]]:
         """Optional[Dict[:class:`str`, :class:`str`]]: A dict with a locale -> localization mapping, if available."""
         if self._data is MISSING:
+            # This will happen when `_link(store)` hasn't been called yet, which *shouldn't* occur under normal circumstances.
             warnings.warn(
-                f"value ('{self._key}') was never localized, this is likely a library bug",
+                f"Localization value ('{self._key}') was never linked to bot; this may be a library bug.",
                 LocalizationWarning,
                 stacklevel=2,
             )

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -92,7 +92,7 @@ def test_localization_copy() -> None:
             self,
             inter,
             param: int = commands.Param(name=disnake.Localized("param", key="PARAM")),
-        ):
+        ) -> None:
             ...
 
     # Ensure the command copy that happens on cog init doesn't raise a LocalizationWarning for the options.

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -95,7 +95,7 @@ def test_localization_copy() -> None:
         ):
             ...
 
-    # this should not raise a warning about missing localizations
+    # Ensure the command copy that happens on cog init doesn't raise a LocalizationWarning for the options.
     cog = Cog()
 
     with pytest.warns(disnake.LocalizationWarning):

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import disnake
 from disnake import Permissions
 from disnake.ext import commands
 
@@ -82,3 +83,20 @@ class TestDefaultPermissions:
 
         assert Cog.overwrite_decorator_below.default_member_permissions == Permissions(64)
         assert Cog().overwrite_decorator_below.default_member_permissions == Permissions(64)
+
+
+def test_localization_copy() -> None:
+    class Cog(commands.Cog):
+        @commands.slash_command()
+        async def cmd(
+            self,
+            inter,
+            param: int = commands.Param(name=disnake.Localized("param", key="PARAM")),
+        ):
+            ...
+
+    # this should not raise a warning about missing localizations
+    cog = Cog()
+
+    with pytest.warns(disnake.LocalizationWarning):
+        assert cog.get_slash_commands()[0].options[0].name_localizations.data is None


### PR DESCRIPTION
## Summary

Cogs copy all command objects at instantiation (for applying cog-wide parameters), which ends up calling `Option.name_localizations.__eq__` further down the line; at that point, `LocalizationValue`s haven't been linked yet, which results in warnings being thrown incorrectly.
This PR fixes the comparison to bypass the property that's responsible for the warning in this particular case.
(at this point, localization probably deserves a full refactor, but that's a topic for another day)

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
