### PR TITLE
ci: skip unnecessary release workflow run

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -127,8 +127,11 @@ jobs:
     - name: Try building package
       run: |
         pdm install -dG build
+
         pdm run python -m build
         ls -la dist/
+
+        pdm run twine check --strict dist/*
 
     # run the libcst parsers and check for changes
     - name: libcst codemod

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: MIT
 
-name: Build (+ Release)
+name: Release
 
-# test build for commit/tag, but only upload release for tags
 on:
   push:
-    branches:
-      - "master"
-      - 'v[0-9]+.[0-9]+.x'  # matches to backport branches, e.g. v3.6.x
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
@@ -15,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  # Builds sdist and wheel, runs `twine check`, and optionally uploads artifacts.
+  # Builds sdist and wheel, runs `twine check`, and uploads artifacts.
   build:
     name: Build package
     runs-on: ubuntu-latest
@@ -50,8 +46,6 @@ jobs:
           echo -e "\n</details>\n" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload artifact
-        # only upload artifacts when necessary
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -59,13 +53,10 @@ jobs:
           if-no-files-found: error
 
 
-  ### Anything below this only runs for tags ###
-
   # Ensures that git tag and built version match.
   validate-tag:
     name: Validate tag
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
     env:
@@ -109,7 +100,6 @@ jobs:
   release-github:
     name: Create GitHub draft release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
       - validate-tag
@@ -150,7 +140,6 @@ jobs:
       name: release-pypi
       url: https://pypi.org/project/disnake/
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
       - validate-tag
@@ -174,7 +163,7 @@ jobs:
   create-dev-version-pr:
     name: Create dev version bump PR
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.validate-tag.outputs.bump_dev
+    if: needs.validate-tag.outputs.bump_dev
     needs:
       - validate-tag
       - release-github


### PR DESCRIPTION
## Summary

Followup to #1072.
The `Build + Release` workflow currently runs on all master/version branch commits, skipping all jobs apart from building the package (i.e. the first one).
Since the `Lint + Test` workflow also already goes through the same steps and ensures the package builds correctly, we don't need to do all that twice.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
