### PR TITLE
fix(shard): handle `RECONNECT` opcode during initial connection flow

### DIFF
--- a/changelog/1155.bugfix.rst
+++ b/changelog/1155.bugfix.rst
@@ -1,0 +1,1 @@
+Handle unexpected ``RECONNECT`` opcode where ``HELLO`` is expected during initial shard connection.


### PR DESCRIPTION
## Summary

The first op we receive when connecting should never be anything other than `HELLO`, but apparently Discord thinks otherwise.
Instead of crashing completely, we now just attempt to perform the requested reconnect.

ref: https://canary.discord.com/channels/808030843078836254/1198023852601659412

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
