### PR TITLE
docs: update supported image formats for bot avatars

### DIFF
--- a/disnake/user.py
+++ b/disnake/user.py
@@ -365,13 +365,6 @@ class ClientUser(BaseUser):
 
         Edits the current profile of the client.
 
-        .. note::
-
-            To upload an avatar, a resource (see below) or a :term:`py:bytes-like object`
-            must be passed in that represents the image being uploaded.
-
-            The only image formats supported for uploading are JPG and PNG.
-
         .. versionchanged:: 2.0
             The edit is no longer in-place, instead the newly edited client user is returned.
 
@@ -385,6 +378,8 @@ class ClientUser(BaseUser):
         avatar: Optional[|resource_type|]
             A :term:`py:bytes-like object` or asset representing the image to upload.
             Could be ``None`` to denote no avatar.
+
+            Only JPG, PNG, WEBP (static), and GIF (static/animated) images are supported.
 
             .. versionchanged:: 2.5
                 Now accepts various resource types in addition to :class:`bytes`.


### PR DESCRIPTION
## Summary

bots can have animated avatars now: https://canary.discord.com/channels/613425648685547541/697138785317814292/1204520610110115852

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
