### PR TITLE
fix(gateway): reconnect on protocol errors

### DIFF
--- a/changelog/1159.bugfix.rst
+++ b/changelog/1159.bugfix.rst
@@ -1,0 +1,1 @@
+Reconnect gateway websocket on protocol errors.

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -706,7 +706,8 @@ class DiscordWebSocket:
                 await self.received_message(msg.data)
             elif msg.type is aiohttp.WSMsgType.ERROR:
                 _log.debug("Received %s", msg)
-                raise msg.data
+                # This is usually just an intermittent gateway hiccup, so try to reconnect again and resume
+                raise WebSocketClosure from msg.data
             elif msg.type in (
                 aiohttp.WSMsgType.CLOSED,
                 aiohttp.WSMsgType.CLOSING,


### PR DESCRIPTION
## Summary

see [this thread](https://canary.discord.com/channels/808030843078836254/1209800956741681184)
```
WSMessage(type=<WSMsgType.ERROR: 258>, data=WebSocketError(<WSCloseCode.PROTOCOL_ERROR: 1002>, 'Received fragmented control frame'), extra=None)
```

This isn't reproducible[^1], but apparently happened at least once. Blame cloudflare, I guess(?).

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

[^1]: ...unless you manually feed it one of these weird non-spec-compliant frames: `bot._get_websocket(shard_id=0).socket._reader._protocol.data_received(bytes([0b00001001, 0]))`