### PR TITLE
fix: handle missing `FFmpegAudio._process` in cleanup

### DIFF
--- a/changelog/1164.bugfix.rst
+++ b/changelog/1164.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid ``AttributeError`` in :class:`FFmpegAudio` when cleaning up after failing to spawn ffmpeg process.

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -175,7 +175,12 @@ class FFmpegAudio(AudioSource):
             raise ClientException(f"Popen failed: {exc.__class__.__name__}: {exc}") from exc
 
     def _kill_process(self) -> None:
-        proc = self._process
+        try:
+            proc = self._process
+        except AttributeError:
+            # may occur if something errors while spawning process
+            return
+
         if proc is MISSING:
             return
 


### PR DESCRIPTION
## Summary

`AudioSource.__del__` calls `cleanup()`, which in the case of `FFmpegAudio` can raise an `AttributeError` when spawning the ffmpeg process failed, since `_process` ends up not being initialized yet.

see also https://canary.discord.com/channels/808030843078836254/942319505915412500/1214270424943427615

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
