### PR TITLE
feat: support `banner` parameter in `ClientUser.edit`

### DIFF
--- a/changelog/1165.feature.rst
+++ b/changelog/1165.feature.rst
@@ -1,0 +1,1 @@
+Add ``banner`` parameter to :meth:`ClientUser.edit`.

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -359,7 +359,11 @@ class ClientUser(BaseUser):
         self.mfa_enabled = data.get("mfa_enabled", False)
 
     async def edit(
-        self, *, username: str = MISSING, avatar: Optional[AssetBytes] = MISSING
+        self,
+        *,
+        username: str = MISSING,
+        avatar: Optional[AssetBytes] = MISSING,
+        banner: Optional[AssetBytes] = MISSING,
     ) -> ClientUser:
         """|coro|
 
@@ -384,16 +388,24 @@ class ClientUser(BaseUser):
             .. versionchanged:: 2.5
                 Now accepts various resource types in addition to :class:`bytes`.
 
+        banner: Optional[|resource_type|]
+            A :term:`py:bytes-like object` or asset representing the image to upload.
+            Could be ``None`` to denote no banner.
+
+            Only JPG, PNG, WEBP (static), and GIF (static/animated) images are supported.
+
+            .. versionadded:: 2.10
+
         Raises
         ------
         NotFound
-            The ``avatar`` asset couldn't be found.
+            The ``avatar`` or ``banner`` asset couldn't be found.
         HTTPException
             Editing your profile failed.
         TypeError
-            The ``avatar`` asset is a lottie sticker (see :func:`Sticker.read`).
+            The ``avatar`` or ``banner`` asset is a lottie sticker (see :func:`Sticker.read`).
         ValueError
-            Wrong image format passed for ``avatar``.
+            Wrong image format passed for ``avatar`` or ``banner``.
 
         Returns
         -------
@@ -406,6 +418,9 @@ class ClientUser(BaseUser):
 
         if avatar is not MISSING:
             payload["avatar"] = await _assetbytes_to_base64_data(avatar)
+
+        if banner is not MISSING:
+            payload["banner"] = await _assetbytes_to_base64_data(banner)
 
         data: UserPayload = await self._state.http.edit_profile(payload)
         return ClientUser(state=self._state, data=data)


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/pull/6710

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
