### PR TITLE
fix: Examples Hyperlink Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ async def ping(ctx):
 bot.run("BOT_TOKEN")
 ```
 
-You can find more examples in the [examples directory](./examples).
+[1]: https://github.com/
+
+You can find more examples in the [examples directory](https://github.com/DisnakeDev/disnake/tree/master/examples).
 
 <br>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ async def ping(ctx):
 bot.run("BOT_TOKEN")
 ```
 
-[1]: https://github.com/
-
 You can find more examples in the [examples directory](https://github.com/DisnakeDev/disnake/tree/master/examples).
 
 <br>


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
In `README.md` the `you can find more examples in the examples directory`. In PyPi the hyperlink will redirect you to https://pypi.org/project/disnake/examples/ instead of https://github.com/DisnakeDev/disnake/tree/master/examples. This will fix it by adding that url.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
