### PR TITLE
fix(typing): Reduce number of `Unknown`s in public APIs.

### DIFF
--- a/changelog/1167.misc.rst
+++ b/changelog/1167.misc.rst
@@ -1,0 +1,1 @@
+Reduce the amount of unknown (unresolved) types in public-facing APIs.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1150,7 +1150,7 @@ class GuildChannel(ABC):
     ) -> None:
         ...
 
-    async def move(self, **kwargs) -> None:
+    async def move(self, **kwargs: Any) -> None:
         """|coro|
 
         A rich interface to help move a channel relative to other channels.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -3000,7 +3000,7 @@ class CategoryChannel(disnake.abc.GuildChannel, Hashable):
         ...
 
     @utils.copy_doc(disnake.abc.GuildChannel.move)
-    async def move(self, **kwargs) -> None:
+    async def move(self, **kwargs: Any) -> None:
         kwargs.pop("category", None)
         return await super().move(**kwargs)
 

--- a/disnake/ext/commands/base_core.py
+++ b/disnake/ext/commands/base_core.py
@@ -130,7 +130,7 @@ class InvokableApplicationCommand(ABC):
         self.__original_kwargs__ = {k: v for k, v in kwargs.items() if v is not None}
         return self
 
-    def __init__(self, func: CommandCallback, *, name: Optional[str] = None, **kwargs) -> None:
+    def __init__(self, func: CommandCallback, *, name: Optional[str] = None, **kwargs: Any) -> None:
         self.__command_flag__ = None
         self._callback: CommandCallback = func
         self.name: str = name or func.__name__
@@ -281,7 +281,9 @@ class InvokableApplicationCommand(ABC):
         except ValueError:
             pass
 
-    async def __call__(self, interaction: ApplicationCommandInteraction, *args, **kwargs) -> Any:
+    async def __call__(
+        self, interaction: ApplicationCommandInteraction, *args: Any, **kwargs: Any
+    ) -> Any:
         """|coro|
 
         Calls the internal callback that the application command holds.
@@ -381,7 +383,7 @@ class InvokableApplicationCommand(ABC):
         return 0.0
 
     # This method isn't really usable in this class, but it's usable in subclasses.
-    async def invoke(self, inter: ApplicationCommandInteraction, *args, **kwargs) -> None:
+    async def invoke(self, inter: ApplicationCommandInteraction, *args: Any, **kwargs: Any) -> None:
         await self.prepare(inter)
 
         try:

--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -78,7 +78,7 @@ class InvokableUserCommand(InvokableApplicationCommand):
         nsfw: Optional[bool] = None,
         guild_ids: Optional[Sequence[int]] = None,
         auto_sync: Optional[bool] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
@@ -122,7 +122,11 @@ class InvokableUserCommand(InvokableApplicationCommand):
             inter.bot.dispatch("user_command_error", inter, error)
 
     async def __call__(
-        self, interaction: ApplicationCommandInteraction, target: Any = None, *args, **kwargs
+        self,
+        interaction: ApplicationCommandInteraction,
+        target: Any = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         # the target may just not be passed in
         args = (target or interaction.target,) + args
@@ -180,7 +184,7 @@ class InvokableMessageCommand(InvokableApplicationCommand):
         nsfw: Optional[bool] = None,
         guild_ids: Optional[Sequence[int]] = None,
         auto_sync: Optional[bool] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
@@ -218,7 +222,11 @@ class InvokableMessageCommand(InvokableApplicationCommand):
             inter.bot.dispatch("message_command_error", inter, error)
 
     async def __call__(
-        self, interaction: ApplicationCommandInteraction, target: Any = None, *args, **kwargs
+        self,
+        interaction: ApplicationCommandInteraction,
+        target: Any = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         # the target may just not be passed in
         args = (target or interaction.target,) + args
@@ -237,7 +245,7 @@ def user_command(
     guild_ids: Optional[Sequence[int]] = None,
     auto_sync: Optional[bool] = None,
     extras: Optional[Dict[str, Any]] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Callable[[InteractionCommandCallback[CogT, UserCommandInteraction, P]], InvokableUserCommand]:
     """A shortcut decorator that builds a user command.
 
@@ -316,7 +324,7 @@ def message_command(
     guild_ids: Optional[Sequence[int]] = None,
     auto_sync: Optional[bool] = None,
     extras: Optional[Dict[str, Any]] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Callable[
     [InteractionCommandCallback[CogT, MessageCommandInteraction, P]],
     InvokableMessageCommand,

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -494,7 +494,7 @@ class InteractionBotBase(CommonBotBase):
         connectors: Optional[Dict[str, str]] = None,
         auto_sync: Optional[bool] = None,
         extras: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Callable[[CommandCallback], InvokableSlashCommand]:
         """A shortcut decorator that invokes :func:`~disnake.ext.commands.slash_command` and adds it to
         the internal command list.
@@ -585,7 +585,7 @@ class InteractionBotBase(CommonBotBase):
         guild_ids: Optional[Sequence[int]] = None,
         auto_sync: Optional[bool] = None,
         extras: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Callable[
         [InteractionCommandCallback[CogT, UserCommandInteraction, P]], InvokableUserCommand
     ]:
@@ -662,7 +662,7 @@ class InteractionBotBase(CommonBotBase):
         guild_ids: Optional[Sequence[int]] = None,
         auto_sync: Optional[bool] = None,
         extras: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Callable[
         [InteractionCommandCallback[CogT, MessageCommandInteraction, P]], InvokableMessageCommand
     ]:

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -142,7 +142,7 @@ class SubCommandGroup(InvokableApplicationCommand):
         parent: InvokableSlashCommand,
         *,
         name: LocalizedOptional = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
@@ -193,7 +193,7 @@ class SubCommandGroup(InvokableApplicationCommand):
         options: Optional[list] = None,
         connectors: Optional[dict] = None,
         extras: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Callable[[CommandCallback], SubCommand]:
         """A decorator that creates a subcommand in the subcommand group.
         Parameters are the same as in :class:`InvokableSlashCommand.sub_command`
@@ -272,7 +272,7 @@ class SubCommand(InvokableApplicationCommand):
         description: LocalizedOptional = None,
         options: Optional[list] = None,
         connectors: Optional[Dict[str, str]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
@@ -345,7 +345,7 @@ class SubCommand(InvokableApplicationCommand):
     ) -> Optional[Choices]:
         return await _call_autocompleter(self, param, inter, user_input)
 
-    async def invoke(self, inter: ApplicationCommandInteraction, *args, **kwargs) -> None:
+    async def invoke(self, inter: ApplicationCommandInteraction, *args: Any, **kwargs: Any) -> None:
         for k, v in self.connectors.items():
             if k in kwargs:
                 kwargs[v] = kwargs.pop(k)
@@ -439,7 +439,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         guild_ids: Optional[Sequence[int]] = None,
         connectors: Optional[Dict[str, str]] = None,
         auto_sync: Optional[bool] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         name_loc = Localized._cast(name, False)
         super().__init__(func, name=name_loc.string, **kwargs)
@@ -525,7 +525,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         options: Optional[list] = None,
         connectors: Optional[dict] = None,
         extras: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Callable[[CommandCallback], SubCommand]:
         """A decorator that creates a subcommand under the base command.
 
@@ -587,7 +587,7 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         self,
         name: LocalizedOptional = None,
         extras: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Callable[[CommandCallback], SubCommandGroup]:
         """A decorator that creates a subcommand group under the base command.
 
@@ -758,7 +758,7 @@ def slash_command(
     connectors: Optional[Dict[str, str]] = None,
     auto_sync: Optional[bool] = None,
     extras: Optional[Dict[str, Any]] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> Callable[[CommandCallback], InvokableSlashCommand]:
     """A decorator that builds a slash command.
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2165,7 +2165,7 @@ class HTTPClient:
         guild_id: Snowflake,
         *,
         reason: Optional[str] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Response[welcome_screen.WelcomeScreen]:
         valid_keys = (
             "enabled",

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -2083,7 +2083,7 @@ class Message(Hashable):
         return Thread(guild=self.guild, state=self._state, data=data)
 
     async def reply(
-        self, content: Optional[str] = None, *, fail_if_not_exists: bool = True, **kwargs
+        self, content: Optional[str] = None, *, fail_if_not_exists: bool = True, **kwargs: Any
     ) -> Message:
         """|coro|
 


### PR DESCRIPTION
## Summary

Reduces the amount of unknown types in public-facing APIs. Intended to improve experience with disnake when using pyright in strict mode. I intentionally didn't go too deep and only focused on untyped `*args`/`**kwargs` here since they are (from my experience, at least) one of the most common untyped things when using disnake.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
