### PR TITLE
fix(docs): add `entitlements` to interaction subclasses

### DIFF
--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -82,10 +82,16 @@ class ApplicationCommandInteraction(Interaction[ClientT]):
 
     token: :class:`str`
         The token to continue the interaction. These are valid for 15 minutes.
-    data: :class:`ApplicationCommandInteractionData`
-        The wrapped interaction data.
     client: :class:`Client`
         The interaction client.
+    entitlements: List[:class:`Entitlement`]
+        The entitlements for the invoking user and guild,
+        representing access to an application subscription.
+
+        .. versionadded:: 2.10
+
+    data: :class:`ApplicationCommandInteractionData`
+        The wrapped interaction data.
     application_command: :class:`.InvokableApplicationCommand`
         The command invoked by the interaction.
     command_failed: :class:`bool`

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -69,12 +69,18 @@ class MessageInteraction(Interaction[ClientT]):
         .. versionchanged:: 2.5
             Changed to :class:`Locale` instead of :class:`str`.
 
-    message: Optional[:class:`Message`]
-        The message that sent this interaction.
-    data: :class:`MessageInteractionData`
-        The wrapped interaction data.
     client: :class:`Client`
         The interaction client.
+    entitlements: List[:class:`Entitlement`]
+        The entitlements for the invoking user and guild,
+        representing access to an application subscription.
+
+        .. versionadded:: 2.10
+
+    data: :class:`MessageInteractionData`
+        The wrapped interaction data.
+    message: Optional[:class:`Message`]
+        The message that this interaction's component is attached to.
     """
 
     def __init__(self, *, data: MessageInteractionPayload, state: ConnectionState) -> None:

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -57,16 +57,21 @@ class ModalInteraction(Interaction[ClientT]):
         .. versionchanged:: 2.5
             Changed to :class:`Locale` instead of :class:`str`.
 
+    client: :class:`Client`
+        The interaction client.
+    entitlements: List[:class:`Entitlement`]
+        The entitlements for the invoking user and guild,
+        representing access to an application subscription.
+
+        .. versionadded:: 2.10
+
+    data: :class:`ModalInteractionData`
+        The wrapped interaction data.
     message: Optional[:class:`Message`]
         The message that this interaction's modal originated from,
         if the modal was sent in response to a component interaction.
 
         .. versionadded:: 2.5
-
-    data: :class:`ModalInteractionData`
-        The wrapped interaction data.
-    client: :class:`Client`
-        The interaction client.
     """
 
     __slots__ = ("message", "_cs_text_values")


### PR DESCRIPTION
## Summary

`entitlements` was only documented on the base `Interaction` type, not any of the subclasses (e.g. `ApplicationCommandInteraction`).

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
