### PR TITLE
feat(guild): add `Guild.bulk_ban` method

### DIFF
--- a/changelog/1174.feature.rst
+++ b/changelog/1174.feature.rst
@@ -1,0 +1,1 @@
+Add :meth:`Guild.bulk_ban`.

--- a/changelog/1174.feature.rst
+++ b/changelog/1174.feature.rst
@@ -1,1 +1,1 @@
-Add :meth:`Guild.bulk_ban`.
+Support banning multiple users at once using :meth:`Guild.bulk_ban`.

--- a/disnake/bans.py
+++ b/disnake/bans.py
@@ -16,6 +16,6 @@ class BanEntry(NamedTuple):
     user: "User"
 
 
-class BulkBan(NamedTuple):
+class BulkBanResult(NamedTuple):
     banned: List[Snowflake]
     failed: List[Snowflake]

--- a/disnake/bans.py
+++ b/disnake/bans.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple, Optional
+from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 __all__ = ("BanEntry",)
 
 if TYPE_CHECKING:
+    from .abc import Snowflake
     from .user import User
 
 
 class BanEntry(NamedTuple):
     reason: Optional[str]
     user: "User"
+
+
+class BulkBan(NamedTuple):
+    banned: List[Snowflake]
+    failed: List[Snowflake]

--- a/disnake/bans.py
+++ b/disnake/bans.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, NamedTuple, Optional, Sequence
 
 __all__ = ("BanEntry",)
 
@@ -17,5 +17,5 @@ class BanEntry(NamedTuple):
 
 
 class BulkBanResult(NamedTuple):
-    banned: List[Snowflake]
-    failed: List[Snowflake]
+    banned: Sequence[Snowflake]
+    failed: Sequence[Snowflake]

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    Iterable,
     List,
     Literal,
     NamedTuple,
@@ -4010,7 +4011,7 @@ class Guild(Hashable):
 
     async def bulk_ban(
         self,
-        users: Sequence[Snowflake],
+        users: Iterable[Snowflake],
         *,
         clean_history_duration: Union[int, datetime.timedelta] = 0,
         reason: Optional[str] = None,
@@ -4028,7 +4029,7 @@ class Guild(Hashable):
 
         Parameters
         ----------
-        users: Sequence[:class:`abc.Snowflake`]
+        users: Iterable[:class:`abc.Snowflake`]
             The users to ban from the guild, up to 200.
         clean_history_duration: Union[:class:`int`, :class:`datetime.timedelta`]
             The timespan (seconds or timedelta) of messages to delete from the users

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4010,7 +4010,7 @@ class Guild(Hashable):
 
     async def bulk_ban(
         self,
-        users: List[Snowflake],
+        users: Sequence[Snowflake],
         *,
         clean_history_duration: Union[int, datetime.timedelta] = 0,
         reason: Optional[str] = None,
@@ -4028,7 +4028,7 @@ class Guild(Hashable):
 
         Parameters
         ----------
-        users: List[:class:`abc.Snowflake`]
+        users: Sequence[:class:`abc.Snowflake`]
             The users to ban from the guild, up to 200.
         clean_history_duration: Union[:class:`int`, :class:`datetime.timedelta`]
             The timespan (seconds or timedelta) of messages to delete from the users

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4011,7 +4011,7 @@ class Guild(Hashable):
     async def bulk_ban(
         self,
         *users: Snowflake,
-        clean_history_duration: Union[int, datetime.timedelta] = 86400,
+        clean_history_duration: Union[int, datetime.timedelta] = 0,
         reason: Optional[str] = None,
     ) -> BulkBanResult:
         """|coro|
@@ -4030,7 +4030,7 @@ class Guild(Hashable):
         clean_history_duration: Union[:class:`int`, :class:`datetime.timedelta`]
             The timespan (seconds or timedelta) of messages to delete from the users
             in the guild, up to 7 days (604800 seconds).
-            Defaults to 1 day (86400 seconds).
+            Defaults to ``0``.
 
             .. note::
                 This may not be accurate with small durations (e.g. a few minutes)

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4016,7 +4016,7 @@ class Guild(Hashable):
     ) -> BulkBanResult:
         """|coro|
 
-        Bans multiple users from the guild.
+        Bans multiple users from the guild at once.
 
         The users must meet the :class:`abc.Snowflake` abc.
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -27,7 +27,7 @@ from . import abc, utils
 from .app_commands import GuildApplicationCommandPermissions
 from .asset import Asset
 from .automod import AutoModAction, AutoModRule
-from .bans import BanEntry, BulkBan
+from .bans import BanEntry, BulkBanResult
 from .channel import (
     CategoryChannel,
     ForumChannel,
@@ -4013,7 +4013,7 @@ class Guild(Hashable):
         *users: Snowflake,
         clean_history_duration: Union[int, datetime.timedelta] = 86400,
         reason: Optional[str] = None,
-    ) -> BulkBan:
+    ) -> BulkBanResult:
         """|coro|
 
         Bans multiple users from the guild.
@@ -4050,7 +4050,7 @@ class Guild(Hashable):
 
         Returns
         -------
-        :class:`BulkBan`
+        :class:`BulkBanResult`
             An object containing the successful and failed bans.
         """
         if isinstance(clean_history_duration, datetime.timedelta):
@@ -4070,7 +4070,7 @@ class Guild(Hashable):
             reason=reason,
         )
 
-        return BulkBan(
+        return BulkBanResult(
             # these keys should always exist, but have a fallback just in case
             [Object(u) for u in (data.get("banned_users") or [])],
             [Object(u) for u in (data.get("failed_users") or [])],

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4028,7 +4028,7 @@ class Guild(Hashable):
         Parameters
         ----------
         *users: :class:`abc.Snowflake`
-            The users to ban from the guild.
+            The users to ban from the guild, up to 200.
         clean_history_duration: Union[:class:`int`, :class:`datetime.timedelta`]
             The timespan (seconds or timedelta) of messages to delete from the users
             in the guild, up to 7 days (604800 seconds).

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4010,7 +4010,8 @@ class Guild(Hashable):
 
     async def bulk_ban(
         self,
-        *users: Snowflake,
+        users: List[Snowflake],
+        *,
         clean_history_duration: Union[int, datetime.timedelta] = 0,
         reason: Optional[str] = None,
     ) -> BulkBanResult:
@@ -4027,7 +4028,7 @@ class Guild(Hashable):
 
         Parameters
         ----------
-        *users: :class:`abc.Snowflake`
+        users: List[:class:`abc.Snowflake`]
             The users to ban from the guild, up to 200.
         clean_history_duration: Union[:class:`int`, :class:`datetime.timedelta`]
             The timespan (seconds or timedelta) of messages to delete from the users

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4023,6 +4023,8 @@ class Guild(Hashable):
         You must have :attr:`~Permissions.ban_members` and :attr:`~Permissions.manage_guild`
         permissions to do this.
 
+        .. versionadded:: 2.10
+
         Parameters
         ----------
         *users: :class:`abc.Snowflake`

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -876,6 +876,22 @@ class HTTPClient:
         r = Route("DELETE", "/guilds/{guild_id}/bans/{user_id}", guild_id=guild_id, user_id=user_id)
         return self.request(r, reason=reason)
 
+    def bulk_ban(
+        self,
+        user_ids: List[Snowflake],
+        guild_id: Snowflake,
+        *,
+        delete_message_seconds: int = 86400,
+        reason: Optional[str] = None,
+    ) -> Response[guild.BulkBan]:
+        r = Route("POST", "/guilds/{guild_id}/bulk-ban", guild_id=guild_id)
+        payload = {
+            "user_ids": user_ids,
+            "delete_message_seconds": delete_message_seconds,
+        }
+
+        return self.request(r, json=payload, reason=reason)
+
     def get_guild_voice_regions(self, guild_id: Snowflake) -> Response[List[voice.VoiceRegion]]:
         return self.request(Route("GET", "/guilds/{guild_id}/regions", guild_id=guild_id))
 

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -881,7 +881,7 @@ class HTTPClient:
         user_ids: List[Snowflake],
         guild_id: Snowflake,
         *,
-        delete_message_seconds: int = 86400,
+        delete_message_seconds: int = 0,
         reason: Optional[str] = None,
     ) -> Response[guild.BulkBanResult]:
         r = Route("POST", "/guilds/{guild_id}/bulk-ban", guild_id=guild_id)

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -883,7 +883,7 @@ class HTTPClient:
         *,
         delete_message_seconds: int = 86400,
         reason: Optional[str] = None,
-    ) -> Response[guild.BulkBan]:
+    ) -> Response[guild.BulkBanResult]:
         r = Route("POST", "/guilds/{guild_id}/bulk-ban", guild_id=guild_id)
         payload = {
             "user_ids": user_ids,

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -23,6 +23,11 @@ class Ban(TypedDict):
     user: User
 
 
+class BulkBan(TypedDict):
+    banned_users: List[Snowflake]
+    failed_users: List[Snowflake]
+
+
 class UnavailableGuild(TypedDict):
     id: Snowflake
     unavailable: NotRequired[bool]

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -23,7 +23,7 @@ class Ban(TypedDict):
     user: User
 
 
-class BulkBan(TypedDict):
+class BulkBanResult(TypedDict):
     banned_users: List[Snowflake]
     failed_users: List[Snowflake]
 

--- a/docs/api/guilds.rst
+++ b/docs/api/guilds.rst
@@ -69,10 +69,10 @@ BanEntry
 
         :type: :class:`User`
 
-BulkBan
-~~~~~~~
+BulkBanResult
+~~~~~~~~~~~~~
 
-.. class:: BulkBan
+.. class:: BulkBanResult
 
     A namedtuple which represents the successful and failed bans returned from :meth:`~Guild.bulk_ban`.
 

--- a/docs/api/guilds.rst
+++ b/docs/api/guilds.rst
@@ -69,6 +69,24 @@ BanEntry
 
         :type: :class:`User`
 
+BulkBan
+~~~~~~~
+
+.. class:: BulkBan
+
+    A namedtuple which represents the successful and failed bans returned from :meth:`~Guild.bulk_ban`.
+
+    .. attribute:: banned
+
+        The list of users that were successfully banned.
+
+        :type: List[:class:`Object`]
+    .. attribute:: failed
+
+        The list of users that were not banned.
+
+        :type: List[:class:`Object`]
+
 Onboarding
 ~~~~~~~~~~
 

--- a/docs/api/guilds.rst
+++ b/docs/api/guilds.rst
@@ -80,14 +80,14 @@ BulkBanResult
 
     .. attribute:: banned
 
-        The list of users that were successfully banned.
+        The users that were successfully banned.
 
-        :type: List[:class:`Object`]
+        :type: Sequence[:class:`Object`]
     .. attribute:: failed
 
-        The list of users that were not banned.
+        The users that were not banned.
 
-        :type: List[:class:`Object`]
+        :type: Sequence[:class:`Object`]
 
 Onboarding
 ~~~~~~~~~~

--- a/docs/api/guilds.rst
+++ b/docs/api/guilds.rst
@@ -76,6 +76,8 @@ BulkBanResult
 
     A namedtuple which represents the successful and failed bans returned from :meth:`~Guild.bulk_ban`.
 
+    .. versionadded:: 2.10
+
     .. attribute:: banned
 
         The list of users that were successfully banned.


### PR DESCRIPTION
## Summary

Pretty self-explanatory - adds `Guild.bulk_ban([user1, user2, ...])`, as well as `BulkBanResult` for the API response.

Unlike `Guild.ban`, the default for this is set not to delete any messages. Given that it can be a rather destructive action, I would rather have people be explicit with this.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
