### PR TITLE
chore(docs): adjust locale names in descriptions

### DIFF
--- a/docs/api/localization.rst
+++ b/docs/api/localization.rst
@@ -71,15 +71,15 @@ Locale
 
     .. attribute:: en_GB
 
-        The ``en_GB`` (English, UK) locale.
+        The ``en-GB`` (English, UK) locale.
 
     .. attribute:: en_US
 
-        The ``en_US`` (English, US) locale.
+        The ``en-US`` (English, US) locale.
 
     .. attribute:: es_ES
 
-        The ``es_ES`` (Spanish) locale.
+        The ``es-ES`` (Spanish) locale.
 
     .. attribute:: es_LATAM
 
@@ -143,7 +143,7 @@ Locale
 
     .. attribute:: pt_BR
 
-        The ``pt_BR`` (Portuguese) locale.
+        The ``pt-BR`` (Portuguese) locale.
 
     .. attribute:: ro
 
@@ -155,7 +155,7 @@ Locale
 
     .. attribute:: sv_SE
 
-        The ``sv_SE`` (Swedish) locale.
+        The ``sv-SE`` (Swedish) locale.
 
     .. attribute:: th
 
@@ -175,8 +175,8 @@ Locale
 
     .. attribute:: zh_CN
 
-        The ``zh_CN`` (Chinese, China) locale.
+        The ``zh-CN`` (Chinese, China) locale.
 
     .. attribute:: zh_TW
 
-        The ``zh_TW`` (Chinese, Taiwan) locale.
+        The ``zh-TW`` (Chinese, Taiwan) locale.


### PR DESCRIPTION
## Summary

This keeps the attribute names the same as before, but adjusts the descriptions in the docs to match the [reference table](https://discord.com/developers/docs/reference#locales) for consistency, i.e. `en_GB` -> `en-GB`.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
