### PR TITLE
fix: use media.discordapp.net for gif stickers

### DIFF
--- a/changelog/1189.bugfix.rst
+++ b/changelog/1189.bugfix.rst
@@ -1,0 +1,1 @@
+Fix base URL for stickers with :attr:`StickerFormatType.gif`.

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -195,6 +195,9 @@ class Asset(AssetMixin):
 
     BASE = "https://cdn.discordapp.com"
 
+    # only used in special cases where Discord doesn't provide an asset on the CDN url
+    BASE_MEDIA = "https://media.discordapp.net"
+
     def __init__(self, state: AnyState, *, url: str, key: str, animated: bool = False) -> None:
         self._state: AnyState = state
         self._url: str = url

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -128,7 +128,11 @@ class _StickerTag(Hashable, AssetMixin):
     @property
     def url(self) -> str:
         """:class:`str`: The url for the sticker's image."""
-        return f"{Asset.BASE}/stickers/{self.id}.{self.format.file_extension}"
+        # https://github.com/discord/discord-api-docs/issues/6675#issuecomment-1954755672
+        base = (
+            "https://media.discordapp.net" if self.format is StickerFormatType.gif else Asset.BASE
+        )
+        return f"{base}/stickers/{self.id}.{self.format.file_extension}"
 
     async def read(self) -> bytes:
         """|coro|

--- a/disnake/sticker.py
+++ b/disnake/sticker.py
@@ -129,9 +129,7 @@ class _StickerTag(Hashable, AssetMixin):
     def url(self) -> str:
         """:class:`str`: The url for the sticker's image."""
         # https://github.com/discord/discord-api-docs/issues/6675#issuecomment-1954755672
-        base = (
-            "https://media.discordapp.net" if self.format is StickerFormatType.gif else Asset.BASE
-        )
+        base = Asset.BASE_MEDIA if self.format is StickerFormatType.gif else Asset.BASE
         return f"{base}/stickers/{self.id}.{self.format.file_extension}"
 
     async def read(self) -> bytes:


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/0a7d731bad7d49c2e49b0687d2a9ec633efeabc9

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
