### PR TITLE
fix: Add LargeInt Support to Range

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -357,7 +357,7 @@ class _BaseRange(ABC):
             return Union[self, other]  # type: ignore
 
 if TYPE_CHECKING:
-    from typing_extensions import Annotated as Range
+    from typing_extensions import Annotated as Range, Annotated as String
 else:
     @dataclass(frozen=True, repr=False)
     class Range(_BaseRange):


### PR DESCRIPTION
## Summary

This pull request introduces a new `LargeInt` converter for command arguments in Disnake, providing a built-in way to handle large integers in command arguments.

- Closes #787 

## Checklist

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes (❓)
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
