### PR TITLE
ci: resolve importlib-metadata errors

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -29,6 +29,8 @@ runs:
         cache: false
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
         enable-pep582: false  # Disable PEP 582 package loading globally
+      env:
+        PDM_DEPS: 'importlib-metadata<8; python_version < "3.10"'
 
     - name: Disable PDM version check
       shell: bash

--- a/noxfile.py
+++ b/noxfile.py
@@ -49,7 +49,7 @@ def docs(session: nox.Session) -> None:
     If running locally, will build automatic reloading docs.
     If running in CI, will build a production version of the documentation.
     """
-    session.run_always("pdm", "install", "--prod", "-G", "docs", external=True)
+    session.run_always("pdm", "install", "-v", "--prod", "-G", "docs", external=True)
     with session.chdir("docs"):
         args = ["-b", "html", "-n", ".", "_build/html", *session.posargs]
         if session.interactive:

--- a/noxfile.py
+++ b/noxfile.py
@@ -49,7 +49,7 @@ def docs(session: nox.Session) -> None:
     If running locally, will build automatic reloading docs.
     If running in CI, will build a production version of the documentation.
     """
-    session.run_always("pdm", "install", "-v", "--prod", "-G", "docs", external=True)
+    session.run_always("pdm", "install", "--prod", "-G", "docs", external=True)
     with session.chdir("docs"):
         args = ["-b", "html", "-n", ".", "_build/html", *session.posargs]
         if session.interactive:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ test = [
 build = [
     "wheel~=0.40.0",
     "build~=0.10.0",
-    "twine~=4.0.2",
+    "twine~=5.1.1",
 ]
 
 [tool.pdm.scripts]


### PR DESCRIPTION
## Summary

Both pdm and twine depend on `importlib-metadata`, but broke due to a change in [importlib-metadata v8.0.0](https://importlib-metadata.readthedocs.io/en/latest/history.html#deprecations-and-removals).
Since updating pdm is rather tricky, we just pin `importlib-metadata<8` there for now:tm:.
In the case of twine, v5.1.1 no longer has this issue (and funnily enough, neither does 5.0.0, but 5.1.0 does).

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
