### PR TITLE
docs(channel): clarify `ForumChannel.create_thread` return type

### DIFF
--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -3494,7 +3494,7 @@ class ThreadOnlyGuildChannel(disnake.abc.GuildChannel, Hashable):
     ) -> ThreadWithMessage:
         """|coro|
 
-        Creates a thread in this channel.
+        Creates a thread (with an initial message) in this channel.
 
         You must have the :attr:`~Permissions.create_forum_threads` permission to do this.
 
@@ -3506,6 +3506,10 @@ class ThreadOnlyGuildChannel(disnake.abc.GuildChannel, Hashable):
 
         .. versionchanged:: 2.6
             The ``content`` parameter is no longer required.
+
+        .. note::
+            Unlike :meth:`TextChannel.create_thread`,
+            this **returns a tuple** with both the created **thread and message**.
 
         Parameters
         ----------
@@ -3583,10 +3587,8 @@ class ThreadOnlyGuildChannel(disnake.abc.GuildChannel, Hashable):
 
         Returns
         -------
-        Tuple[:class:`Thread`, :class:`Message`]
+        :class:`ThreadWithMessage`
             A :class:`~typing.NamedTuple` with the newly created thread and the message sent in it.
-
-            These values can also be accessed through the ``thread`` and ``message`` fields.
         """
         from .message import Message
         from .webhook.async_ import handle_message_parameters_dict

--- a/docs/api/channels.rst
+++ b/docs/api/channels.rst
@@ -187,7 +187,7 @@ ThreadWithMessage
 
 .. class:: ThreadWithMessage
 
-    A namedtuple which represents a thread and message returned from :meth:`ForumChannel.create_thread`.
+    A :class:`~typing.NamedTuple` which represents a thread and message returned from :meth:`ForumChannel.create_thread`.
 
     .. attribute:: thread
 

--- a/docs/api/channels.rst
+++ b/docs/api/channels.rst
@@ -182,6 +182,24 @@ ForumTag
     :members:
     :inherited-members:
 
+ThreadWithMessage
+~~~~~~~~~~~~~~~~~
+
+.. class:: ThreadWithMessage
+
+    A namedtuple which represents a thread and message returned from :meth:`ForumChannel.create_thread`.
+
+    .. attribute:: thread
+
+        The created thread.
+
+        :type: :class:`Thread`
+    .. attribute:: message
+
+        The initial message in the thread.
+
+        :type: :class:`Message`
+
 Enumerations
 ------------
 

--- a/docs/api/guilds.rst
+++ b/docs/api/guilds.rst
@@ -56,7 +56,7 @@ BanEntry
 
 .. class:: BanEntry
 
-    A namedtuple which represents a ban returned from :meth:`~Guild.bans`.
+    A :class:`~typing.NamedTuple` which represents a ban returned from :meth:`~Guild.bans`.
 
     .. attribute:: reason
 
@@ -74,7 +74,7 @@ BulkBanResult
 
 .. class:: BulkBanResult
 
-    A namedtuple which represents the successful and failed bans returned from :meth:`~Guild.bulk_ban`.
+    A :class:`~typing.NamedTuple` which represents the successful and failed bans returned from :meth:`~Guild.bulk_ban`.
 
     .. versionadded:: 2.10
 


### PR DESCRIPTION
## Summary

Resolves #1198, by adding a `.. note::` and explicitly documenting the `ThreadWithMessage` namedtuple.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
