### PR TITLE
feat(app): add guild/user install count fields

### DIFF
--- a/changelog/1220.feature.rst
+++ b/changelog/1220.feature.rst
@@ -1,0 +1,1 @@
+Add :attr:`AppInfo.approximate_guild_count` and :attr:`AppInfo.approximate_user_install_count`.

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -98,8 +98,7 @@ class AppInfo:
         .. versionadded:: 1.3
 
     guild_id: Optional[:class:`int`]
-        If this application is a game sold on Discord,
-        this field will be the guild to which it has been linked to.
+        The ID of the guild associated with the application, if any.
 
         .. versionadded:: 1.3
 
@@ -151,6 +150,15 @@ class AppInfo:
         in the guild role verification configuration.
 
         .. versionadded:: 2.8
+    approximate_guild_count: :class:`int`
+        The approximate number of guilds the application is installed to.
+
+        .. versionadded:: 2.10
+    approximate_user_install_count: :class:`int`
+        The approximate number of users that have installed the application
+        (for user-installable apps).
+
+        .. versionadded:: 2.10
     """
 
     __slots__ = (
@@ -177,6 +185,8 @@ class AppInfo:
         "install_params",
         "custom_install_url",
         "role_connections_verification_url",
+        "approximate_guild_count",
+        "approximate_user_install_count",
     )
 
     def __init__(self, state: ConnectionState, data: AppInfoPayload) -> None:
@@ -218,6 +228,8 @@ class AppInfo:
         self.role_connections_verification_url: Optional[str] = data.get(
             "role_connections_verification_url"
         )
+        self.approximate_guild_count: int = data.get("approximate_guild_count", 0)
+        self.approximate_user_install_count: int = data.get("approximate_user_install_count", 0)
 
     def __repr__(self) -> str:
         return (
@@ -245,8 +257,7 @@ class AppInfo:
 
     @property
     def guild(self) -> Optional[Guild]:
-        """Optional[:class:`Guild`]: If this application is a game sold on Discord,
-        this field will be the guild to which it has been linked
+        """Optional[:class:`Guild`]: The guild associated with the application, if any.
 
         .. versionadded:: 1.3
         """

--- a/disnake/types/appinfo.py
+++ b/disnake/types/appinfo.py
@@ -42,6 +42,8 @@ class AppInfo(BaseAppInfo):
     install_params: NotRequired[InstallParams]
     custom_install_url: NotRequired[str]
     role_connections_verification_url: NotRequired[str]
+    approximate_guild_count: NotRequired[int]
+    approximate_user_install_count: NotRequired[int]
 
 
 class PartialAppInfo(BaseAppInfo, total=False):


### PR DESCRIPTION
## Summary

This adds `AppInfo.approximate_guild_count` and `.approximate_user_install_count`, available through `Client.application_info()`.

https://github.com/discord/discord-api-docs/commit/0817246c9f254a4c2537146b49b8758048abdd70
https://github.com/discord/discord-api-docs/commit/9c45aa73fb353cba97e71257a8e5374ba53876f7

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
