### PR TITLE
feat: new message type PURCHASE_NOTIFICATION

### DIFF
--- a/changelog/1225.feature.rst
+++ b/changelog/1225.feature.rst
@@ -1,0 +1,4 @@
+Implement new :attr:`Message.type`: :attr:`MessageType.purchase_notifcation`.
+- New types :class:`PurchaseNotificationInfo`, :class:`GuildProductInfo`.
+- New :attr:`Message.purchase_information` attribute.
+- New enum :class:`PurchaseType`.

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -71,6 +71,7 @@ __all__ = (
     "OnboardingPromptType",
     "SKUType",
     "EntitlementType",
+    "PurchaseType",
 )
 
 
@@ -260,6 +261,7 @@ class MessageType(Enum):
     guild_incident_alert_mode_disabled = 37
     guild_incident_report_raid = 38
     guild_incident_report_false_alarm = 39
+    purchase_notification = 44
 
 
 class PartyType(Enum):
@@ -1362,6 +1364,10 @@ class EntitlementType(Enum):
     user_gift = 6
     premium_purchase = 7
     application_subscription = 8
+
+
+class PurchaseType(Enum):
+    guild_product = 0
 
 
 T = TypeVar("T")

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -77,6 +77,19 @@ class RoleSubscriptionData(TypedDict):
     is_renewal: bool
 
 
+class GuildProductPurchase(TypedDict):
+    listing_id: Snowflake
+    product_name: str
+
+
+PurchaseType = Literal[0]
+
+
+class PurchaseNotification(TypedDict):
+    type: PurchaseType
+    guild_product_purchase: NotRequired[GuildProductPurchase]
+
+
 # fmt: off
 MessageType = Literal[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 36, 37, 38, 39]
 # fmt: on
@@ -114,6 +127,7 @@ class Message(TypedDict):
     sticker_items: NotRequired[List[StickerItem]]
     position: NotRequired[int]
     role_subscription_data: NotRequired[RoleSubscriptionData]
+    purchase_notification: NotRequired[PurchaseNotification]
 
     # specific to MESSAGE_CREATE/MESSAGE_UPDATE events
     guild_id: NotRequired[Snowflake]

--- a/docs/api/messages.rst
+++ b/docs/api/messages.rst
@@ -62,6 +62,22 @@ RoleSubscriptionData
 .. autoclass:: RoleSubscriptionData
     :members:
 
+GuildProductInfo
+~~~~~~~~~~~~~~~~
+
+.. attributetable:: GuildProductInfo
+
+.. autoclass:: GuildProductInfo
+    :members:
+
+PurchaseNotificationInfo
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: PurchaseNotificationInfo
+
+.. autoclass:: PurchaseNotificationInfo
+    :members:
+
 RawTypingEvent
 ~~~~~~~~~~~~~~
 
@@ -182,6 +198,14 @@ Enumerations
 
 MessageType
 ~~~~~~~~~~~
+
+.. class:: PurchaseType
+
+    Specifies the type of purchase for :class:`PurchaseNotificationInfo`.
+
+    .. attribute:: guild_product
+
+        The purchase is of a product from a guild.
 
 .. class:: MessageType
 
@@ -366,6 +390,11 @@ MessageType
     .. attribute:: guild_incident_report_false_alarm
 
         The system message denoting that a raid report was a false alarm.
+
+        .. versionadded:: 2.10
+    .. attribute:: purchase_notification
+
+        The system message denoting that a user has purchased a product.
 
         .. versionadded:: 2.10
 


### PR DESCRIPTION
## Summary

Implements GH-1225 & relevant types from the OpenAPI spec: [`Message.purchase_notification`](https://github.com/discord/discord-api-spec/blob/2ea9cb243da96de0a42684adb8aabbf2801a7b21/specs/openapi.json#L12832-L12841) & [`PurchaseNotification`](https://github.com/discord/discord-api-spec/blob/2ea9cb243da96de0a42684adb8aabbf2801a7b21/specs/openapi.json#L24564-L24594).

Since these data types are not officially documented yet, I will put this PR on draft.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
