### PR TITLE
feat(guild): support guild incidents

### DIFF
--- a/changelog/1230.feature.rst
+++ b/changelog/1230.feature.rst
@@ -1,0 +1,3 @@
+Add support for guild incident actions.
+- Add :class:`IncidentsData` and :attr:`Guild.incidents_data` attribute.
+- New ``invites_disabled_until`` and ``dms_disabled_until`` parameters for :meth:`Guild.edit`.

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -147,9 +147,21 @@ class IncidentsData:
             Checks if two ``IncidentsData`` instances are not equal.
 
     .. versionadded:: 2.10
+
+    Attributes
+    ----------
+    dm_spam_detected_at: Optional[:class:`datetime.datetime`]
+        The datetime at which DM spam was last detected.
+    raid_detected_at: Optional[:class:`datetime.datetime`]
+        The datetime at which a raid was last detected.
     """
 
-    __slots__ = ("_invites_disabled_until", "_dms_disabled_until")
+    __slots__ = (
+        "_invites_disabled_until",
+        "_dms_disabled_until",
+        "dm_spam_detected_at",
+        "raid_detected_at",
+    )
 
     def __init__(self, data: IncidentsDataPayload) -> None:
         self._invites_disabled_until: Optional[datetime.datetime] = utils.parse_time(
@@ -157,6 +169,12 @@ class IncidentsData:
         )
         self._dms_disabled_until: Optional[datetime.datetime] = utils.parse_time(
             data.get("dms_disabled_until")
+        )
+        self.dm_spam_detected_at: Optional[datetime.datetime] = utils.parse_time(
+            data.get("dm_spam_detected_at")
+        )
+        self.raid_detected_at: Optional[datetime.datetime] = utils.parse_time(
+            data.get("raid_detected_at")
         )
 
     @property

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -134,7 +134,20 @@ class _GuildLimit(NamedTuple):
 
 # TODO: "IncidentData"?
 class IncidentsData:
-    """TODO"""
+    """Represents data about various security incidents/actions in a guild.
+
+    .. container:: operations
+
+        .. describe:: x == y
+
+            Checks if two ``IncidentsData`` instances are equal.
+
+        .. describe:: x != y
+
+            Checks if two ``IncidentsData`` instances are not equal.
+
+    .. versionadded:: 2.10
+    """
 
     __slots__ = ("_invites_disabled_until", "_dms_disabled_until")
 
@@ -148,7 +161,9 @@ class IncidentsData:
 
     @property
     def invites_disabled_until(self) -> Optional[datetime.datetime]:
-        """TODO"""
+        """Optional[:class:`datetime.datetime`]: Returns the datetime until
+        which users cannot join the server via invites, if any.
+        """
         if (
             self._invites_disabled_until is not None
             and self._invites_disabled_until < utils.utcnow()
@@ -159,7 +174,12 @@ class IncidentsData:
 
     @property
     def dms_disabled_until(self) -> Optional[datetime.datetime]:
-        """TODO"""
+        """Optional[:class:`datetime.datetime`]: Returns the datetime until
+        which members cannot send DMs to each other, if any.
+
+        This does not apply to moderators, bots, or members who are
+        already friends with each other.
+        """
         if self._dms_disabled_until is not None and self._dms_disabled_until < utils.utcnow():
             self._dms_disabled_until = None
 
@@ -354,7 +374,7 @@ class Guild(Hashable):
         .. versionadded:: 2.5
 
     incidents_data: Optional[:class:`IncidentsData`]
-        # TODO
+        Data about various security incidents/actions in this guild, like disabled invites/DMs.
 
         .. versionadded:: 2.10
     """
@@ -632,7 +652,6 @@ class Guild(Hashable):
         self._safety_alerts_channel_id: Optional[int] = utils._get_as_snowflake(
             guild, "safety_alerts_channel_id"
         )
-        # TODO: only store if at least one valid value?
         self.incidents_data: Optional[IncidentsData] = (
             IncidentsData(incidents_data)
             if (incidents_data := guild.get("incidents_data"))

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2335,7 +2335,7 @@ class Guild(Hashable):
                 payload["dms_disabled_until"] = utils.isoformat_utc(dms_disabled_until)
 
             if payload:
-                await http.edit_guild_incident_actions(self.id, **payload)
+                await http.edit_guild_incident_actions(self.id, payload)
 
         fields: Dict[str, Any] = {}
         if name is not MISSING:

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -208,6 +208,8 @@ class IncidentsData:
             isinstance(other, IncidentsData)
             and self.invites_disabled_until == other.invites_disabled_until
             and self.dms_disabled_until == other.dms_disabled_until
+            and self.dm_spam_detected_at == other.dm_spam_detected_at
+            and self.raid_detected_at == other.raid_detected_at
         )
 
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -132,11 +132,10 @@ class _GuildLimit(NamedTuple):
     filesize: int
 
 
-# TODO: "IncidentData"?
 class IncidentsData:
     """Represents data about various security incidents/actions in a guild.
 
-    .. container:: operations
+    .. collapse:: operations
 
         .. describe:: x == y
 

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -151,9 +151,9 @@ class IncidentsData:
     Attributes
     ----------
     dm_spam_detected_at: Optional[:class:`datetime.datetime`]
-        The datetime at which DM spam was last detected.
+        The time (in UTC) at which DM spam was last detected.
     raid_detected_at: Optional[:class:`datetime.datetime`]
-        The datetime at which a raid was last detected.
+        The time (in UTC) at which a raid was last detected.
     """
 
     __slots__ = (
@@ -179,7 +179,7 @@ class IncidentsData:
 
     @property
     def invites_disabled_until(self) -> Optional[datetime.datetime]:
-        """Optional[:class:`datetime.datetime`]: Returns the datetime until
+        """Optional[:class:`datetime.datetime`]: Returns the time (in UTC) until
         which users cannot join the server via invites, if any.
         """
         if (
@@ -192,7 +192,7 @@ class IncidentsData:
 
     @property
     def dms_disabled_until(self) -> Optional[datetime.datetime]:
-        """Optional[:class:`datetime.datetime`]: Returns the datetime until
+        """Optional[:class:`datetime.datetime`]: Returns the time (in UTC) until
         which members cannot send DMs to each other, if any.
 
         This does not apply to moderators, bots, or members who are

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1398,7 +1398,7 @@ class HTTPClient:
         )
 
     def edit_guild_incident_actions(
-        self, guild_id: Snowflake, **payload: Any
+        self, guild_id: Snowflake, payload: guild.IncidentsData
     ) -> Response[guild.IncidentsData]:
         r = Route("PUT", "/guilds/{guild_id}/incident-actions", guild_id=guild_id)
         return self.request(r, json=payload)

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -1397,6 +1397,12 @@ class HTTPClient:
             Route("PATCH", "/guilds/{guild_id}", guild_id=guild_id), json=payload, reason=reason
         )
 
+    def edit_guild_incident_actions(
+        self, guild_id: Snowflake, **payload: Any
+    ) -> Response[guild.IncidentsData]:
+        r = Route("PUT", "/guilds/{guild_id}/incident-actions", guild_id=guild_id)
+        return self.request(r, json=payload)
+
     def get_template(self, code: str) -> Response[template.Template]:
         return self.request(Route("GET", "/guilds/templates/{code}", code=code))
 

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -721,12 +721,11 @@ class Member(disnake.abc.Messageable, _UserTag):
 
         .. versionadded:: 2.3
         """
-        if self._communication_disabled_until is None:
-            return None
-
-        if self._communication_disabled_until < utils.utcnow():
+        if (
+            self._communication_disabled_until is not None
+            and self._communication_disabled_until < utils.utcnow()
+        ):
             self._communication_disabled_until = None
-            return None
 
         return self._communication_disabled_until
 

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -84,6 +84,12 @@ GuildFeature = Literal[
 ]
 
 
+class IncidentsData(TypedDict):
+    invites_disabled_until: Optional[str]
+    dms_disabled_until: Optional[str]
+    # TODO: raid_detected_at, dm_spam_detected_at ?
+
+
 class _BaseGuildPreview(UnavailableGuild):
     name: str
     icon: Optional[str]
@@ -135,6 +141,7 @@ class Guild(_BaseGuildPreview):
     stickers: NotRequired[List[GuildSticker]]
     premium_progress_bar_enabled: bool
     safety_alerts_channel_id: Optional[Snowflake]
+    incidents_data: Optional[IncidentsData]
 
     # specific to GUILD_CREATE event
     joined_at: NotRequired[Optional[str]]

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -87,7 +87,8 @@ GuildFeature = Literal[
 class IncidentsData(TypedDict, total=False):
     invites_disabled_until: Optional[str]
     dms_disabled_until: Optional[str]
-    # TODO: raid_detected_at, dm_spam_detected_at ?
+    dm_spam_detected_at: Optional[str]
+    raid_detected_at: Optional[str]
 
 
 class _BaseGuildPreview(UnavailableGuild):

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -84,7 +84,7 @@ GuildFeature = Literal[
 ]
 
 
-class IncidentsData(TypedDict):
+class IncidentsData(TypedDict, total=False):
     invites_disabled_until: Optional[str]
     dms_disabled_until: Optional[str]
     # TODO: raid_detected_at, dm_spam_detected_at ?

--- a/docs/api/guilds.rst
+++ b/docs/api/guilds.rst
@@ -113,6 +113,14 @@ OnboardingPromptOption
 .. autoclass:: OnboardingPromptOption()
     :members:
 
+IncidentsData
+~~~~~~~~~~~~~
+
+.. attributetable:: IncidentsData
+
+.. autoclass:: IncidentsData()
+    :members:
+
 Data Classes
 ------------
 


### PR DESCRIPTION
## Summary

Adds `IncidentsData`, as well as two new parameters `invites_disabled_until` and `dms_disabled_until` to `Guild.edit`.

The already existing `invites_disabled` parameter (and corresponding `INVITES_DISABLED` feature) still works, and appears to override any duration set by `invites_disabled_until` on Discord's end.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
