### PR TITLE
fix(cog): fix typing of cog check methods 

### DIFF
--- a/disnake/ext/commands/cog.py
+++ b/disnake/ext/commands/cog.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Coroutine,
     Dict,
     Generator,
     List,
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
 
     from disnake.interactions import ApplicationCommandInteraction
 
+    from ._types import MaybeCoro
     from .bot import AutoShardedBot, AutoShardedInteractionBot, Bot, InteractionBot
     from .context import Context
     from .core import Command
@@ -492,7 +492,7 @@ class Cog(metaclass=CogMeta):
         pass
 
     @_cog_special_method
-    def bot_check_once(self, ctx: Context) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def bot_check_once(self, ctx: Context) -> MaybeCoro[bool]:
         """A special method that registers as a :meth:`.Bot.check_once`
         check.
 
@@ -504,7 +504,7 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_check(self, ctx: Context) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def bot_check(self, ctx: Context) -> MaybeCoro[bool]:
         """A special method that registers as a :meth:`.Bot.check`
         check.
 
@@ -516,9 +516,7 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_slash_command_check_once(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def bot_slash_command_check_once(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """A special method that registers as a :meth:`.Bot.slash_command_check_once`
         check.
 
@@ -528,9 +526,7 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_slash_command_check(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def bot_slash_command_check(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """A special method that registers as a :meth:`.Bot.slash_command_check`
         check.
 
@@ -540,35 +536,29 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_user_command_check_once(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def bot_user_command_check_once(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """Similar to :meth:`.Bot.slash_command_check_once` but for user commands."""
         return True
 
     @_cog_special_method
-    def bot_user_command_check(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def bot_user_command_check(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """Similar to :meth:`.Bot.slash_command_check` but for user commands."""
         return True
 
     @_cog_special_method
     def bot_message_command_check_once(
         self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    ) -> MaybeCoro[bool]:
         """Similar to :meth:`.Bot.slash_command_check_once` but for message commands."""
         return True
 
     @_cog_special_method
-    def bot_message_command_check(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def bot_message_command_check(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """Similar to :meth:`.Bot.slash_command_check` but for message commands."""
         return True
 
     @_cog_special_method
-    def cog_check(self, ctx: Context) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def cog_check(self, ctx: Context) -> MaybeCoro[bool]:
         """A special method that registers as a :func:`~.check`
         for every text command and subcommand in this cog.
 
@@ -580,9 +570,7 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def cog_slash_command_check(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def cog_slash_command_check(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """A special method that registers as a :func:`~.check`
         for every slash command and subcommand in this cog.
 
@@ -592,16 +580,12 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def cog_user_command_check(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def cog_user_command_check(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """Similar to :meth:`.Cog.cog_slash_command_check` but for user commands."""
         return True
 
     @_cog_special_method
-    def cog_message_command_check(
-        self, inter: ApplicationCommandInteraction
-    ) -> Union[bool, Coroutine[Any, Any, bool]]:
+    def cog_message_command_check(self, inter: ApplicationCommandInteraction) -> MaybeCoro[bool]:
         """Similar to :meth:`.Cog.cog_slash_command_check` but for message commands."""
         return True
 

--- a/disnake/ext/commands/cog.py
+++ b/disnake/ext/commands/cog.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Coroutine,
     Dict,
     Generator,
     List,
@@ -491,7 +492,7 @@ class Cog(metaclass=CogMeta):
         pass
 
     @_cog_special_method
-    def bot_check_once(self, ctx: Context) -> bool:
+    def bot_check_once(self, ctx: Context) -> Union[bool, Coroutine[Any, Any, bool]]:
         """A special method that registers as a :meth:`.Bot.check_once`
         check.
 
@@ -503,7 +504,7 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_check(self, ctx: Context) -> bool:
+    def bot_check(self, ctx: Context) -> Union[bool, Coroutine[Any, Any, bool]]:
         """A special method that registers as a :meth:`.Bot.check`
         check.
 
@@ -515,7 +516,9 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_slash_command_check_once(self, inter: ApplicationCommandInteraction) -> bool:
+    def bot_slash_command_check_once(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """A special method that registers as a :meth:`.Bot.slash_command_check_once`
         check.
 
@@ -525,7 +528,9 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_slash_command_check(self, inter: ApplicationCommandInteraction) -> bool:
+    def bot_slash_command_check(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """A special method that registers as a :meth:`.Bot.slash_command_check`
         check.
 
@@ -535,27 +540,35 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def bot_user_command_check_once(self, inter: ApplicationCommandInteraction) -> bool:
+    def bot_user_command_check_once(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """Similar to :meth:`.Bot.slash_command_check_once` but for user commands."""
         return True
 
     @_cog_special_method
-    def bot_user_command_check(self, inter: ApplicationCommandInteraction) -> bool:
+    def bot_user_command_check(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """Similar to :meth:`.Bot.slash_command_check` but for user commands."""
         return True
 
     @_cog_special_method
-    def bot_message_command_check_once(self, inter: ApplicationCommandInteraction) -> bool:
+    def bot_message_command_check_once(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """Similar to :meth:`.Bot.slash_command_check_once` but for message commands."""
         return True
 
     @_cog_special_method
-    def bot_message_command_check(self, inter: ApplicationCommandInteraction) -> bool:
+    def bot_message_command_check(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """Similar to :meth:`.Bot.slash_command_check` but for message commands."""
         return True
 
     @_cog_special_method
-    def cog_check(self, ctx: Context) -> bool:
+    def cog_check(self, ctx: Context) -> Union[bool, Coroutine[Any, Any, bool]]:
         """A special method that registers as a :func:`~.check`
         for every text command and subcommand in this cog.
 
@@ -567,7 +580,9 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def cog_slash_command_check(self, inter: ApplicationCommandInteraction) -> bool:
+    def cog_slash_command_check(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """A special method that registers as a :func:`~.check`
         for every slash command and subcommand in this cog.
 
@@ -577,12 +592,16 @@ class Cog(metaclass=CogMeta):
         return True
 
     @_cog_special_method
-    def cog_user_command_check(self, inter: ApplicationCommandInteraction) -> bool:
+    def cog_user_command_check(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """Similar to :meth:`.Cog.cog_slash_command_check` but for user commands."""
         return True
 
     @_cog_special_method
-    def cog_message_command_check(self, inter: ApplicationCommandInteraction) -> bool:
+    def cog_message_command_check(
+        self, inter: ApplicationCommandInteraction
+    ) -> Union[bool, Coroutine[Any, Any, bool]]:
         """Similar to :meth:`.Cog.cog_slash_command_check` but for message commands."""
         return True
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Basically the check methods on `commands.Cog` were documented to be either a normal function or a Coroutine, though this wasn't reflexed on the typing part. This PR fixes that issue, refer to the attached image for clarifications.

![image](https://github.com/user-attachments/assets/6aa40ed3-05e7-4135-889f-72d555f83997)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
