### PR TITLE
feat: deserialize dm/group channels in interactions

### DIFF
--- a/changelog/1233.feature.rst
+++ b/changelog/1233.feature.rst
@@ -1,0 +1,2 @@
+For interactions in private channels, :attr:`Interaction.channel` is now always a proper :class:`DMChannel` or :class:`GroupChannel` object, instead of :class:`PartialMessageable`.
+- This also applies to other channel objects in interactions, e.g. channel parameters in slash commands, or :attr:`ui.ChannelSelect.values`.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -64,12 +64,12 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .asset import Asset
-    from .channel import CategoryChannel, DMChannel, PartialMessageable
+    from .channel import CategoryChannel, DMChannel, GroupChannel, PartialMessageable
     from .client import Client
     from .embeds import Embed
     from .emoji import Emoji
     from .enums import InviteTarget
-    from .guild import Guild, GuildMessageable
+    from .guild import Guild, GuildChannel as AnyGuildChannel, GuildMessageable
     from .guild_scheduled_event import GuildScheduledEvent
     from .iterators import HistoryIterator
     from .member import Member
@@ -90,7 +90,10 @@ if TYPE_CHECKING:
     from .user import ClientUser
     from .voice_region import VoiceRegion
 
-    MessageableChannel = Union[GuildMessageable, DMChannel, PartialMessageable]
+    MessageableChannel = Union[GuildMessageable, DMChannel, GroupChannel, PartialMessageable]
+    # include non-messageable channels, e.g. category/forum
+    AnyChannel = Union[MessageableChannel, AnyGuildChannel]
+
     SnowflakeTime = Union["Snowflake", datetime]
 
 MISSING = utils.MISSING

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -4663,7 +4663,10 @@ class DMChannel(disnake.abc.Messageable, Hashable):
 
     def __init__(self, *, me: ClientUser, state: ConnectionState, data: DMChannelPayload) -> None:
         self._state: ConnectionState = state
-        self.recipient: Optional[User] = state.store_user(data["recipients"][0])  # type: ignore
+        self.recipient: Optional[User] = None
+        if recipients := data.get("recipients"):
+            self.recipient = state.store_user(recipients[0])  # type: ignore
+
         self.me: ClientUser = me
         self.id: int = int(data["id"])
         self.last_pin_timestamp: Optional[datetime.datetime] = utils.parse_time(

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -4806,8 +4806,10 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
     ----------
     recipients: List[:class:`User`]
         The users you are participating with in the group channel.
+        If this channel is received through the gateway, the recipient information
+        may not be always available.
     me: :class:`ClientUser`
-        The user presenting yourself.
+        The user representing yourself.
     id: :class:`int`
         The group channel ID.
     owner: Optional[:class:`User`]

--- a/disnake/ext/commands/context.py
+++ b/disnake/ext/commands/context.py
@@ -14,7 +14,7 @@ from disnake.message import Message
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
-    from disnake.channel import DMChannel
+    from disnake.channel import DMChannel, GroupChannel
     from disnake.guild import Guild, GuildMessageable
     from disnake.member import Member
     from disnake.state import ConnectionState
@@ -262,7 +262,7 @@ class Context(disnake.abc.Messageable, Generic[BotT]):
         return self.message.guild
 
     @disnake.utils.cached_property
-    def channel(self) -> Union[GuildMessageable, DMChannel]:
+    def channel(self) -> Union[GuildMessageable, DMChannel, GroupChannel]:
         """Union[:class:`.abc.Messageable`]: Returns the channel associated with this context's command.
         Shorthand for :attr:`.Message.channel`.
         """

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -58,16 +58,18 @@ class ApplicationCommandInteraction(Interaction[ClientT]):
         The application ID that the interaction was for.
     guild_id: Optional[:class:`int`]
         The guild ID the interaction was sent from.
-    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`]
+    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`abc.PrivateChannel`, :class:`PartialMessageable`]
         The channel the interaction was sent from.
 
         Note that due to a Discord limitation, DM channels
-        are not resolved as there is no data to complete them.
-        These are :class:`PartialMessageable` instead.
+        may not contain recipient information.
+        Unknown channel types will be :class:`PartialMessageable`.
 
         .. versionchanged:: 2.10
             If the interaction was sent from a thread and the bot cannot normally access the thread,
             this is now a proper :class:`Thread` object.
+            Private channels are now proper :class:`DMChannel`/:class:`GroupChannel`
+            objects instead of :class:`PartialMessageable`.
 
         .. note::
             If you want to compute the interaction author's or bot's permissions in the channel,

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1956,6 +1956,7 @@ class InteractionDataResolved(Dict[str, Any]):
             else:
                 channel = cast(
                     "Optional[MessageableChannel]",
+                    # TODO: don't use state.get_channel
                     (guild and guild.get_channel(channel_id) or state.get_channel(channel_id)),
                 )
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -65,13 +65,12 @@ if TYPE_CHECKING:
 
     from aiohttp import ClientSession
 
-    from ..abc import MessageableChannel
+    from ..abc import AnyChannel, MessageableChannel
     from ..app_commands import Choices
     from ..client import Client
     from ..embeds import Embed
     from ..ext.commands import AutoShardedBot, Bot
     from ..file import File
-    from ..guild import GuildChannel, GuildMessageable
     from ..mentions import AllowedMentions
     from ..poll import Poll
     from ..state import ConnectionState
@@ -87,9 +86,6 @@ if TYPE_CHECKING:
     from ..ui.view import View
     from .message import MessageInteraction
     from .modal import ModalInteraction
-
-    InteractionMessageable = Union[GuildMessageable, PartialMessageable]
-    InteractionChannel = Union[InteractionMessageable, GuildChannel]
 
     AnyBot = Union[Bot, AutoShardedBot]
 
@@ -130,16 +126,18 @@ class Interaction(Generic[ClientT]):
         .. versionchanged:: 2.5
             Changed to :class:`Locale` instead of :class:`str`.
 
-    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`]
+    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`abc.PrivateChannel`, :class:`PartialMessageable`]
         The channel the interaction was sent from.
 
         Note that due to a Discord limitation, DM channels
-        are not resolved as there is no data to complete them.
-        These are :class:`PartialMessageable` instead.
+        may not contain recipient information.
+        Unknown channel types will be :class:`PartialMessageable`.
 
         .. versionchanged:: 2.10
             If the interaction was sent from a thread and the bot cannot normally access the thread,
             this is now a proper :class:`Thread` object.
+            Private channels are now proper :class:`DMChannel`/:class:`GroupChannel`
+            objects instead of :class:`PartialMessageable`.
 
         .. note::
             If you want to compute the interaction author's or bot's permissions in the channel,
@@ -236,7 +234,7 @@ class Interaction(Generic[ClientT]):
             self.author = self._state.store_user(user)
 
         # TODO: consider making this optional in 3.0
-        self.channel: InteractionMessageable = state._get_partial_interaction_channel(
+        self.channel: MessageableChannel = state._get_partial_interaction_channel(
             data["channel"], guild_fallback, return_messageable=True
         )
 
@@ -1866,7 +1864,7 @@ class InteractionDataResolved(Dict[str, Any]):
         A mapping of IDs to users.
     roles: Dict[:class:`int`, :class:`Role`]
         A mapping of IDs to roles.
-    channels: Dict[:class:`int`, Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`]]
+    channels: Dict[:class:`int`, Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`abc.PrivateChannel`, :class:`PartialMessageable`]]
         A mapping of IDs to partial channels (only ``id``, ``name`` and ``permissions`` are included,
         threads also have ``thread_metadata`` and ``parent_id``).
     messages: Dict[:class:`int`, :class:`Message`]
@@ -1891,7 +1889,7 @@ class InteractionDataResolved(Dict[str, Any]):
         self.members: Dict[int, Member] = {}
         self.users: Dict[int, User] = {}
         self.roles: Dict[int, Role] = {}
-        self.channels: Dict[int, InteractionChannel] = {}
+        self.channels: Dict[int, AnyChannel] = {}
         self.messages: Dict[int, Message] = {}
         self.attachments: Dict[int, Attachment] = {}
 
@@ -1980,18 +1978,18 @@ class InteractionDataResolved(Dict[str, Any]):
     @overload
     def get_with_type(
         self, key: Snowflake, data_type: Union[OptionType, ComponentType]
-    ) -> Union[Member, User, Role, InteractionChannel, Message, Attachment, None]:
+    ) -> Union[Member, User, Role, AnyChannel, Message, Attachment, None]:
         ...
 
     @overload
     def get_with_type(
         self, key: Snowflake, data_type: Union[OptionType, ComponentType], default: T
-    ) -> Union[Member, User, Role, InteractionChannel, Message, Attachment, T]:
+    ) -> Union[Member, User, Role, AnyChannel, Message, Attachment, T]:
         ...
 
     def get_with_type(
         self, key: Snowflake, data_type: Union[OptionType, ComponentType], default: T = None
-    ) -> Union[Member, User, Role, InteractionChannel, Message, Attachment, T, None]:
+    ) -> Union[Member, User, Role, AnyChannel, Message, Attachment, T, None]:
         if data_type is OptionType.mentionable or data_type is ComponentType.mentionable_select:
             key = int(key)
             if (result := self.members.get(key)) is not None:
@@ -2019,7 +2017,7 @@ class InteractionDataResolved(Dict[str, Any]):
 
     def get_by_id(
         self, key: Optional[int]
-    ) -> Optional[Union[Member, User, Role, InteractionChannel, Message, Attachment]]:
+    ) -> Optional[Union[Member, User, Role, AnyChannel, Message, Attachment]]:
         if key is None:
             return None
 

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -16,6 +16,7 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from ..abc import AnyChannel
     from ..member import Member
     from ..role import Role
     from ..state import ConnectionState
@@ -25,7 +26,6 @@ if TYPE_CHECKING:
         MessageInteraction as MessageInteractionPayload,
     )
     from ..user import User
-    from .base import InteractionChannel
 
 
 class MessageInteraction(Interaction[ClientT]):
@@ -47,16 +47,18 @@ class MessageInteraction(Interaction[ClientT]):
         The token to continue the interaction. These are valid for 15 minutes.
     guild_id: Optional[:class:`int`]
         The guild ID the interaction was sent from.
-    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`]
+    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`abc.PrivateChannel`, :class:`PartialMessageable`]
         The channel the interaction was sent from.
 
         Note that due to a Discord limitation, DM channels
-        are not resolved as there is no data to complete them.
-        These are :class:`PartialMessageable` instead.
+        may not contain recipient information.
+        Unknown channel types will be :class:`PartialMessageable`.
 
         .. versionchanged:: 2.10
             If the interaction was sent from a thread and the bot cannot normally access the thread,
             this is now a proper :class:`Thread` object.
+            Private channels are now proper :class:`DMChannel`/:class:`GroupChannel`
+            objects instead of :class:`PartialMessageable`.
 
         .. note::
             If you want to compute the interaction author's or bot's permissions in the channel,
@@ -116,7 +118,7 @@ class MessageInteraction(Interaction[ClientT]):
     @cached_slot_property("_cs_resolved_values")
     def resolved_values(
         self,
-    ) -> Optional[Sequence[Union[str, Member, User, Role, InteractionChannel]]]:
+    ) -> Optional[Sequence[Union[str, Member, User, Role, AnyChannel]]]:
         """Optional[Sequence[:class:`str`, :class:`Member`, :class:`User`, :class:`Role`, Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`]]]: The (resolved) values the user selected.
 
         For select menus of type :attr:`~ComponentType.string_select`,
@@ -134,7 +136,7 @@ class MessageInteraction(Interaction[ClientT]):
             return self.data.values
 
         resolved = self.data.resolved
-        values: List[Union[Member, User, Role, InteractionChannel]] = []
+        values: List[Union[Member, User, Role, AnyChannel]] = []
         for key in self.data.values:
             # force upcast to avoid typing issues; we expect the api to only provide valid values
             value: Any = resolved.get_with_type(key, component_type, key)

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -39,16 +39,18 @@ class ModalInteraction(Interaction[ClientT]):
         These are valid for 15 minutes.
     guild_id: Optional[:class:`int`]
         The guild ID the interaction was sent from.
-    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`]
+    channel: Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`abc.PrivateChannel`, :class:`PartialMessageable`]
         The channel the interaction was sent from.
 
         Note that due to a Discord limitation, DM channels
-        are not resolved as there is no data to complete them.
-        These are :class:`PartialMessageable` instead.
+        may not contain recipient information.
+        Unknown channel types will be :class:`PartialMessageable`.
 
         .. versionchanged:: 2.10
             If the interaction was sent from a thread and the bot cannot normally access the thread,
             this is now a proper :class:`Thread` object.
+            Private channels are now proper :class:`DMChannel`/:class:`GroupChannel`
+            objects instead of :class:`PartialMessageable`.
 
         .. note::
             If you want to compute the interaction author's or bot's permissions in the channel,

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .abc import GuildChannel, MessageableChannel, Snowflake
-    from .channel import DMChannel
+    from .channel import DMChannel, GroupChannel
     from .guild import GuildMessageable
     from .mentions import AllowedMentions
     from .role import Role
@@ -1007,7 +1007,7 @@ class Message(Hashable):
         self.activity: Optional[MessageActivityPayload] = data.get("activity")
         # for user experience, on_message has no business getting partials
         # TODO: Subscripted message to include the channel
-        self.channel: Union[GuildMessageable, DMChannel] = channel  # type: ignore
+        self.channel: Union[GuildMessageable, DMChannel, GroupChannel] = channel  # type: ignore
         self.position: Optional[int] = data.get("position", None)
         self._edited_timestamp: Optional[datetime.datetime] = utils.parse_time(
             data["edited_timestamp"]
@@ -2258,7 +2258,7 @@ class PartialMessage(Hashable):
 
     Attributes
     ----------
-    channel: Union[:class:`TextChannel`, :class:`Thread`, :class:`DMChannel`, :class:`VoiceChannel`, :class:`StageChannel`, :class:`PartialMessageable`]
+    channel: Union[:class:`TextChannel`, :class:`VoiceChannel`, :class:`StageChannel`, :class:`Thread`, :class:`DMChannel`, :class:`GroupChannel`, :class:`PartialMessageable`]
         The channel associated with this partial message.
     id: :class:`int`
         The message ID.

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -2071,6 +2071,7 @@ class ConnectionState:
                 type=ch_type,
             )
 
+        # TODO: check private channel cache for these first
         if ch_type in (ChannelType.group, ChannelType.private):
             # the factory will be a DMChannel or GroupChannel here
             return factory(me=self.user, data=data, state=self)  # type: ignore

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -2071,10 +2071,12 @@ class ConnectionState:
                 type=ch_type,
             )
 
-        # TODO: check private channel cache for these first
         if ch_type in (ChannelType.group, ChannelType.private):
-            # the factory will be a DMChannel or GroupChannel here
-            return factory(me=self.user, data=data, state=self)  # type: ignore
+            return (
+                self._get_private_channel(channel_id)
+                # the factory will be a DMChannel or GroupChannel here
+                or factory(me=self.user, data=data, state=self)  # type: ignore
+            )
 
         # the factory can't be a DMChannel or GroupChannel here
         data.setdefault("position", 0)  # type: ignore

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -12,7 +12,7 @@ from .base import BaseSelect, P, V_co, _create_decorator
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-    from ...interactions.base import InteractionChannel
+    from ...abc import AnyChannel
     from ..item import DecoratedItem, ItemCallbackType, Object
 
 
@@ -22,7 +22,7 @@ __all__ = (
 )
 
 
-class ChannelSelect(BaseSelect[ChannelSelectMenu, "InteractionChannel", V_co]):
+class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
     """Represents a UI channel select menu.
 
     This is usually represented as a drop down menu.

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -58,7 +58,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
 
     Attributes
     ----------
-    values: List[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.PartialMessageable`]]
+    values: List[Union[:class:`.abc.GuildChannel`, :class:`.Thread`, :class:`.abc.PrivateChannel`, :class:`.PartialMessageable`]]
         A list of channels that have been selected by the user.
     """
 

--- a/tests/interactions/test_base.py
+++ b/tests/interactions/test_base.py
@@ -133,8 +133,9 @@ class TestInteractionDataResolved:
     # TODO: use proper mock models once we have state/guild mocks
     @pytest.fixture
     def state(self):
-        s = mock.Mock(spec_set=ConnectionState)
+        s = mock.Mock(spec=ConnectionState)
         s._get_guild.return_value = None
+        s.user = mock.Mock()
         return s
 
     @pytest.fixture
@@ -209,6 +210,5 @@ class TestInteractionDataResolved:
             return_messageable=False,
         )
 
-        # should be partial if and only if it's a dm/group or unknown
-        # TODO: currently includes directory channels (14), see `_get_partial_interaction_channel`
-        assert isinstance(channel, disnake.PartialMessageable) == (channel_type in (1, 3, 14, 99))
+        # should be partial if and only if it's an unknown/unexpected channel type
+        assert isinstance(channel, disnake.PartialMessageable) == (channel_type in (14, 99))


### PR DESCRIPTION
## Summary

Followup to #1012 - `interaction.channel` and other channel fields (slash params, channel select menus, ...) in interactions are now proper `DMChannel`/`GroupChannel` objects in dms/gdms respectively, instead of `PartialMessageable`. They don't have recipient data, since the API doesn't provide the field in interactions.

The core addition is this, everything else is primarily documentation/typing adjustments: https://github.com/DisnakeDev/disnake/blob/dfaadc6708f756b44955d2be55a2942e449de6f4/disnake/state.py#L2074-L2079

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
