### PR TITLE
docs: Add parameter info to disnake.ext.commands.Bot.run() docstring

### DIFF
--- a/disnake/client.py
+++ b/disnake/client.py
@@ -901,7 +901,7 @@ class Client:
             @client.listen('on_message')
             async def my_message(message):
                 print('two')
-    
+
             # in yet another file
             @client.listen(Event.message)
             async def another_message(message):

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -901,7 +901,7 @@ class Client:
             @client.listen('on_message')
             async def my_message(message):
                 print('two')
-
+    
             # in yet another file
             @client.listen(Event.message)
             async def another_message(message):
@@ -1258,6 +1258,11 @@ class Client:
         function should not be used. Use :meth:`start` coroutine
         or :meth:`connect` + :meth:`login`.
 
+        Parameters
+        ----------
+        token: `str`
+            The discord token of the bot that is being ran.
+        
         Roughly Equivalent to: ::
 
             try:

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -11,7 +11,7 @@ import types
 import warnings
 from datetime import datetime, timedelta
 from errno import ECONNRESET
-from typing import ( 
+from typing import (
     TYPE_CHECKING,
     Any,
     Callable,

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1260,7 +1260,7 @@ class Client:
 
         Parameters
         ----------
-        token: `str`
+        token: :class:`str`
             The discord token of the bot that is being ran.
         
         Roughly Equivalent to: ::

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1257,11 +1257,6 @@ class Client:
         If you want more control over the event loop then this
         function should not be used. Use :meth:`start` coroutine
         or :meth:`connect` + :meth:`login`.
-
-        Parameters
-        ----------
-        token: :class:`str`
-            The discord token of the bot that is being ran.
         
         Roughly Equivalent to: ::
 
@@ -1277,7 +1272,12 @@ class Client:
 
             This function must be the last function to call due to the fact that it
             is blocking. That means that registration of events or anything being
-            called after this function call will not execute until it returns.
+            called after this function call will not execute until it returns
+
+        Parameters
+        ----------
+        token: :class:`str`
+            The discord token of the bot that is being ran.
         """
         loop = self.loop
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1257,7 +1257,7 @@ class Client:
         If you want more control over the event loop then this
         function should not be used. Use :meth:`start` coroutine
         or :meth:`connect` + :meth:`login`.
-        
+
         Roughly Equivalent to: ::
 
             try:

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -11,7 +11,7 @@ import types
 import warnings
 from datetime import datetime, timedelta
 from errno import ECONNRESET
-from typing import (
+from typing import ( 
     TYPE_CHECKING,
     Any,
     Callable,


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
The class method run() for the class disnake.ext.commands.Bot did not have any information on what parameters it has. This is a quite small change but quite important as nearly all disnake bots use this method to start the bot. If people don't read the docs or simply just are new, they might not know what to pass.


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
