### PR TITLE
fix: attempt resume on websocket closure with `close_code = 1000` in edge cases

### DIFF
--- a/changelog/1241.bugfix.rst
+++ b/changelog/1241.bugfix.rst
@@ -1,0 +1,1 @@
+Attempt to handle abrupt websocket closures on ``aiohttp >= 3.9.0`` and ``python < 3.11.0`` gracefully.

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -696,7 +696,7 @@ class DiscordWebSocket:
         # try to reconnect.
         if self._close_code is None and self.socket.close_code == 1000:
             _log.info(
-                "Websocket remote in shard ID %s closed with %s. Assuming the connection dropped and attempting a reconnect.",
+                "Websocket remote in shard ID %s closed with %s. Assuming the connection dropped.",
                 self.shard_id,
                 self.socket.close_code,
             )

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -687,6 +687,21 @@ class DiscordWebSocket:
         return float("inf") if heartbeat is None else heartbeat.latency
 
     def _can_handle_close(self) -> bool:
+        # bandaid fix for https://github.com/aio-libs/aiohttp/issues/8138
+        # tl;dr: on aiohttp >= 3.9.0 and python < 3.11.0, aiohttp returns close code 1000 (OK)
+        # on abrupt connection loss, not 1006 (ABNORMAL_CLOSURE) like one would expect, ultimately
+        # due to faulty ssl lifecycle handling in cpython.
+        # If we end up in a situation where the close code is 1000 but we didn't
+        # initiate the closure (i.e. `self._close_code` isn't set), assume this has happened and
+        # try to reconnect.
+        if self._close_code is None and self.socket.close_code == 1000:
+            _log.info(
+                "Websocket remote in shard ID %s closed with %s. Assuming the connection dropped and attempting a reconnect.",
+                self.shard_id,
+                self.socket.close_code,
+            )
+            return True  # consider this a reconnectable close code
+
         code = self._close_code or self.socket.close_code
         return code not in (1000, 4004, 4010, 4011, 4012, 4013, 4014)
 


### PR DESCRIPTION
## Summary

This should hopefully fix a spurious websocket quirk introduced in aiohttp 3.9.0, which results in shards fully reconnecting instead of resuming on abrupt connection loss. See https://github.com/aio-libs/aiohttp/issues/8138 and the comment left in the code for more details.
There are several different workarounds for this, this is one of them. It's not pretty, but likely the most reliable one, besides another one I experimented with a while ago which relied on aiohttp internals too much :/

Only cpython 3.10 and earlier is affected, since 3.11.0a6+ uses uvloop's ssl implementation, which doesn't have this particular issue with ssl transport lifecycles.

Some references:
- https://canary.discord.com/channels/808030843078836254/1196843077659283496
- https://canary.discord.com/channels/808030843078836254/1280292681565605939
- https://canary.discord.com/channels/808030843078836254/1219276382648008704
- https://canary.discord.com/channels/808030843078836254/1199231240369352715
- https://canary.discord.com/channels/808030843078836254/942319505915412500/1276306995674087479

#### Reproduction steps (sort of):
- run an autosharded client
- get the client ws port using `bot._get_websocket(shard_id=0).socket.get_extra_info("sockname")`
- run `sudo tcpkill -i <iface> port <port>` (simulating the connection drop by inserting a TCP RST)
- wait for (or cause) some sort of websocket frame to be sent
- notice the shard fully reconnecting instead of resuming

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
