### PR TITLE
fix: remove decorator check in `InvokableUserCommand`

### DIFF
--- a/changelog/1252.bugfix.rst
+++ b/changelog/1252.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Fix incorrect exception when using the :func:`~ext.commands.default_member_permissions` decorator on a :func:`~ext.commands.user_command` while also using the cog-level ``user_command_attrs`` field.

--- a/disnake/ext/commands/ctx_menus_core.py
+++ b/disnake/ext/commands/ctx_menus_core.py
@@ -86,15 +86,9 @@ class InvokableUserCommand(InvokableApplicationCommand):
         self.auto_sync: bool = True if auto_sync is None else auto_sync
 
         try:
-            default_perms: int = func.__default_member_permissions__
+            default_member_permissions = func.__default_member_permissions__
         except AttributeError:
             pass
-        else:
-            if default_member_permissions is not None:
-                raise ValueError(
-                    "Cannot set `default_member_permissions` in both parameter and decorator"
-                )
-            default_member_permissions = default_perms
 
         dm_permission = True if dm_permission is None else dm_permission
 

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -7,19 +7,33 @@ from disnake import Permissions
 from disnake.ext import commands
 
 
+class DecoratorMeta:
+    def __init__(self, type: str) -> None:
+        self.decorator = {
+            "slash": commands.slash_command,
+            "user": commands.user_command,
+            "message": commands.message_command,
+        }[type]
+        self.attr_key = f"{type}_command_attrs"
+
+
 class TestDefaultPermissions:
-    def test_decorator(self) -> None:
+    @pytest.fixture(params=["slash", "user", "message"])
+    def meta(self, request):
+        return DecoratorMeta(request.param)
+
+    def test_decorator(self, meta: DecoratorMeta) -> None:
         class Cog(commands.Cog):
-            @commands.slash_command(default_member_permissions=64)
+            @meta.decorator(default_member_permissions=64)
             async def cmd(self, _) -> None:
                 ...
 
             @commands.default_member_permissions(64)
-            @commands.slash_command()
+            @meta.decorator()
             async def above(self, _) -> None:
                 ...
 
-            @commands.slash_command()
+            @meta.decorator()
             @commands.default_member_permissions(64)
             async def below(self, _) -> None:
                 ...
@@ -29,13 +43,13 @@ class TestDefaultPermissions:
             assert c.above.default_member_permissions == Permissions(64)
             assert c.below.default_member_permissions == Permissions(64)
 
-    def test_decorator_overwrite(self) -> None:
+    def test_decorator_overwrite(self, meta: DecoratorMeta) -> None:
         # putting the decorator above should fail
         with pytest.raises(ValueError, match="Cannot set `default_member_permissions`"):
 
             class Cog(commands.Cog):
                 @commands.default_member_permissions(32)
-                @commands.slash_command(default_member_permissions=64)
+                @meta.decorator(default_member_permissions=64)
                 async def above(self, _) -> None:
                     ...
 
@@ -44,7 +58,7 @@ class TestDefaultPermissions:
         # and while this *should* probably fail, we're just testing
         # for regressions for now)
         class Cog2(commands.Cog):
-            @commands.slash_command(default_member_permissions=64)
+            @meta.decorator(default_member_permissions=64)
             @commands.default_member_permissions(32)
             async def below(self, _) -> None:
                 ...
@@ -52,22 +66,24 @@ class TestDefaultPermissions:
         for c in (Cog2, Cog2()):
             assert c.below.default_member_permissions == Permissions(32)
 
-    def test_attrs(self) -> None:
-        class Cog(commands.Cog, slash_command_attrs={"default_member_permissions": 32}):
-            @commands.slash_command()
+    def test_attrs(self, meta: DecoratorMeta) -> None:
+        kwargs = {meta.attr_key: {"default_member_permissions": 32}}
+
+        class Cog(commands.Cog, **kwargs):
+            @meta.decorator()
             async def no_overwrite(self, _) -> None:
                 ...
 
-            @commands.slash_command(default_member_permissions=64)
+            @meta.decorator(default_member_permissions=64)
             async def overwrite(self, _) -> None:
                 ...
 
             @commands.default_member_permissions(64)
-            @commands.slash_command()
+            @meta.decorator()
             async def overwrite_decorator_above(self, _) -> None:
                 ...
 
-            @commands.slash_command()
+            @meta.decorator()
             @commands.default_member_permissions(64)
             async def overwrite_decorator_below(self, _) -> None:
                 ...
@@ -75,6 +91,7 @@ class TestDefaultPermissions:
         assert Cog.no_overwrite.default_member_permissions is None
         assert Cog().no_overwrite.default_member_permissions == Permissions(32)
 
+        # all of these should overwrite the cog-level attr
         assert Cog.overwrite.default_member_permissions == Permissions(64)
         assert Cog().overwrite.default_member_permissions == Permissions(64)
 

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -53,8 +53,8 @@ class TestDefaultPermissions:
                 async def above(self, _) -> None:
                     ...
 
-        # putting the decorator below shouldn't fail
-        # (this is a side effect of how command copying works,
+        # putting the decorator below shouldn't fail, for now
+        # FIXME: (this is a side effect of how command copying works,
         # and while this *should* probably fail, we're just testing
         # for regressions for now)
         class Cog2(commands.Cog):


### PR DESCRIPTION
## Summary

The sanity check for cases where both `@command(default_member_permissions=)` and `@default_member_permissions()` are used on the same callback was adjusted in #678.
Putting the `@default_member_permissions()` decorator *below* the application command decorator while also using `Cog(..., *_command_attrs=...)` (see example below) isn't supposed to throw an exception, and while this holds for `@slash_command` and `@message_command`, it didn't work with `@user_command`.

This makes all decorators work the same way.

#### Example:
```py
class Misc(
    commands.Cog,
    user_command_attrs={"default_member_permissions": disnake.Permissions(32)},
):
    # this shouldn't raise.
    @commands.user_command()
    @commands.default_member_permissions(64)
    async def test(self, inter) -> None:
        await inter.send("pong!")
```

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
