### PR TITLE
feat(modal, embeds): new method for Embed and metaclass for class Modal

### DIFF
--- a/changelog/1234.feature.rst
+++ b/changelog/1234.feature.rst
@@ -1,0 +1,1 @@
+Adding :method:`Embed.add_some_fields` and :metaclass:`ModalMeta` for :class:`Modal`

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
+
 import asyncio
 import logging
 import signal

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
-
 import asyncio
 import logging
 import signal

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -674,6 +674,45 @@ class Embed:
             self._fields = [field]
 
         return self
+    
+    
+    def add_some_fields(self, *data: Dict[str, Any]) -> Self:
+        """This function allows you to create several fields at once
+
+        This function returns the class instance to allow for fluent-style
+        chaining.
+
+        Parameters
+        ----------
+        data: :class:`dict` 
+            field data in dictionary
+            
+            Example:
+                add_some_fields(
+                    {"name": "Jack", "value": "Barker", "inline": False}
+                    {"name": "Sandra", "value": "Himenez", "inline": False}
+                )
+        """
+        fields: List[EmbedFieldPayload] = []
+        for element in data:
+            if (element.get("name") is None) or (element.get("value") is None):
+                raise TypeError("Missing argument. Name and Value - required.")
+                                             
+            fields.append(
+                {
+                    "inline": element.get("inline"),
+                    "name": str(element.get("name")),
+                    "value": str(element.get("value"))
+                }
+            )
+            
+        if self._fields is not None:
+            self._fields.extend(fields)
+        else:
+            self._fields = fields
+            
+        return self
+    
 
     def clear_fields(self) -> None:
         """Removes all fields from this embed."""

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -674,19 +674,18 @@ class Embed:
             self._fields = [field]
 
         return self
-    
-    
+
     def add_some_fields(self, *data: Dict[str, Any]) -> Self:
-        """This function allows you to create several fields at once
+        """Function allows you to create several fields at once
 
         This function returns the class instance to allow for fluent-style
         chaining.
 
         Parameters
         ----------
-        data: :class:`dict` 
+        data: :class:`dict`
             field data in dictionary
-            
+
             Example:
                 add_some_fields(
                     {"name": "Jack", "value": "Barker", "inline": False}
@@ -697,22 +696,21 @@ class Embed:
         for element in data:
             if (element.get("name") is None) or (element.get("value") is None):
                 raise TypeError("Missing argument. Name and Value - required.")
-                                             
+
             fields.append(
                 {
-                    "inline": element.get("inline"),
+                    "inline": bool(element.get("inline")),
                     "name": str(element.get("name")),
-                    "value": str(element.get("value"))
+                    "value": str(element.get("value")),
                 }
             )
-            
+
         if self._fields is not None:
             self._fields.extend(fields)
         else:
             self._fields = fields
-            
+
         return self
-    
 
     def clear_fields(self) -> None:
         """Removes all fields from this embed."""

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -427,7 +427,6 @@ class AsyncWebhookAdapter:
             if files:
                 set_attachments(data, files)
             payload["data"] = data
-
         if files:
             multipart = to_multipart(payload, files)
             return self.request(route, session=session, multipart=multipart, files=files)

--- a/examples/interactions/modal.py
+++ b/examples/interactions/modal.py
@@ -26,7 +26,7 @@ bot = commands.Bot(command_prefix=commands.when_mentioned)
 class MyModal(disnake.ui.Modal):
     __title__ = "Create Tag"
     __custom_id__ = "create_tag"
-    
+
     name = disnake.ui.TextInput(
         label="Name",
         placeholder="The name of the tag",

--- a/examples/interactions/modal.py
+++ b/examples/interactions/modal.py
@@ -24,26 +24,25 @@ bot = commands.Bot(command_prefix=commands.when_mentioned)
 
 
 class MyModal(disnake.ui.Modal):
-    def __init__(self) -> None:
-        components = [
-            disnake.ui.TextInput(
-                label="Name",
-                placeholder="The name of the tag",
-                custom_id="name",
-                style=disnake.TextInputStyle.short,
-                min_length=5,
-                max_length=50,
-            ),
-            disnake.ui.TextInput(
-                label="Content",
-                placeholder="The content of the tag",
-                custom_id="content",
-                style=disnake.TextInputStyle.paragraph,
-                min_length=5,
-                max_length=1024,
-            ),
-        ]
-        super().__init__(title="Create Tag", custom_id="create_tag", components=components)
+    __title__ = "Create Tag"
+    __custom_id__ = "create_tag"
+    
+    name = disnake.ui.TextInput(
+        label="Name",
+        placeholder="The name of the tag",
+        custom_id="name",
+        style=disnake.TextInputStyle.short,
+        min_length=5,
+        max_length=50,
+    )
+    content = disnake.ui.TextInput(
+        label="Content",
+        placeholder="The content of the tag",
+        custom_id="content",
+        style=disnake.TextInputStyle.paragraph,
+        min_length=5,
+        max_length=1024,
+    )
 
     async def callback(self, inter: disnake.ModalInteraction) -> None:
         tag_name = inter.text_values["name"]

--- a/test_bot/cogs/modals.py
+++ b/test_bot/cogs/modals.py
@@ -8,7 +8,7 @@ from disnake.ext import commands
 class MyModal(disnake.ui.Modal):
     __title__ = "Create Tag"
     __custom_id__ = "create_tag"
-    
+
     name = disnake.ui.TextInput(
         label="Name",
         placeholder="The name of the tag",
@@ -16,7 +16,7 @@ class MyModal(disnake.ui.Modal):
         style=TextInputStyle.short,
         max_length=50,
     )
-    
+
     description = disnake.ui.TextInput(
         label="Description",
         placeholder="The description of the tag",

--- a/test_bot/cogs/modals.py
+++ b/test_bot/cogs/modals.py
@@ -6,23 +6,23 @@ from disnake.ext import commands
 
 
 class MyModal(disnake.ui.Modal):
-    def __init__(self) -> None:
-        components = [
-            disnake.ui.TextInput(
-                label="Name",
-                placeholder="The name of the tag",
-                custom_id="name",
-                style=TextInputStyle.short,
-                max_length=50,
-            ),
-            disnake.ui.TextInput(
-                label="Description",
-                placeholder="The description of the tag",
-                custom_id="description",
-                style=TextInputStyle.paragraph,
-            ),
-        ]
-        super().__init__(title="Create Tag", custom_id="create_tag", components=components)
+    __title__ = "Create Tag"
+    __custom_id__ = "create_tag"
+    
+    name = disnake.ui.TextInput(
+        label="Name",
+        placeholder="The name of the tag",
+        custom_id="name",
+        style=TextInputStyle.short,
+        max_length=50,
+    )
+    
+    description = disnake.ui.TextInput(
+        label="Description",
+        placeholder="The description of the tag",
+        custom_id="description",
+        style=TextInputStyle.paragraph,
+    )
 
     async def callback(self, inter: disnake.ModalInteraction[commands.Bot]) -> None:
         embed = disnake.Embed(title="Tag Creation")


### PR DESCRIPTION
## Summary

### Embed
New method Embed.add_some_fields in order to be able to create multiple fields at once without using add_field multiple times.

For example,
```python
user_profile = get_profile(user_id) # -> List[Dict]

emb = Embed(title="Profile")
emb.add_some_fields(*user_profile)
```

### Modal
I also think that you need to create a Modal using metaclass. This improves readability.

Example
```python
import disnake

class MyModal(disnake.ui.Modal):
    __title__ = "Create Tag"
    __custom_id__ = "create_tag"
    
    name = disnake.ui.TextInput(
        label="Name",
        placeholder="The name of the tag",
        custom_id="name",
        style=disnake.TextInputStyle.short,
        min_length=5,
        max_length=50,
    )
    content = disnake.ui.TextInput(
        label="Content",
        placeholder="The content of the tag",
        custom_id="content",
        style=disnake.TextInputStyle.paragraph,
        min_length=5,
        max_length=1024,
    )

```

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
