### PR TITLE
feat(channel): add `GroupChannel.get_partial_message`

### DIFF
--- a/changelog/1256.feature.rst
+++ b/changelog/1256.feature.rst
@@ -1,0 +1,1 @@
+Add :meth:`GroupChannel.get_partial_message`.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -4968,6 +4968,28 @@ class GroupChannel(disnake.abc.Messageable, Hashable):
 
         return base
 
+    def get_partial_message(self, message_id: int, /) -> PartialMessage:
+        """Creates a :class:`PartialMessage` from the given message ID.
+
+        This is useful if you want to work with a message and only have its ID without
+        doing an unnecessary API call.
+
+        .. versionadded:: 2.10
+
+        Parameters
+        ----------
+        message_id: :class:`int`
+            The message ID to create a partial message for.
+
+        Returns
+        -------
+        :class:`PartialMessage`
+            The partial message object.
+        """
+        from .message import PartialMessage
+
+        return PartialMessage(channel=self, id=message_id)
+
     async def leave(self) -> None:
         """|coro|
 

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -2511,6 +2511,7 @@ class PartialMessage(Hashable):
     - :meth:`StageChannel.get_partial_message`
     - :meth:`Thread.get_partial_message`
     - :meth:`DMChannel.get_partial_message`
+    - :meth:`GroupChannel.get_partial_message`
     - :meth:`PartialMessageable.get_partial_message`
 
     Note that this class is trimmed down and has no rich attributes.
@@ -2560,6 +2561,7 @@ class PartialMessage(Hashable):
             ChannelType.text,
             ChannelType.news,
             ChannelType.private,
+            ChannelType.group,
             ChannelType.news_thread,
             ChannelType.public_thread,
             ChannelType.private_thread,
@@ -2567,7 +2569,7 @@ class PartialMessage(Hashable):
             ChannelType.stage_voice,
         ):
             raise TypeError(
-                f"Expected TextChannel, VoiceChannel, DMChannel, StageChannel, Thread, or PartialMessageable "
+                f"Expected TextChannel, VoiceChannel, StageChannel, Thread, DMChannel, GroupChannel, or PartialMessageable "
                 f"with a valid type, not {type(channel)!r} (type: {channel.type!r})"
             )
 


### PR DESCRIPTION
## Summary

Now that `Message.channel` can potentially be a `GroupChannel` (in user app interactions, see #1233), having `get_partial_message` available on all but one of the possible types is annoying.
This fixes that, adding `get_partial_message` to the common interface that all messageable channel types support, even if partial messages in this context may not be incredibly useful.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
