### PR TITLE
fix(state): prevent `DeprecationWarning` on shard reconnect

### DIFF
--- a/changelog/1267.bugfix.rst
+++ b/changelog/1267.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent :class:`py:DeprecationWarning` related to :attr:`Message.interaction` field on shard reconnect.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1446,8 +1446,8 @@ class Message(Hashable):
         # updated later in _update_member_references, after re-chunking
         if isinstance(self.author, Member):
             self.author.guild = new_guild
-        if self.interaction and isinstance(self.interaction.user, Member):
-            self.interaction.user.guild = new_guild
+        if self._interaction and isinstance(self._interaction.user, Member):
+            self._interaction.user.guild = new_guild
 
     @utils.cached_slot_property("_cs_raw_mentions")
     def raw_mentions(self) -> List[int]:

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -2433,10 +2433,10 @@ class AutoShardedConnectionState(ConnectionState):
             if new_author is not None and new_author is not msg.author:
                 msg.author = new_author
 
-            if msg.interaction is not None and isinstance(msg.interaction.user, Member):
-                new_author = msg.guild.get_member(msg.interaction.user.id)
-                if new_author is not None and new_author is not msg.interaction.user:
-                    msg.interaction.user = new_author
+            if msg._interaction is not None and isinstance(msg._interaction.user, Member):
+                new_author = msg.guild.get_member(msg._interaction.user.id)
+                if new_author is not None and new_author is not msg._interaction.user:
+                    msg._interaction.user = new_author
 
     async def chunker(
         self,


### PR DESCRIPTION
## Summary

Rebinding guild/member references on shard reconnect also updates `Message.interaction.user`; `interaction` is deprecated, so this should use the underlying `_interaction` instead to avoid copious amounts of `DeprecationWarning`s (one per cached message).

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
