### PR TITLE
faet: allow passing autocompleters that take a cog as first argument to commands.Param

### DIFF
--- a/changelog/1269.feature.rst
+++ b/changelog/1269.feature.rst
@@ -1,0 +1,1 @@
+Allow passing autocompleters that take a :class:`commands.Cog` as first argument to :class:`commands.Param`.

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -531,7 +531,11 @@ class ParamInfo:
         self.param_name: str = self.name
         self.converter = converter
         self.convert_default = convert_default
+
+        if autocomplete:
+            classify_autocompleter(autocomplete)
         self.autocomplete = autocomplete
+
         self.choices = choices or []
         self.type = type or str
         self.channel_types = channel_types or []
@@ -1121,7 +1125,7 @@ def Param(
     choices: Optional[Choices] = None,
     converter: Optional[Callable[[ApplicationCommandInteraction[BotT], Any], Any]] = None,
     convert_defaults: bool = False,
-    autocomplete: Optional[Callable[[ApplicationCommandInteraction[BotT], str], Any]] = None,
+    autocomplete: Optional[AnyAutocompleter] = None,
     channel_types: Optional[List[ChannelType]] = None,
     lt: Optional[float] = None,
     le: Optional[float] = None,


### PR DESCRIPTION
## Summary

Currently, `commands.Param` assumes the provided autocompleter does *not* take a cog and is typehinted as such, despite *somewhat* working with alternative autocomplete options such as a simple sequence.

This PR ensures cog-based autocompleters work with `commands.Param`.
The typehint is changed to work with any valid autocompleter (callback without cog, callback with cog, sequence), and callbacks are internally marked so that slash commands handle them correctly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
