### PR TITLE
feat(components): support premium buttons

### DIFF
--- a/changelog/1276.deprecate.rst
+++ b/changelog/1276.deprecate.rst
@@ -1,0 +1,1 @@
+:meth:`InteractionResponse.require_premium` is deprecated in favor of premium buttons (see :attr:`ui.Button.sku_id`).

--- a/changelog/1276.feature.rst
+++ b/changelog/1276.feature.rst
@@ -1,0 +1,1 @@
+Support premium buttons, using :attr:`ui.Button.sku_id`.

--- a/changelog/1276.feature.rst
+++ b/changelog/1276.feature.rst
@@ -1,1 +1,1 @@
-Support premium buttons, using :attr:`ui.Button.sku_id`.
+Support premium buttons using :attr:`ui.Button.sku_id`.

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -27,7 +27,7 @@ from .enums import (
     try_enum,
 )
 from .partial_emoji import PartialEmoji, _EmojiTag
-from .utils import MISSING, assert_never, get_slots
+from .utils import MISSING, _get_as_snowflake, assert_never, get_slots
 
 if TYPE_CHECKING:
     from typing_extensions import Self, TypeAlias
@@ -193,6 +193,8 @@ class Button(Component):
         The label of the button, if any.
     emoji: Optional[:class:`PartialEmoji`]
         The emoji of the button, if available.
+    sku_id: Optional[:class:`int`]
+        TODO
     """
 
     __slots__: Tuple[str, ...] = (
@@ -202,6 +204,7 @@ class Button(Component):
         "disabled",
         "label",
         "emoji",
+        "sku_id",
     )
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
@@ -218,6 +221,8 @@ class Button(Component):
             self.emoji = PartialEmoji.from_dict(data["emoji"])
         except KeyError:
             self.emoji = None
+
+        self.sku_id: Optional[int] = _get_as_snowflake(data, "sku_id")
 
     def to_dict(self) -> ButtonComponentPayload:
         payload: ButtonComponentPayload = {
@@ -237,6 +242,9 @@ class Button(Component):
 
         if self.emoji:
             payload["emoji"] = self.emoji.to_dict()
+
+        if self.sku_id:
+            payload["sku_id"] = self.sku_id
 
         return payload
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -184,7 +184,7 @@ class Button(Component):
         The style of the button.
     custom_id: Optional[:class:`str`]
         The ID of the button that gets received during an interaction.
-        If this button is for a URL, it does not have a custom ID.
+        If this button is for a URL or an SKU, it does not have a custom ID.
     url: Optional[:class:`str`]
         The URL this button sends you to.
     disabled: :class:`bool`
@@ -194,7 +194,10 @@ class Button(Component):
     emoji: Optional[:class:`PartialEmoji`]
         The emoji of the button, if available.
     sku_id: Optional[:class:`int`]
-        TODO
+        The ID of a purchasable SKU, for premium buttons.
+        Premium buttons additionally cannot have a ``label``, ``url``, or ``emoji``.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = (

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -1148,6 +1148,9 @@ class InteractionResponseType(Enum):
     See also :meth:`InteractionResponse.require_premium`.
 
     .. versionadded:: 2.10
+
+    .. deprecated:: 2.11
+        Use premium buttons (:class:`ui.Button` with :attr:`~ui.Button.sku_id`) instead.
     """
 
 

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -1226,6 +1226,11 @@ class ButtonStyle(Enum):
     """Represents a red button for a dangerous action."""
     link = 5
     """Represents a link button."""
+    premium = 6
+    """Represents a premium/SKU button.
+
+    .. versionadded:: 2.11
+    """
 
     # Aliases
     blurple = 1
@@ -1240,6 +1245,11 @@ class ButtonStyle(Enum):
     """An alias for :attr:`danger`."""
     url = 5
     """An alias for :attr:`link`."""
+    sku = 6
+    """An alias for :attr:`premium`.
+
+    .. versionadded:: 2.11
+    """
 
     def __int__(self) -> int:
         return self.value

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1485,6 +1485,7 @@ class InteractionResponse:
         if modal is not None:
             parent._state.store_modal(parent.author.id, modal)
 
+    @utils.deprecated("premium buttons")
     async def require_premium(self) -> None:
         """|coro|
 
@@ -1493,6 +1494,9 @@ class InteractionResponse:
         Only available for applications with monetization enabled.
 
         .. versionadded:: 2.10
+
+        .. deprecated:: 2.11
+            Use premium buttons (:class:`ui.Button` with :attr:`~ui.Button.sku_id`) instead.
 
         Example
         -------

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -11,7 +11,7 @@ from .emoji import PartialEmoji
 from .snowflake import Snowflake
 
 ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8]
-ButtonStyle = Literal[1, 2, 3, 4, 5]
+ButtonStyle = Literal[1, 2, 3, 4, 5, 6]
 TextInputStyle = Literal[1, 2]
 
 SelectDefaultValueType = Literal["user", "role", "channel"]
@@ -32,6 +32,7 @@ class ButtonComponent(TypedDict):
     custom_id: NotRequired[str]
     url: NotRequired[str]
     disabled: NotRequired[bool]
+    sku_id: NotRequired[Snowflake]
 
 
 class SelectOption(TypedDict):

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -127,12 +127,14 @@ class Button(Item[V_co]):
         row: Optional[int] = None,
     ) -> None:
         super().__init__()
-        if custom_id is not None and (url is not None or sku_id is not None):
-            raise TypeError("cannot mix both url/sku_id and custom_id with Button")
 
         self._provided_custom_id = custom_id is not None
-        if url is None and sku_id is None and custom_id is None:
-            custom_id = os.urandom(16).hex()
+        if url is None and sku_id is None:
+            if custom_id is None:
+                custom_id = os.urandom(16).hex()
+        else:
+            if custom_id is not None:
+                raise TypeError("cannot mix both url/sku_id and custom_id with Button")
 
         if url is not None:
             style = ButtonStyle.link

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -53,7 +53,7 @@ class Button(Item[V_co]):
         The style of the button.
     custom_id: Optional[:class:`str`]
         The ID of the button that gets received during an interaction.
-        If this button is for a URL, it does not have a custom ID.
+        If this button is for a URL or an SKU, it does not have a custom ID.
     url: Optional[:class:`str`]
         The URL this button sends you to.
     disabled: :class:`bool`
@@ -63,7 +63,10 @@ class Button(Item[V_co]):
     emoji: Optional[Union[:class:`.PartialEmoji`, :class:`.Emoji`, :class:`str`]]
         The emoji of the button, if available.
     sku_id: Optional[:class:`int`]
-        TODO
+        The ID of a purchasable SKU, for premium buttons.
+        Premium buttons additionally cannot have a ``label``, ``url``, or ``emoji``.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this button belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -180,7 +183,7 @@ class Button(Item[V_co]):
     def custom_id(self) -> Optional[str]:
         """Optional[:class:`str`]: The ID of the button that gets received during an interaction.
 
-        If this button is for a URL, it does not have a custom ID.
+        If this button is for a URL or an SKU, it does not have a custom ID.
         """
         return self._underlying.custom_id
 
@@ -241,7 +244,10 @@ class Button(Item[V_co]):
 
     @property
     def sku_id(self) -> Optional[int]:
-        """Optional[:class:`int`]: TODO"""
+        """Optional[:class:`int`]: The ID of a purchasable SKU, for premium buttons.
+
+        .. versionadded:: 2.11
+        """
         return self._underlying.sku_id
 
     @sku_id.setter
@@ -308,11 +314,10 @@ def button(
 
     .. note::
 
-        Buttons with a URL cannot be created with this function.
-        Consider creating a :class:`Button` manually instead.
-        This is because buttons with a URL do not have a callback
-        associated with them since Discord does not do any processing
-        with it.
+        Link/Premium buttons cannot be created with this function,
+        since these buttons do not have a callback associated with them.
+        Consider creating a :class:`Button` manually instead, and adding it
+        using :meth:`View.add_item`.
 
     Parameters
     ----------

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -477,8 +477,9 @@ class View:
     def is_persistent(self) -> bool:
         """Whether the view is set up as persistent.
 
-        A persistent view has all their components with a set ``custom_id`` and
-        a :attr:`timeout` set to ``None``.
+        A persistent view only has components with a set ``custom_id``
+        (or non-interactive components such as :attr:`~.ButtonStyle.link` or :attr:`~.ButtonStyle.premium` buttons),
+        and a :attr:`timeout` set to ``None``.
 
         :return type: :class:`bool`
         """

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -32,8 +32,9 @@ from ..components import (
     UserSelectMenu as UserSelectComponent,
     _component_factory,
 )
-from ..enums import ComponentType, try_enum_to_int
+from ..enums import try_enum_to_int
 from ..utils import assert_never
+from .button import Button
 from .item import Item
 
 __all__ = ("View",)
@@ -424,21 +425,24 @@ class View:
             try:
                 older = old_state[(component.type.value, component.custom_id)]  # type: ignore
             except (KeyError, AttributeError):
-                # workaround for url buttons, since they're not part of `old_state`
+                # workaround for non-interactive buttons, since they're not part of `old_state`
                 if isinstance(component, ButtonComponent):
                     for child in self.children:
+                        if not isinstance(child, Button):
+                            continue
+                        # try finding the corresponding child in this view based on other attributes
                         if (
-                            child.type is ComponentType.button
-                            and child.label == component.label  # type: ignore
-                            and child.url == component.url  # type: ignore
-                        ):
+                            (child.label and child.label == component.label)
+                            and (child.url and child.url == component.url)
+                        ) or (child.sku_id and child.sku_id == component.sku_id):
                             older = child
                             break
 
             if older:
-                older.refresh_component(component)
+                older.refresh_component(component)  # type: ignore  # this is fine, pyright is trying to be smart
                 children.append(older)
             else:
+                # fallback, should not happen as long as implementation covers all cases
                 children.append(_component_to_item(component))
 
         self.children = children

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -413,7 +413,7 @@ class View:
         )
 
     def refresh(self, components: List[ActionRowComponent[MessageComponent]]) -> None:
-        # TODO: this is pretty hacky at the moment
+        # TODO: this is pretty hacky at the moment, see https://github.com/DisnakeDev/disnake/commit/9384a72acb8c515b13a600592121357e165368da
         old_state: Dict[Tuple[int, str], Item] = {
             (item.type.value, item.custom_id): item  # type: ignore
             for item in self.children


### PR DESCRIPTION
## Summary

This adds support for premium buttons via `ButtonStyle.premium` and `ui.Button.sku_id`, and deprecates `InteractionResponse.require_premium`[^1].

https://github.com/discord/discord-api-docs/commit/4853fbc9ba8df174fc8bf1abbe8a19bc8f14cd1c

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

[^1]: Looks like this response type does not work at all anymore, contrary to the documentation and changelog, which claim "This will continue to function but may be eventually unsupported.". This makes it already a breaking change on Discord's end, so no point in making it even more breaking here. Still, it could honestly just be removed.