### PR TITLE
fix(commands): retrieve localization key for subcommand groups from docstring

### DIFF
--- a/changelog/1285.bugfix.rst
+++ b/changelog/1285.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Fix extracting localization key for :meth:`~ext.commands.InvokableSlashCommand.sub_command_group`\s from docstring, to be more consistent with top-level slash commands and sub commands.

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -172,8 +172,13 @@ class SubCommandGroup(InvokableApplicationCommand):
         super().__init__(func, name=name_loc.string, **kwargs)
         self.parent: InvokableSlashCommand = parent
         self.children: Dict[str, SubCommand] = {}
+
+        # while subcommand groups don't have a description, parse the docstring regardless to
+        # retrieve the localization key, if any
+        docstring = utils.parse_docstring(func)
+
         self.option = Option(
-            name=name_loc._upgrade(self.name),
+            name=name_loc._upgrade(self.name, key=docstring["localization_key_name"]),
             description="-",
             type=OptionType.sub_command_group,
             options=[],


### PR DESCRIPTION
## Summary

While the docstring of subcommand groups is largely useless (as descriptions of subcommand groups are not exposed in the UI anywhere), it should still be parsed to retrieve [localization key](https://docs.disnake.dev/en/stable/ext/commands/slash_commands.html#localizations) for the group name, if any.

see also: https://canary.discord.com/channels/808030843078836254/1337797831347671122

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
