### PR TITLE
fix(tasks): support `change_interval` before first loop run

### DIFF
--- a/changelog/1290.bugfix.rst
+++ b/changelog/1290.bugfix.rst
@@ -1,0 +1,1 @@
+|tasks| Correctly handle :meth:`Loop.change_interval <ext.tasks.Loop.change_interval>` when called from :meth:`~ext.tasks.Loop.before_loop` or through other means before initial loop run.

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -689,7 +689,9 @@ class Loop(Generic[LF]):
             self._time = self._get_time_parameter(time)
             self._sleep = self._seconds = self._minutes = self._hours = MISSING
 
-        if self.is_running():
+        # `_last_iteration` can be missing if `change_interval` gets called in `before_loop` or
+        # before the event loop ticks after `start()`
+        if self.is_running() and self._last_iteration is not MISSING:
             if self._time is not MISSING:
                 # prepare the next time index starting from after the last iteration
                 self._prepare_time_index(now=self._last_iteration)


### PR DESCRIPTION
## Summary

Fixes #1290.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
