### PR TITLE
feat: components v2

### DIFF
--- a/changelog/1294.feature.rst
+++ b/changelog/1294.feature.rst
@@ -4,11 +4,11 @@ Add support for :ddocs:`components v2 <components/reference>` (`example <https:/
     - :class:`ui.Section`: Displays an accessory (:class:`ui.Thumbnail` or :class:`ui.Button`) alongside some text.
     - :class:`ui.TextDisplay`: Text component, similar to the ``content`` field of messages.
     - :class:`ui.MediaGallery`: A gallery/mosaic of up to 10 :class:`MediaGalleryItem`\s.
-    - :class:`ui.File`: Display an uploaded file as an attachment
+    - :class:`ui.File`: Display an uploaded file as an attachment.
     - :class:`ui.Separator`: A spacer/separator adding vertical padding.
     - :class:`ui.Container`: Contains other components, visually similar to :class:`Embed`\s.
     - Each component has a corresponding new :class:`ComponentType`.
 - New :attr:`MessageFlags.is_components_v2` flag. This is set automatically when sending v2 components, and cannot be reverted once set.
 - New :func:`ui.walk_components` and :func:`ui.components_from_message` utility functions.
 - All ``ui.*`` components now inherit from a common :class:`ui.UIComponent` base class.
-- Components now have an :attr:`~UIComponent.id` attribute, which is a unique (per-message) optional numeric identifier.
+- Components now have an :attr:`~ui.UIComponent.id` attribute, which is a unique (per-message) optional numeric identifier.

--- a/changelog/1294.feature.rst
+++ b/changelog/1294.feature.rst
@@ -1,1 +1,14 @@
-TODO.
+Add support for :ddocs:`components v2 <components/reference>` (`example <https://github.com/DisnakeDev/disnake/blob/master/examples/components_v2.py>`_):
+- These components allow you to have more control over the layout of your messages, and are used instead of the classic ``content`` and ``embeds`` fields.
+- New top-level components:
+    - :class:`ui.Section`: Displays an accessory (:class:`ui.Thumbnail` or :class:`ui.Button`) alongside some text.
+    - :class:`ui.TextDisplay`: Text component, similar to the ``content`` field of messages.
+    - :class:`ui.MediaGallery`: A gallery/mosaic of up to 10 :class:`MediaGalleryItem`\s.
+    - :class:`ui.File`: Display an uploaded file as an attachment
+    - :class:`ui.Separator`: A spacer/separator adding vertical padding.
+    - :class:`ui.Container`: Contains other components, visually similar to :class:`Embed`\s.
+    - Each component has a corresponding new :class:`ComponentType`.
+- New :attr:`MessageFlags.is_components_v2` flag. This is set automatically when sending v2 components, and cannot be reverted once set.
+- New :func:`ui.walk_components` and :func:`ui.components_from_message` utility functions.
+- All ``ui.*`` components now inherit from a common :class:`ui.UIComponent` base class.
+- Components now have an :attr:`~UIComponent.id` attribute, which is a unique (per-message) optional numeric identifier.

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1614,6 +1614,11 @@ class Messageable:
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~.MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content``, ``embeds``, ``stickers``, and ``poll`` fields.
+
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This hides
             all the embeds from the UI if set to ``True``.
@@ -1648,7 +1653,8 @@ class Messageable:
             or the ``reference`` object is not a :class:`.Message`,
             :class:`.MessageReference` or :class:`.PartialMessage`.
         ValueError
-            The ``files`` or ``embeds`` list is too large.
+            The ``files`` or ``embeds`` list is too large, or
+            you tried to send v2 components together with ``content``, ``embeds``, ``stickers``, or ``poll``.
 
         Returns
         -------

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1627,8 +1627,8 @@ class Messageable:
 
         flags: :class:`.MessageFlags`
             The flags to set for this message.
-            Only :attr:`~.MessageFlags.suppress_embeds` and :attr:`~.MessageFlags.suppress_notifications`
-            are supported.
+            Only :attr:`~.MessageFlags.suppress_embeds`, :attr:`~.MessageFlags.suppress_notifications`,
+            and :attr:`~.MessageFlags.is_components_v2` are supported.
 
             If parameter ``suppress_embeds`` is provided,
             that will override the setting of :attr:`.MessageFlags.suppress_embeds`.

--- a/disnake/asset.py
+++ b/disnake/asset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import os
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Tuple, Union
 
 import yarl
 
@@ -33,59 +33,47 @@ VALID_ASSET_FORMATS = VALID_STATIC_FORMATS | {"gif"}
 MISSING = utils.MISSING
 
 
-class ResourceMixin:
-    _resource_url_attr: ClassVar[str]
-
+class AssetMixin:
+    url: str
     _state: Optional[AnyState]
 
     __slots__: Tuple[str, ...] = ("_state",)
 
-    def __init_subclass__(cls, url_attr: Optional[str] = None) -> None:
-        # either this subclass has a `url_attr`, or a parent class already should
-        if url_attr:
-            cls._resource_url_attr = url_attr
-        elif not hasattr(cls, "_resource_url_attr"):
-            raise RuntimeError("ResourceMixin subclass must specify `url_attr`")
-
-    @property
-    def _resource_url(self) -> str:
-        return getattr(self, self._resource_url_attr)
-
     async def read(self) -> bytes:
         """|coro|
 
-        Retrieves the content of this resource as a :class:`bytes` object.
+        Retrieves the content of this asset as a :class:`bytes` object.
 
         Raises
         ------
         DiscordException
             There was no internal connection state.
         HTTPException
-            Downloading the resource failed.
+            Downloading the asset failed.
         NotFound
-            The resource was deleted.
+            The asset was deleted.
 
         Returns
         -------
         :class:`bytes`
-            The content of the resource.
+            The content of the asset.
         """
         if self._state is None:
             raise DiscordException("Invalid state (no ConnectionState provided)")
 
-        return await self._state.http.get_from_cdn(self._resource_url)
+        return await self._state.http.get_from_cdn(self.url)
 
     async def save(
         self, fp: Union[str, bytes, os.PathLike, io.BufferedIOBase], *, seek_begin: bool = True
     ) -> int:
         """|coro|
 
-        Saves this resource into a file-like object.
+        Saves this asset into a file-like object.
 
         Parameters
         ----------
         fp: Union[:class:`io.BufferedIOBase`, :class:`os.PathLike`]
-            The file-like object to save this resource to or the filename
+            The file-like object to save this asset to or the filename
             to use. If a filename is passed then a file is created with that
             filename and used instead.
         seek_begin: :class:`bool`
@@ -97,9 +85,9 @@ class ResourceMixin:
         DiscordException
             There was no internal connection state.
         HTTPException
-            Downloading the resource failed.
+            Downloading the asset failed.
         NotFound
-            The resource was deleted.
+            The asset was deleted.
 
         Returns
         -------
@@ -125,7 +113,7 @@ class ResourceMixin:
     ) -> File:
         """|coro|
 
-        Converts the resource into a :class:`File` suitable for sending via
+        Converts the asset into a :class:`File` suitable for sending via
         :meth:`abc.Messageable.send`.
 
         .. versionadded:: 2.5
@@ -139,30 +127,30 @@ class ResourceMixin:
             Whether the file is a spoiler.
         filename: Optional[:class:`str`]
             The filename to display when uploading to Discord. If this is not given, it defaults to
-            the name of the resource's URL.
+            the name of the asset's URL.
         description: Optional[:class:`str`]
             The file's description.
 
         Raises
         ------
         DiscordException
-            The resource does not have an associated state.
+            The asset does not have an associated state.
         HTTPException
-            Downloading the resource failed.
+            Downloading the asset failed.
         NotFound
-            The resource was deleted.
+            The asset was deleted.
         TypeError
-            The resource is a unicode emoji or a sticker with lottie type.
+            The asset is a unicode emoji or a sticker with lottie type.
 
         Returns
         -------
         :class:`File`
-            The resource as a file suitable for sending.
+            The asset as a file suitable for sending.
         """
         data = await self.read()
 
         if not filename:
-            filename = yarl.URL(self._resource_url).name
+            filename = yarl.URL(self.url).name
             # if the filename doesn't have an extension (e.g. widget member avatars),
             # try to infer it from the data
             if not os.path.splitext(filename)[1]:
@@ -171,10 +159,6 @@ class ResourceMixin:
                     filename += ext
 
         return File(io.BytesIO(data), filename=filename, spoiler=spoiler, description=description)
-
-
-class AssetMixin(ResourceMixin, url_attr="url"):
-    url: str
 
 
 class Asset(AssetMixin):

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -3618,7 +3618,8 @@ class ThreadOnlyGuildChannel(disnake.abc.GuildChannel, Hashable):
             all the embeds from the UI if set to ``True``.
         flags: :class:`MessageFlags`
             The flags to set for this message.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameter ``suppress_embeds`` is provided,
             that will override the setting of :attr:`MessageFlags.suppress_embeds`.

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -3643,6 +3643,12 @@ class ThreadOnlyGuildChannel(disnake.abc.GuildChannel, Hashable):
             A Discord UI View to add to the message. This cannot be mixed with ``components``.
         components: |components_type|
             A list of components to include in the message. This cannot be mixed with ``view``.
+
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content``, ``embeds``, and ``stickers`` fields.
+
         reason: Optional[:class:`str`]
             The reason for creating the thread. Shows up on the audit log.
 
@@ -3655,11 +3661,11 @@ class ThreadOnlyGuildChannel(disnake.abc.GuildChannel, Hashable):
         TypeError
             Specified both ``file`` and ``files``,
             or you specified both ``embed`` and ``embeds``,
-            or you specified both ``view`` and ``components``.
+            or you specified both ``view`` and ``components``,
             or you have passed an object that is not :class:`File` to ``file`` or ``files``.
         ValueError
-            Specified more than 10 embeds,
-            or more than 10 files.
+            Specified more than 10 embeds, or more than 10 files, or
+            you tried to send v2 components together with ``content``, ``embeds``, or ``stickers``.
 
         Returns
         -------

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1205,7 +1205,7 @@ class Separator(Component):
         Whether the separator should be visible, instead of just being vertical padding/spacing.
         Defaults to ``True``.
     spacing: :class:`SeparatorSpacingSize`
-        The size of the separator.
+        The size of the separator padding.
     """
 
     __slots__: Tuple[str, ...] = ("divider", "spacing")
@@ -1217,7 +1217,6 @@ class Separator(Component):
         self.id = data.get("id", 0)
 
         self.divider: bool = data.get("divider", True)
-        # TODO: `size` instead of `spacing`?
         self.spacing: SeparatorSpacingSize = try_enum(SeparatorSpacingSize, data.get("spacing", 1))
 
     def to_dict(self) -> SeparatorComponentPayload:

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1022,8 +1022,9 @@ class Thumbnail(Component):
 
     Attributes
     ----------
-    media: Any
-        n/a
+    media: :class:`UnfurledMediaItem`
+        The media item to display. Can be an arbitrary URL or attachment
+        reference (``attachment://<filename>``).
     description: Optional[:class:`str`]
         The thumbnail's description ("alt text"), if any.
     spoiler: :class:`bool`
@@ -1165,8 +1166,9 @@ class FileComponent(Component):
 
     Attributes
     ----------
-    file: Any
-        n/a
+    file: :class:`UnfurledMediaItem`
+        The file to display. This **only** supports attachment references (i.e.
+        using the ``attachment://<filename>`` syntax), not arbitrary URLs.
     spoiler: :class:`bool`
         Whether the file is marked as a spoiler. Defaults to ``False``.
     """

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -144,17 +144,21 @@ MessageTopLevelComponent = Union[MessageTopLevelComponentV1, MessageTopLevelComp
 
 
 class Component:
-    """Represents a Discord Bot UI Kit Component.
+    """Represents the base component that all other components inherit from.
 
-    Currently, the only components supported by Discord are:
+    The components supported by Discord are:
 
     - :class:`ActionRow`
     - :class:`Button`
     - subtypes of :class:`BaseSelectMenu` (:class:`ChannelSelectMenu`, :class:`MentionableSelectMenu`, :class:`RoleSelectMenu`, :class:`StringSelectMenu`, :class:`UserSelectMenu`)
     - :class:`TextInput`
-
-    ..
-        TODO: add cv2 components to list
+    - :class:`Section`
+    - :class:`TextDisplay`
+    - :class:`Thumbnail`
+    - :class:`MediaGallery`
+    - :class:`FileComponent`
+    - :class:`Separator`
+    - :class:`Container`
 
     This class is abstract and cannot be instantiated.
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -69,7 +69,8 @@ if TYPE_CHECKING:
         UserSelectMenu as UserSelectMenuPayload,
     )
 
-    MediaItemInput = Union[str, "AssetMixin", "Attachment", "UnfurledMediaItem"]
+    LocalMediaItemInput = Union[str, "UnfurledMediaItem"]
+    MediaItemInput = Union[LocalMediaItemInput, "AssetMixin", "Attachment"]
 
 __all__ = (
     "Component",

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1265,7 +1265,7 @@ def _walk_internal(component: Component, seen: Set[Component]) -> Iterator[Compo
 
 # yields *all* components recursively
 def _walk_all_components(components: Sequence[Component]) -> Iterator[Component]:
-    seen = set()
+    seen: Set[Component] = set()
     for item in components:
         yield from _walk_internal(item, seen)
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -9,13 +9,10 @@ from typing import (
     Dict,
     Final,
     Generic,
-    Iterator,
     List,
     Literal,
     Mapping,
     Optional,
-    Sequence,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -1321,35 +1318,6 @@ VALID_ACTION_ROW_MESSAGE_COMPONENT_TYPES: Final = (
     MentionableSelectMenu,
     ChannelSelectMenu,
 )
-
-
-def _walk_internal(component: Component, seen: Set[Component]) -> Iterator[Component]:
-    if component in seen:
-        # prevent infinite recursion if anyone manages to nest a component in itself
-        return
-    # add current component, while also creating a copy to allow reusing a component multiple times,
-    # as long as it's not within itself
-    seen = {*seen, component}
-
-    yield component
-
-    if isinstance(component, ActionRow):
-        for item in component.children:
-            yield from _walk_internal(item, seen)
-    elif isinstance(component, Section):
-        yield from _walk_internal(component.accessory, seen)
-        for item in component.components:
-            yield from _walk_internal(item, seen)
-    elif isinstance(component, Container):
-        for item in component.components:
-            yield from _walk_internal(item, seen)
-
-
-# yields *all* components recursively
-def _walk_all_components(components: Sequence[Component]) -> Iterator[Component]:
-    seen: Set[Component] = set()
-    for item in components:
-        yield from _walk_internal(item, seen)
 
 
 def handle_media_item_input(value: MediaItemInput) -> UnfurledMediaItem:

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1351,9 +1351,8 @@ def handle_media_item_input(value: MediaItemInput) -> UnfurledMediaItem:
     if isinstance(value, (AssetMixin, Attachment)):
         return UnfurledMediaItem(value.url)
 
-    # TODO: raise proper exception (?)
     assert_never(value)
-    return value
+    raise TypeError(f"{type(value).__name__} cannot be converted to UnfurledMediaItem")
 
 
 C = TypeVar("C", bound="Component")

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -69,9 +69,6 @@ if TYPE_CHECKING:
         UserSelectMenu as UserSelectMenuPayload,
     )
 
-    LocalMediaItemInput = Union[str, "UnfurledMediaItem"]
-    MediaItemInput = Union[LocalMediaItemInput, "AssetMixin", "Attachment"]
-
 __all__ = (
     "Component",
     "ActionRow",
@@ -96,6 +93,11 @@ __all__ = (
     "Separator",
     "Container",
 )
+
+# miscellaneous components-related type aliases
+
+LocalMediaItemInput = Union[str, "UnfurledMediaItem"]
+MediaItemInput = Union[LocalMediaItemInput, "AssetMixin", "Attachment"]
 
 AnySelectMenu = Union[
     "StringSelectMenu",

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -27,7 +27,7 @@ from .enums import (
     ChannelType,
     ComponentType,
     SelectDefaultValueType,
-    SeparatorSpacingSize,
+    SeparatorSpacing,
     TextInputStyle,
     try_enum,
 )
@@ -1297,7 +1297,7 @@ class Separator(Component):
     divider: :class:`bool`
         Whether the separator should be visible, instead of just being vertical padding/spacing.
         Defaults to ``True``.
-    spacing: :class:`SeparatorSpacingSize`
+    spacing: :class:`SeparatorSpacing`
         The size of the separator padding.
     id: :class:`int`
         The numeric identifier for the component.
@@ -1316,7 +1316,7 @@ class Separator(Component):
         self.id = data.get("id", 0)
 
         self.divider: bool = data.get("divider", True)
-        self.spacing: SeparatorSpacingSize = try_enum(SeparatorSpacingSize, data.get("spacing", 1))
+        self.spacing: SeparatorSpacing = try_enum(SeparatorSpacing, data.get("spacing", 1))
 
     def to_dict(self) -> SeparatorComponentPayload:
         return {

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -187,6 +187,10 @@ class Component:
     __slots__: Tuple[str, ...] = ("type", "id")
 
     __repr_info__: ClassVar[Tuple[str, ...]]
+
+    # subclasses are expected to overwrite this if they're only usable with `MessageFlags.is_components_v2`
+    is_v2: ClassVar[bool] = False
+
     type: ComponentType
     id: int
 
@@ -952,6 +956,8 @@ class Section(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
+    is_v2 = True
+
     def __init__(self, data: SectionComponentPayload) -> None:
         self.type: Literal[ComponentType.section] = ComponentType.section
         self.id = data.get("id", 0)
@@ -996,6 +1002,8 @@ class TextDisplay(Component):
     __slots__: Tuple[str, ...] = ("content",)
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
+
+    is_v2 = True
 
     def __init__(self, data: TextDisplayComponentPayload) -> None:
         self.type: Literal[ComponentType.text_display] = ComponentType.text_display
@@ -1107,6 +1115,8 @@ class Thumbnail(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
+    is_v2 = True
+
     def __init__(self, data: ThumbnailComponentPayload) -> None:
         self.type: Literal[ComponentType.thumbnail] = ComponentType.thumbnail
         self.id = data.get("id", 0)
@@ -1155,6 +1165,8 @@ class MediaGallery(Component):
     __slots__: Tuple[str, ...] = ("items",)
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
+
+    is_v2 = True
 
     def __init__(self, data: MediaGalleryComponentPayload) -> None:
         self.type: Literal[ComponentType.media_gallery] = ComponentType.media_gallery
@@ -1262,6 +1274,8 @@ class FileComponent(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
+    is_v2 = True
+
     def __init__(self, data: FileComponentPayload) -> None:
         self.type: Literal[ComponentType.file] = ComponentType.file
         self.id = data.get("id", 0)
@@ -1310,6 +1324,8 @@ class Separator(Component):
     __slots__: Tuple[str, ...] = ("divider", "spacing")
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
+
+    is_v2 = True
 
     def __init__(self, data: SeparatorComponentPayload) -> None:
         self.type: Literal[ComponentType.separator] = ComponentType.separator
@@ -1361,6 +1377,8 @@ class Container(Component):
     )
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
+
+    is_v2 = True
 
     def __init__(self, data: ContainerComponentPayload) -> None:
         self.type: Literal[ComponentType.container] = ComponentType.container

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1171,9 +1171,15 @@ class FileComponent(Component):
         using the ``attachment://<filename>`` syntax), not arbitrary URLs.
     spoiler: :class:`bool`
         Whether the file is marked as a spoiler. Defaults to ``False``.
+    name: Optional[:class:`str`]
+        The name of the file.
+        This is available in objects from the API, and ignored when sending.
+    size: Optional[:class:`int`]
+        The size of the file.
+        This is available in objects from the API, and ignored when sending.
     """
 
-    __slots__: Tuple[str, ...] = ("file", "spoiler")
+    __slots__: Tuple[str, ...] = ("file", "spoiler", "name", "size")
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
@@ -1183,6 +1189,9 @@ class FileComponent(Component):
 
         self.file: UnfurledMediaItem = UnfurledMediaItem.from_dict(data["file"])
         self.spoiler: bool = data.get("spoiler", False)
+
+        self.name: Optional[str] = data.get("name")
+        self.size: Optional[int] = data.get("size")
 
     def to_dict(self) -> FileComponentPayload:
         return {

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -118,7 +118,6 @@ ActionRowModalComponent: TypeAlias = "TextInput"
 
 # any child component type of action rows
 ActionRowChildComponent = Union[ActionRowMessageComponent, ActionRowModalComponent]
-# TODO: this might have to be covariant
 ActionRowChildComponentT = TypeVar("ActionRowChildComponentT", bound=ActionRowChildComponent)
 
 # valid `Section.accessory` types
@@ -1464,6 +1463,7 @@ COMPONENT_LOOKUP: Mapping[ComponentTypeLiteral, Type[Component]] = {
 
 
 # NOTE: The type param is purely for type-checking, it has no implications on runtime behavior.
+# FIXME: could be improved with https://peps.python.org/pep-0747/
 def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> C:
     component_type = data["type"]
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1250,29 +1250,29 @@ class Container(Component):
 
     Attributes
     ----------
-    spoiler: :class:`bool`
-        Whether the container is marked as a spoiler. Defaults to ``False``.
     components: List[Union[:class:`ActionRow`, :class:`Section`, :class:`TextDisplay`, :class:`MediaGallery`, :class:`FileComponent`, :class:`Separator`]]
         The components in this container.
+    accent_colour: Optional[:class:`Colour`]
+        The accent colour of the container. An alias exists under ``accent_color``.
+    spoiler: :class:`bool`
+        Whether the container is marked as a spoiler. Defaults to ``False``.
     """
 
     __slots__: Tuple[str, ...] = (
-        "_accent_colour",
-        "spoiler",
-        "components",
-    )
-
-    __repr_info__: ClassVar[Tuple[str, ...]] = (
         "accent_colour",
         "spoiler",
         "components",
     )
 
+    __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
+
     def __init__(self, data: ContainerComponentPayload) -> None:
         self.type: Literal[ComponentType.container] = ComponentType.container
         self.id = data.get("id", 0)
 
-        self._accent_colour: Optional[int] = data.get("accent_color")
+        self.accent_colour: Optional[Colour] = (
+            Colour(accent_color) if (accent_color := data.get("accent_color")) is not None else None
+        )
         self.spoiler: bool = data.get("spoiler", False)
 
         components = [_component_factory(d) for d in data.get("components", [])]
@@ -1286,21 +1286,14 @@ class Container(Component):
             "components": [child.to_dict() for child in self.components],
         }
 
-        if self._accent_colour is not None:
-            payload["accent_color"] = self._accent_colour
+        if self.accent_colour is not None:
+            payload["accent_color"] = self.accent_colour.value
 
         return payload
 
     @property
-    def accent_colour(self) -> Optional[Colour]:
-        """Optional[:class:`Colour`]: Returns the accent colour of the container.
-        An alias exists under ``accent_color``.
-        """
-        return Colour(self._accent_colour) if self._accent_colour is not None else None
-
-    @property
     def accent_color(self) -> Optional[Colour]:
-        """Optional[:class:`Colour`]: Returns the accent color of the container.
+        """Optional[:class:`Colour`]: The accent color of the container.
         An alias exists under ``accent_colour``.
         """
         return self.accent_colour

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
     from .emoji import Emoji
     from .message import Attachment
+    from .state import ConnectionState
     from .types.components import (
         ActionRow as ActionRowPayload,
         AnySelectMenu as AnySelectMenuPayload,
@@ -229,11 +230,11 @@ class ActionRow(Component, Generic[ActionRowChildComponentT]):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: ActionRowPayload) -> None:
+    def __init__(self, data: ActionRowPayload, *, state: Optional[ConnectionState] = None) -> None:
         self.type: Literal[ComponentType.action_row] = ComponentType.action_row
         self.id = data.get("id", 0)
 
-        children = [_component_factory(d) for d in data.get("components", [])]
+        children = [_component_factory(d, state=state) for d in data.get("components", [])]
         self.children: List[ActionRowChildComponentT] = children  # type: ignore
 
     def to_dict(self) -> ActionRowPayload:
@@ -290,7 +291,9 @@ class Button(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: ButtonComponentPayload) -> None:
+    def __init__(
+        self, data: ButtonComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.button] = ComponentType.button
         self.id = data.get("id", 0)
 
@@ -302,6 +305,7 @@ class Button(Component):
         self.emoji: Optional[PartialEmoji]
         try:
             self.emoji = PartialEmoji.from_dict(data["emoji"])
+            self.emoji._state = state
         except KeyError:
             self.emoji = None
 
@@ -388,7 +392,9 @@ class BaseSelectMenu(Component):
     # n.b: ideally this would be `BaseSelectMenuPayload`,
     # but pyright made TypedDict keys invariant and doesn't
     # fully support readonly items yet (which would help avoid this)
-    def __init__(self, data: AnySelectMenuPayload) -> None:
+    def __init__(
+        self, data: AnySelectMenuPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         component_type = try_enum(ComponentType, data["type"])
         self.type: SelectMenuType = component_type  # type: ignore
         self.id = data.get("id", 0)
@@ -456,8 +462,10 @@ class StringSelectMenu(BaseSelectMenu):
     __repr_info__: ClassVar[Tuple[str, ...]] = BaseSelectMenu.__repr_info__ + __slots__
     type: Literal[ComponentType.string_select]
 
-    def __init__(self, data: StringSelectMenuPayload) -> None:
-        super().__init__(data)
+    def __init__(
+        self, data: StringSelectMenuPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
+        super().__init__(data, state=state)
         self.options: List[SelectOption] = [
             SelectOption.from_dict(option) for option in data.get("options", [])
         ]
@@ -629,8 +637,10 @@ class ChannelSelectMenu(BaseSelectMenu):
     __repr_info__: ClassVar[Tuple[str, ...]] = BaseSelectMenu.__repr_info__ + __slots__
     type: Literal[ComponentType.channel_select]
 
-    def __init__(self, data: ChannelSelectMenuPayload) -> None:
-        super().__init__(data)
+    def __init__(
+        self, data: ChannelSelectMenuPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
+        super().__init__(data, state=state)
         # on the API side, an empty list is (currently) equivalent to no value
         channel_types = data.get("channel_types")
         self.channel_types: Optional[List[ChannelType]] = (
@@ -829,7 +839,7 @@ class TextInput(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: TextInputPayload) -> None:
+    def __init__(self, data: TextInputPayload, *, state: Optional[ConnectionState] = None) -> None:
         self.type: Literal[ComponentType.text_input] = ComponentType.text_input
         self.id = data.get("id", 0)
 
@@ -892,15 +902,18 @@ class Section(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: SectionComponentPayload) -> None:
+    def __init__(
+        self, data: SectionComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.section] = ComponentType.section
         self.id = data.get("id", 0)
 
-        accessory = _component_factory(data["accessory"])
+        accessory = _component_factory(data["accessory"], state=state)
         self.accessory: SectionAccessoryComponent = accessory  # type: ignore
 
         self.components: List[SectionChildComponent] = [
-            _component_factory(d, type=SectionChildComponent) for d in data.get("components", [])
+            _component_factory(d, state=state, type=SectionChildComponent)
+            for d in data.get("components", [])
         ]
 
     def to_dict(self) -> SectionComponentPayload:
@@ -931,7 +944,9 @@ class TextDisplay(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: TextDisplayComponentPayload) -> None:
+    def __init__(
+        self, data: TextDisplayComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.text_display] = ComponentType.text_display
         self.id = data.get("id", 0)
 
@@ -987,15 +1002,16 @@ class UnfurledMediaItem(AssetMixin):
         self.content_type: Optional[str] = None
         self.attachment_id: Optional[int] = None
 
-    # FIXME: when deserializing, try to attach _state for AssetMixin as well
     @classmethod
-    def from_dict(cls, data: UnfurledMediaItemPayload) -> Self:
+    def from_dict(cls, data: UnfurledMediaItemPayload, *, state: Optional[ConnectionState]) -> Self:
         self = cls(data["url"])
         self.proxy_url = data.get("proxy_url")
         self.height = _get_as_snowflake(data, "height")
         self.width = _get_as_snowflake(data, "width")
         self.content_type = data.get("content_type")
         self.attachment_id = _get_as_snowflake(data, "attachment_id")
+        # this may be missing, and is provided on a best-effort basis
+        self._state = state
         return self
 
     def to_dict(self) -> UnfurledMediaItemPayload:
@@ -1036,11 +1052,13 @@ class Thumbnail(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: ThumbnailComponentPayload) -> None:
+    def __init__(
+        self, data: ThumbnailComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.thumbnail] = ComponentType.thumbnail
         self.id = data.get("id", 0)
 
-        self.media: UnfurledMediaItem = UnfurledMediaItem.from_dict(data["media"])
+        self.media: UnfurledMediaItem = UnfurledMediaItem.from_dict(data["media"], state=state)
         self.description: Optional[str] = data.get("description")
         self.spoiler: bool = data.get("spoiler", False)
 
@@ -1079,11 +1097,15 @@ class MediaGallery(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: MediaGalleryComponentPayload) -> None:
+    def __init__(
+        self, data: MediaGalleryComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.media_gallery] = ComponentType.media_gallery
         self.id = data.get("id", 0)
 
-        self.items: List[MediaGalleryItem] = [MediaGalleryItem.from_dict(i) for i in data["items"]]
+        self.items: List[MediaGalleryItem] = [
+            MediaGalleryItem.from_dict(i, state=state) for i in data["items"]
+        ]
 
     def to_dict(self) -> MediaGalleryComponentPayload:
         return {
@@ -1126,11 +1148,10 @@ class MediaGalleryItem:
         self.description: Optional[str] = description
         self.spoiler: bool = spoiler
 
-    # FIXME: when deserializing, try to attach _state for `self.media` as well
     @classmethod
-    def from_dict(cls, data: MediaGalleryItemPayload) -> Self:
+    def from_dict(cls, data: MediaGalleryItemPayload, *, state: Optional[ConnectionState]) -> Self:
         return cls(
-            media=UnfurledMediaItem.from_dict(data["media"]),
+            media=UnfurledMediaItem.from_dict(data["media"], state=state),
             description=data.get("description"),
             spoiler=data.get("spoiler", False),
         )
@@ -1180,11 +1201,13 @@ class FileComponent(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: FileComponentPayload) -> None:
+    def __init__(
+        self, data: FileComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.file] = ComponentType.file
         self.id = data.get("id", 0)
 
-        self.file: UnfurledMediaItem = UnfurledMediaItem.from_dict(data["file"])
+        self.file: UnfurledMediaItem = UnfurledMediaItem.from_dict(data["file"], state=state)
         self.spoiler: bool = data.get("spoiler", False)
 
         self.name: Optional[str] = data.get("name")
@@ -1223,7 +1246,9 @@ class Separator(Component):
 
     __repr_info__: ClassVar[Tuple[str, ...]] = __slots__
 
-    def __init__(self, data: SeparatorComponentPayload) -> None:
+    def __init__(
+        self, data: SeparatorComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.separator] = ComponentType.separator
         self.id = data.get("id", 0)
 
@@ -1270,14 +1295,16 @@ class Container(Component):
         "components",
     )
 
-    def __init__(self, data: ContainerComponentPayload) -> None:
+    def __init__(
+        self, data: ContainerComponentPayload, *, state: Optional[ConnectionState] = None
+    ) -> None:
         self.type: Literal[ComponentType.container] = ComponentType.container
         self.id = data.get("id", 0)
 
         self._accent_colour: Optional[int] = data.get("accent_color")
         self.spoiler: bool = data.get("spoiler", False)
 
-        components = [_component_factory(d) for d in data.get("components", [])]
+        components = [_component_factory(d, state=state) for d in data.get("components", [])]
         self.components: List[ContainerChildComponent] = components  # type: ignore
 
     def to_dict(self) -> ContainerComponentPayload:
@@ -1359,7 +1386,12 @@ COMPONENT_LOOKUP: Mapping[ComponentTypeLiteral, Type[Component]] = {
 
 
 # NOTE: The type param is purely for type-checking, it has no implications on runtime behavior.
-def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> C:
+def _component_factory(
+    data: ComponentPayload,
+    *,
+    state: Optional[ConnectionState],
+    type: Type[C] = Component,
+) -> C:
     component_type = data["type"]
 
     try:
@@ -1369,7 +1401,7 @@ def _component_factory(data: ComponentPayload, *, type: Type[C] = Component) -> 
         as_enum = try_enum(ComponentType, component_type)
         return Component._raw_construct(type=as_enum)  # type: ignore
     else:
-        return component_cls(data)  # type: ignore
+        return component_cls(data, state=state)  # type: ignore
 
 
 # this is just a rebranded _component_factory, as a workaround to Python not supporting typescript-like mapped types
@@ -1377,6 +1409,8 @@ if TYPE_CHECKING:
 
     def _message_component_factory(
         data: MessageTopLevelComponentPayload,
+        *,
+        state: Optional[ConnectionState],
     ) -> MessageTopLevelComponent: ...
 
 else:

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -223,6 +223,12 @@ class ActionRow(Component, Generic[ActionRowChildComponentT]):
     ----------
     children: List[Union[:class:`Button`, :class:`BaseSelectMenu`, :class:`TextInput`]]
         The children components that this holds, if any.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("children",)
@@ -274,6 +280,12 @@ class Button(Component):
     sku_id: Optional[:class:`int`]
         The ID of a purchasable SKU, for premium buttons.
         Premium buttons additionally cannot have a ``label``, ``url``, or ``emoji``.
+
+        .. versionadded:: 2.11
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
 
         .. versionadded:: 2.11
     """
@@ -371,6 +383,12 @@ class BaseSelectMenu(Component):
         Only available for auto-populated select menus.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = (
@@ -449,6 +467,12 @@ class StringSelectMenu(BaseSelectMenu):
         Whether the select menu is disabled or not.
     options: List[:class:`SelectOption`]
         A list of options that can be selected in this select menu.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("options",)
@@ -499,6 +523,12 @@ class UserSelectMenu(BaseSelectMenu):
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ()
@@ -539,6 +569,12 @@ class RoleSelectMenu(BaseSelectMenu):
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ()
@@ -579,6 +615,12 @@ class MentionableSelectMenu(BaseSelectMenu):
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ()
@@ -622,6 +664,12 @@ class ChannelSelectMenu(BaseSelectMenu):
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("channel_types",)
@@ -814,6 +862,12 @@ class TextInput(Component):
         The minimum length of the text input.
     max_length: Optional[:class:`int`]
         The maximum length of the text input.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = (
@@ -886,6 +940,12 @@ class Section(Component):
         The accessory component displayed next to the section text.
     components: List[:class:`TextDisplay`]
         The text items in this section.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("accessory", "components")
@@ -925,6 +985,12 @@ class TextDisplay(Component):
     ----------
     content: :class:`str`
         The text displayed by this component.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("content",)
@@ -1025,6 +1091,12 @@ class Thumbnail(Component):
         The thumbnail's description ("alt text"), if any.
     spoiler: :class:`bool`
         Whether the thumbnail is marked as a spoiler. Defaults to ``False``.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = (
@@ -1072,6 +1144,12 @@ class MediaGallery(Component):
     ----------
     items: List[:class:`MediaGalleryItem`]
         The images in this gallery.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("items",)
@@ -1172,6 +1250,12 @@ class FileComponent(Component):
     size: Optional[:class:`int`]
         The size of the file.
         This is available in objects from the API, and ignored when sending.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("file", "spoiler", "name", "size")
@@ -1215,6 +1299,12 @@ class Separator(Component):
         Defaults to ``True``.
     spacing: :class:`SeparatorSpacingSize`
         The size of the separator padding.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = ("divider", "spacing")
@@ -1256,6 +1346,12 @@ class Container(Component):
         The accent colour of the container. An alias exists under ``accent_color``.
     spoiler: :class:`bool`
         Whether the container is marked as a spoiler. Defaults to ``False``.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
     """
 
     __slots__: Tuple[str, ...] = (

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1401,7 +1401,8 @@ def _component_factory(
         as_enum = try_enum(ComponentType, component_type)
         return Component._raw_construct(type=as_enum)  # type: ignore
     else:
-        return component_cls(data, state=state)  # type: ignore
+        # FIXME: pass state=state once `AssetMixin` can use `proxy_url`
+        return component_cls(data, state=None)  # type: ignore
 
 
 # this is just a rebranded _component_factory, as a workaround to Python not supporting typescript-like mapped types

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -175,7 +175,7 @@ class Component:
         The numeric identifier for the component.
         This is always present in components received from the API,
         and unique within a message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign sequential
+        If set to ``0`` (the default) when sending a component, the API will assign sequential
         identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -20,7 +20,7 @@ from typing import (
     cast,
 )
 
-from .asset import AssetMixin
+from .asset import AssetMixin, ResourceMixin
 from .colour import Colour
 from .enums import (
     ButtonStyle,
@@ -960,7 +960,7 @@ class TextDisplay(Component):
         }
 
 
-class UnfurledMediaItem(AssetMixin):
+class UnfurledMediaItem(ResourceMixin, url_attr="proxy_url"):
     """Represents an unfurled/resolved media item within a component.
 
     .. versionadded:: 2.11
@@ -1401,8 +1401,7 @@ def _component_factory(
         as_enum = try_enum(ComponentType, component_type)
         return Component._raw_construct(type=as_enum)  # type: ignore
     else:
-        # FIXME: pass state=state once `AssetMixin` can use `proxy_url`
-        return component_cls(data, state=None)  # type: ignore
+        return component_cls(data, state=state)  # type: ignore
 
 
 # this is just a rebranded _component_factory, as a workaround to Python not supporting typescript-like mapped types

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -76,7 +76,7 @@ __all__ = (
     "PollLayoutType",
     "VoiceChannelEffectAnimationType",
     "MessageReferenceType",
-    "SeparatorSpacingSize",
+    "SeparatorSpacing",
 )
 
 
@@ -2356,8 +2356,8 @@ class MessageReferenceType(Enum):
     """Reference used to point to a message at a point in time (forward)."""
 
 
-class SeparatorSpacingSize(Enum):
-    """Specifies the size of a :class:`Separator` component.
+class SeparatorSpacing(Enum):
+    """Specifies the size of a :class:`Separator` component's padding.
 
     .. versionadded:: 2.11
     """

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -708,6 +708,8 @@ class MessageFlags(BaseFlags):
 
         Messages with this flag will use specific components for content layout,
         instead of :attr:`~Message.content` and :attr:`~Message.embeds`.
+        Further details, limits, and example images can be found
+        in the :ddocs:`API documentation <components/reference>`.
 
         Note that once this flag is set on a message, it cannot be reverted.
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -709,6 +709,8 @@ class MessageFlags(BaseFlags):
         Messages with this flag will use specific components for content layout,
         instead of :attr:`~Message.content` and :attr:`~Message.embeds`.
 
+        Note that once this flag is set on a message, it cannot be reverted.
+
         .. versionadded:: 2.11
         """
         return 1 << 15

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -438,10 +438,7 @@ class HTTPClient:
             raise RuntimeError("Unreachable code in HTTP handling")
 
     async def get_from_cdn(self, url: str) -> bytes:
-        # `encoded=True` to prevent aiohttp from canonicalizing URLs and unescaping characters,
-        # which can break some urls (e.g. signed image proxy urls in components)
-        # https://github.com/aio-libs/aiohttp/issues/7393
-        async with self.__session.get(yarl.URL(url, encoded=True)) as resp:
+        async with self.__session.get(url) as resp:
             if resp.status == 200:
                 return await resp.read()
             elif resp.status == 404:

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -438,7 +438,10 @@ class HTTPClient:
             raise RuntimeError("Unreachable code in HTTP handling")
 
     async def get_from_cdn(self, url: str) -> bytes:
-        async with self.__session.get(url) as resp:
+        # `encoded=True` to prevent aiohttp from canonicalizing URLs and unescaping characters,
+        # which can break some urls (e.g. signed image proxy urls in components)
+        # https://github.com/aio-libs/aiohttp/issues/7393
+        async with self.__session.get(yarl.URL(url, encoded=True)) as resp:
             if resp.status == 200:
                 return await resp.read()
             elif resp.status == 404:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1325,10 +1325,9 @@ class InteractionResponse:
             else:
                 payload["components"] = []
 
-        flags = None  # FIXME: temporary, add `flags` parameter and add to payload
         # set cv2 flag automatically
         if is_v2:
-            flags = MessageFlags._from_value(0 if flags is None else flags.value)
+            flags = MessageFlags._from_value(0 if flags is MISSING else flags.value)
             flags.is_components_v2 = True
         # components v2 cannot be used with other content fields
         if flags and flags.is_components_v2 and (content or embeds):

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -499,6 +499,12 @@ class Interaction(Generic[ClientT]):
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content`` and ``embeds`` fields.
+                If the message previously had any of these fields set, you must set them to ``None``.
+
         poll: :class:`Poll`
             A poll. This can only be sent after a defer. If not used after a defer the
             discord API ignore the field.
@@ -543,9 +549,10 @@ class Interaction(Generic[ClientT]):
         Forbidden
             Edited a message that is not yours.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         ValueError
-            The length of ``embeds`` was invalid.
+            The length of ``embeds`` was invalid, or
+            you tried to send v2 components together with ``content`` or ``embeds``.
 
         Returns
         -------
@@ -727,6 +734,11 @@ class Interaction(Generic[ClientT]):
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content``, ``embeds``, and ``poll`` fields.
+
         ephemeral: :class:`bool`
             Whether the message should only be visible to the user who started the interaction.
             If a view is sent with an ephemeral message and it has no timeout set then the timeout
@@ -770,7 +782,8 @@ class Interaction(Generic[ClientT]):
         TypeError
             You specified both ``embed`` and ``embeds``.
         ValueError
-            The length of ``embeds`` was invalid.
+            The length of ``embeds`` was invalid, or
+            you tried to send v2 components together with ``content``, ``embeds``, or ``poll``.
         """
         if self.response._response_type is not None:
             sender = self.followup.send
@@ -995,6 +1008,11 @@ class InteractionResponse:
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content``, ``embeds``, and ``poll`` fields.
+
         tts: :class:`bool`
             Whether the message should be sent using text-to-speech.
         ephemeral: :class:`bool`
@@ -1041,7 +1059,8 @@ class InteractionResponse:
         TypeError
             You specified both ``embed`` and ``embeds``.
         ValueError
-            The length of ``embeds`` was invalid.
+            The length of ``embeds`` was invalid, or
+            you tried to send v2 components together with ``content``, ``embeds``, or ``poll``.
         InteractionResponded
             This interaction has already been responded to before.
         """
@@ -1225,6 +1244,12 @@ class InteractionResponse:
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content`` and ``embeds`` fields.
+                If the message previously had any of these fields set, you must set them to ``None``.
+
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
             Only :attr:`~MessageFlags.suppress_embeds` is supported.
@@ -1250,6 +1275,8 @@ class InteractionResponse:
             Editing the message failed.
         TypeError
             You specified both ``embed`` and ``embeds``.
+        ValueError
+            You tried to send v2 components together with ``content`` or ``embeds``.
         InteractionResponded
             This interaction has already been responded to before.
         """
@@ -1457,6 +1484,7 @@ class InteractionResponse:
             This cannot be mixed with the ``modal`` parameter.
         components: |components_type|
             The components to display in the modal. A maximum of 5.
+            Currently only supports :class:`ui.TextInput` (optionally inside :class:`ui.ActionRow`).
             This cannot be mixed with the ``modal`` parameter.
 
         Raises
@@ -1792,6 +1820,12 @@ class InteractionMessage(Message):
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content`` and ``embeds`` fields.
+                If the message previously had any of these fields set, you must set them to ``None``.
+
         suppress_embeds: :class:`bool`
             Whether to suppress embeds for the message. This hides
             all the embeds from the UI if set to ``True``. If set
@@ -1829,9 +1863,10 @@ class InteractionMessage(Message):
         Forbidden
             Edited a message that is not yours.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         ValueError
-            The length of ``embeds`` was invalid.
+            The length of ``embeds`` was invalid, or
+            you tried to send v2 components together with ``content`` or ``embeds``.
 
         Returns
         -------

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -525,7 +525,8 @@ class Interaction(Generic[ClientT]):
 
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameter ``suppress_embeds`` is provided,
             that will override the setting of :attr:`.MessageFlags.suppress_embeds`.
@@ -751,8 +752,9 @@ class Interaction(Generic[ClientT]):
 
         flags: :class:`MessageFlags`
             The flags to set for this message.
-            Only :attr:`~MessageFlags.suppress_embeds`, :attr:`~MessageFlags.ephemeral`
-            and :attr:`~MessageFlags.suppress_notifications` are supported.
+            Only :attr:`~MessageFlags.suppress_embeds`, :attr:`~MessageFlags.ephemeral`,
+            :attr:`~MessageFlags.suppress_notifications`, and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameters ``suppress_embeds`` or ``ephemeral`` are provided,
             they will override the corresponding setting of this ``flags`` parameter.
@@ -1038,8 +1040,9 @@ class InteractionResponse:
 
         flags: :class:`MessageFlags`
             The flags to set for this message.
-            Only :attr:`~MessageFlags.suppress_embeds`, :attr:`~MessageFlags.ephemeral`
-            and :attr:`~MessageFlags.suppress_notifications` are supported.
+            Only :attr:`~MessageFlags.suppress_embeds`, :attr:`~MessageFlags.ephemeral`,
+            :attr:`~MessageFlags.suppress_notifications`, and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameters ``suppress_embeds`` or ``ephemeral`` are provided,
             they will override the corresponding setting of this ``flags`` parameter.
@@ -1252,7 +1255,8 @@ class InteractionResponse:
 
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             .. versionadded:: 2.11
 
@@ -1836,7 +1840,8 @@ class InteractionMessage(Message):
 
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameter ``suppress_embeds`` is provided,
             that will override the setting of :attr:`.MessageFlags.suppress_embeds`.

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -4,13 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
-from ..components import (
-    VALID_ACTION_ROW_MESSAGE_COMPONENT_TYPES,
-    ActionRowMessageComponent,
-    _walk_all_components,
-)
+from ..components import VALID_ACTION_ROW_MESSAGE_COMPONENT_TYPES, ActionRowMessageComponent
 from ..enums import ComponentType, try_enum
 from ..message import Message
+from ..ui.action_row import walk_components
 from ..utils import cached_slot_property
 from .base import ClientT, Interaction, InteractionDataResolved
 
@@ -172,7 +169,7 @@ class MessageInteraction(Interaction[ClientT]):
     def component(self) -> ActionRowMessageComponent:
         """Union[:class:`Button`, :class:`BaseSelectMenu`]: The component the user interacted with."""
         # FIXME(3.0?): introduce common base type for components with `custom_id`
-        for component in _walk_all_components(self.message.components):
+        for component in walk_components(self.message.components):
             if (
                 isinstance(component, VALID_ACTION_ROW_MESSAGE_COMPONENT_TYPES)
                 and component.custom_id == self.data.custom_id

--- a/disnake/interactions/message.py
+++ b/disnake/interactions/message.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from ..role import Role
     from ..state import ConnectionState
     from ..types.interactions import (
-        InteractionDataResolved as InteractionDataResolvedPayload,
         MessageComponentInteractionData as MessageComponentInteractionDataPayload,
         MessageInteraction as MessageInteractionPayload,
     )
@@ -192,10 +191,6 @@ class MessageInteractionData(Dict[str, Any]):
     ----------
     custom_id: :class:`str`
         The custom ID of the component.
-    id: :class:`int`
-        TODO
-
-        .. versionadded:: 2.11
     component_type: :class:`ComponentType`
         The type of the component.
     values: Optional[List[:class:`str`]]
@@ -207,7 +202,7 @@ class MessageInteractionData(Dict[str, Any]):
         .. versionadded:: 2.7
     """
 
-    __slots__ = ("custom_id", "id", "component_type", "values", "resolved")
+    __slots__ = ("custom_id", "component_type", "values", "resolved")
 
     def __init__(
         self,
@@ -217,16 +212,12 @@ class MessageInteractionData(Dict[str, Any]):
     ) -> None:
         super().__init__(data)
         self.custom_id: str = data["custom_id"]
-        self.id: int = data.get("id")
         self.component_type: ComponentType = try_enum(ComponentType, data["component_type"])
         self.values: Optional[List[str]] = (
             list(map(str, values)) if (values := data.get("values")) else None
         )
 
-        empty_resolved: InteractionDataResolvedPayload = {}  # pyright shenanigans
-        self.resolved = InteractionDataResolved(
-            data=data.get("resolved", empty_resolved), parent=parent
-        )
+        self.resolved = InteractionDataResolved(data=data.get("resolved", {}), parent=parent)
 
     def __repr__(self) -> str:
         return (

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -49,7 +49,6 @@ from .poll import Poll
 from .reaction import Reaction
 from .sticker import StickerItem
 from .threads import Thread
-from .ui.action_row import components_to_dict
 from .user import User
 from .utils import MISSING, _get_as_snowflake, assert_never, deprecated, escape_mentions
 
@@ -218,6 +217,8 @@ async def _edit_handler(
             payload["components"] = []
 
     if components is not MISSING:
+        from .ui.action_row import components_to_dict
+
         payload["components"] = [] if components is None else components_to_dict(components)
 
     try:

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1192,7 +1192,7 @@ class Message(Hashable):
             StickerItem(data=d, state=state) for d in data.get("sticker_items", [])
         ]
         self.components: List[MessageTopLevelComponent] = [
-            _message_component_factory(d) for d in data.get("components", [])
+            _message_component_factory(d, state=state) for d in data.get("components", [])
         ]
 
         self.poll: Optional[Poll] = None
@@ -1439,7 +1439,7 @@ class Message(Hashable):
                     self.role_mentions.append(role)
 
     def _handle_components(self, components: List[MessageTopLevelComponentPayload]) -> None:
-        self.components = [_message_component_factory(d) for d in components]
+        self.components = [_message_component_factory(d, state=self._state) for d in components]
 
     def _rebind_cached_references(self, new_guild: Guild, new_channel: GuildMessageable) -> None:
         self.guild = new_guild
@@ -2933,7 +2933,7 @@ class ForwardedMessage:
             StickerItem(data=d, state=state) for d in data.get("sticker_items", [])
         ]
         self.components: List[MessageTopLevelComponent] = [
-            _message_component_factory(d) for d in data.get("components", [])
+            _message_component_factory(d, state=state) for d in data.get("components", [])
         ]
         self.guild_id = guild_id
 

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -2025,7 +2025,8 @@ class Message(Hashable):
             suppressed.
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameter ``suppress_embeds`` is provided,
             that will override the setting of :attr:`.MessageFlags.suppress_embeds`.
@@ -2798,7 +2799,8 @@ class PartialMessage(Hashable):
             suppressed.
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameter ``suppress_embeds`` is provided,
             that will override the setting of :attr:`.MessageFlags.suppress_embeds`.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -221,7 +221,7 @@ async def _edit_handler(
 
     # set cv2 flag automatically
     if is_v2:
-        flags = MessageFlags._from_value(0 if flags is MISSING else flags.value)
+        flags = MessageFlags._from_value(default_flags if flags is MISSING else flags.value)
         flags.is_components_v2 = True
     # components v2 cannot be used with other content fields
     # (n.b. this doesn't take into account editing messages that *already* have content/embeds,

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1192,7 +1192,7 @@ class Message(Hashable):
             StickerItem(data=d, state=state) for d in data.get("sticker_items", [])
         ]
         self.components: List[MessageTopLevelComponent] = [
-            _message_component_factory(d, state=state) for d in data.get("components", [])
+            _message_component_factory(d) for d in data.get("components", [])
         ]
 
         self.poll: Optional[Poll] = None
@@ -1439,7 +1439,7 @@ class Message(Hashable):
                     self.role_mentions.append(role)
 
     def _handle_components(self, components: List[MessageTopLevelComponentPayload]) -> None:
-        self.components = [_message_component_factory(d, state=self._state) for d in components]
+        self.components = [_message_component_factory(d) for d in components]
 
     def _rebind_cached_references(self, new_guild: Guild, new_channel: GuildMessageable) -> None:
         self.guild = new_guild
@@ -2933,7 +2933,7 @@ class ForwardedMessage:
             StickerItem(data=d, state=state) for d in data.get("sticker_items", [])
         ]
         self.components: List[MessageTopLevelComponent] = [
-            _message_component_factory(d, state=state) for d in data.get("components", [])
+            _message_component_factory(d) for d in data.get("components", [])
         ]
         self.guild_id = guild_id
 

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -2058,6 +2058,12 @@ class Message(Hashable):
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content`` and ``embeds`` fields.
+                If the message previously had any of these fields set, you must set them to ``None``.
+
         Raises
         ------
         HTTPException
@@ -2067,6 +2073,8 @@ class Message(Hashable):
             edited a message's content or embed that isn't yours.
         TypeError
             You specified both ``embed`` and ``embeds``, or ``file`` and ``files``, or ``view`` and ``components``.
+        ValueError
+            You tried to send v2 components together with ``content`` or ``embeds``.
 
         Returns
         -------
@@ -2822,6 +2830,12 @@ class PartialMessage(Hashable):
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content`` and ``embeds`` fields.
+                If the message previously had any of these fields set, you must set them to ``None``.
+
         Raises
         ------
         NotFound
@@ -2833,6 +2847,8 @@ class PartialMessage(Hashable):
             edited a message's content or embed that isn't yours.
         TypeError
             You specified both ``embed`` and ``embeds``, or ``file`` and ``files``, or ``view`` and ``components``.
+        ValueError
+            You tried to send v2 components together with ``content`` or ``embeds``.
 
         Returns
         -------

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -56,8 +56,7 @@ MessageTopLevelComponent = Union[MessageTopLevelComponentV1, MessageTopLevelComp
 
 class _BaseComponent(TypedDict):
     # type: ComponentType  # FIXME: current version of pyright only supports PEP 705 experimentally, this can be re-enabled in 1.1.353+
-    # TODO: always present in responses
-    id: NotRequired[int]  # NOTE: not implemented (yet?)
+    id: int  # note: technically optional when sending, we just default to 0 for simplicity, which is equivalent (https://discord.com/developers/docs/components/reference#anatomy-of-a-component)
 
 
 class ActionRow(_BaseComponent):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -211,6 +211,8 @@ class FileComponent(_BaseComponent):
     type: Literal[13]
     file: UnfurledMediaItem  # only supports `attachment://` urls
     spoiler: NotRequired[bool]
+    name: NotRequired[str]  # only provided by api
+    size: NotRequired[int]  # only provided by api
 
 
 class SeparatorComponent(_BaseComponent):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -40,7 +40,6 @@ ActionRowChildComponent = Union["ButtonComponent", "AnySelectMenu", "TextInput"]
 MessageTopLevelComponentV1: TypeAlias = "ActionRow"
 # currently, all v2 components except Thumbnail
 MessageTopLevelComponentV2 = Union[
-    MessageTopLevelComponentV1,
     "SectionComponent",
     "TextDisplayComponent",
     "MediaGalleryComponent",

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -13,7 +13,7 @@ from .snowflake import Snowflake
 ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17]
 ButtonStyle = Literal[1, 2, 3, 4, 5, 6]
 TextInputStyle = Literal[1, 2]
-SeparatorSpacingSize = Literal[1, 2]
+SeparatorSpacing = Literal[1, 2]
 
 SelectDefaultValueType = Literal["user", "role", "channel"]
 
@@ -218,7 +218,7 @@ class FileComponent(_BaseComponent):
 class SeparatorComponent(_BaseComponent):
     type: Literal[14]
     divider: NotRequired[bool]
-    spacing: NotRequired[SeparatorSpacingSize]
+    spacing: NotRequired[SeparatorSpacing]
 
 
 class ContainerComponent(_BaseComponent):

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, TypedDict, Union
+from typing import List, Literal, Optional, TypedDict, Union
 
-from typing_extensions import NotRequired, TypeAlias
+from typing_extensions import NotRequired, Required, TypeAlias
 
 from .channel import ChannelType
 from .emoji import PartialEmoji
@@ -162,12 +162,18 @@ class TextInput(_BaseComponent):
 
 
 # components v2
+
+
+class UnfurledMediaItem(TypedDict, total=False):
+    url: Required[str]  # this is the only field required for sending
+    proxy_url: str
+    height: Optional[int]
+    width: Optional[int]
+    content_type: str
+    attachment_id: Snowflake
+
+
 # NOTE: these are type definitions for *sending*, while *receiving* likely has fewer optional fields
-
-
-# TODO: this expands to an `EmbedImage`-like structure in responses, with more than just the `url` field
-class UnfurledMediaItem(TypedDict):
-    url: str
 
 
 class SectionComponent(_BaseComponent):

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -226,7 +226,6 @@ MessageComponentInteractionData = Union[
 ### Modal interaction components
 
 
-# TODO: add other select types
 class ModalInteractionStringSelectData(_BaseComponentInteractionData):
     type: Literal[3]
     values: List[str]
@@ -245,6 +244,7 @@ ModalInteractionComponentData = Union[
 
 class ModalInteractionActionRow(TypedDict):
     type: Literal[1]
+    id: int
     components: List[ModalInteractionComponentData]
 
 

--- a/disnake/ui/_types.py
+++ b/disnake/ui/_types.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, Optional, Sequence, TypeVar, Un
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
+    from ..components import UnfurledMediaItem
     from . import (
         ActionRow,
         Button,
@@ -75,3 +76,7 @@ ComponentInput = Union[
 
 MessageComponents = ComponentInput[ActionRowMessageComponent, MessageTopLevelComponentV2]
 ModalComponents = ComponentInput[ActionRowModalComponent, NoReturn]
+
+
+# TODO: support `disnake.File`
+MediaItemInput = Union[str, "UnfurledMediaItem"]

--- a/disnake/ui/_types.py
+++ b/disnake/ui/_types.py
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
     from .select import ChannelSelect, MentionableSelect, RoleSelect, StringSelect, UserSelect
     from .view import View
 
-# TODO: consider if there are any useful types to make public (e.g. disnake-compass used MessageUIComponent)
-
 V_co = TypeVar("V_co", bound="Optional[View]", covariant=True)
 
 AnySelect = Union[

--- a/disnake/ui/_types.py
+++ b/disnake/ui/_types.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING, Any, NoReturn, Optional, Sequence, TypeVar, Un
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-    from ..asset import AssetMixin
-    from ..components import UnfurledMediaItem
-    from ..message import Attachment
     from . import (
         ActionRow,
         Button,
@@ -78,6 +75,3 @@ ComponentInput = Union[
 
 MessageComponents = ComponentInput[ActionRowMessageComponent, MessageTopLevelComponentV2]
 ModalComponents = ComponentInput[ActionRowModalComponent, NoReturn]
-
-
-MediaItemInput = Union[str, "AssetMixin", "Attachment", "UnfurledMediaItem"]

--- a/disnake/ui/_types.py
+++ b/disnake/ui/_types.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING, Any, NoReturn, Optional, Sequence, TypeVar, Un
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
+    from ..asset import AssetMixin
     from ..components import UnfurledMediaItem
+    from ..message import Attachment
     from . import (
         ActionRow,
         Button,
@@ -78,5 +80,4 @@ MessageComponents = ComponentInput[ActionRowMessageComponent, MessageTopLevelCom
 ModalComponents = ComponentInput[ActionRowModalComponent, NoReturn]
 
 
-# TODO: support `disnake.File`
-MediaItemInput = Union[str, "UnfurledMediaItem"]
+MediaItemInput = Union[str, "AssetMixin", "Attachment", "UnfurledMediaItem"]

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -1054,10 +1054,10 @@ def _walk_internal(component: ComponentT, seen: Set[ComponentT]) -> Iterator[Com
             yield from _walk_internal(item, seen)
     elif isinstance(component, (SectionComponent, Section)):
         yield from _walk_internal(component.accessory, seen)
-        for item in component.components:
+        for item in component.children:
             yield from _walk_internal(item, seen)  # type: ignore  # this is fine, pyright loses the conditional type when iterating
     elif isinstance(component, (ContainerComponent, Container)):
-        for item in component.components:
+        for item in component.children:
             yield from _walk_internal(item, seen)  # type: ignore
 
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -158,8 +158,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             context of a modal. Combining components from both contexts is not supported.
     """
 
-    # unused, but technically required by base type
-    __repr_attributes__: ClassVar[Tuple[str, ...]] = ("children",)
+    __repr_attributes__: ClassVar[Tuple[str, ...]] = ("_children",)
 
     # When unspecified and called empty, default to an ActionRow that takes any kind of component.
 
@@ -194,10 +193,6 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
                     f"components should be of type WrappedComponent, got {type(component).__name__}."
                 )
             self.append_item(component)  # type: ignore
-
-    def __repr__(self) -> str:
-        # implemented separately for now, due to SequenceProxy repr
-        return f"<ActionRow children={self._children!r}>"
 
     # FIXME(3.0)?: `bool(ActionRow())` returns False, which may be undesired
     def __len__(self) -> int:

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -291,6 +291,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         sku_id: Optional[int] = None,
+        id: int = 0,
     ) -> ButtonCompatibleActionRowT:
         """Add a button to the action row. Can only be used if the action
         row holds message components.
@@ -327,6 +328,12 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             Premium buttons additionally cannot have a ``label``, ``url``, or ``emoji``.
 
             .. versionadded:: 2.11
+        id: :class:`int`
+            The numeric identifier for the component.
+            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            sequential identifiers to the components in the message.
+
+            .. versionadded:: 2.11
 
         Raises
         ------
@@ -336,6 +343,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         self.insert_item(
             len(self) if index is None else index,
             Button(
+                id=id,
                 style=style,
                 label=label,
                 disabled=disabled,
@@ -356,6 +364,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         max_values: int = 1,
         options: SelectOptionInput = MISSING,
         disabled: bool = False,
+        id: int = 0,
     ) -> SelectCompatibleActionRowT:
         """Add a string select menu to the action row. Can only be used if the action
         row holds message components.
@@ -387,6 +396,12 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             as a list of labels, and a dict will be treated as a mapping of labels to values.
         disabled: :class:`bool`
             Whether the select is disabled or not.
+        id: :class:`int`
+            The numeric identifier for the component.
+            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            sequential identifiers to the components in the message.
+
+            .. versionadded:: 2.11
 
         Raises
         ------
@@ -395,6 +410,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         """
         self.append_item(
             StringSelect(
+                id=id,
                 custom_id=custom_id,
                 placeholder=placeholder,
                 min_values=min_values,
@@ -416,6 +432,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Union[User, Member]]]] = None,
+        id: int = 0,
     ) -> SelectCompatibleActionRowT:
         """Add a user select menu to the action row. Can only be used if the action
         row holds message components.
@@ -447,6 +464,12 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
             .. versionadded:: 2.10
+        id: :class:`int`
+            The numeric identifier for the component.
+            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            sequential identifiers to the components in the message.
+
+            .. versionadded:: 2.11
 
         Raises
         ------
@@ -455,6 +478,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         """
         self.append_item(
             UserSelect(
+                id=id,
                 custom_id=custom_id,
                 placeholder=placeholder,
                 min_values=min_values,
@@ -474,6 +498,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Role]]] = None,
+        id: int = 0,
     ) -> SelectCompatibleActionRowT:
         """Add a role select menu to the action row. Can only be used if the action
         row holds message components.
@@ -505,6 +530,12 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
             .. versionadded:: 2.10
+        id: :class:`int`
+            The numeric identifier for the component.
+            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            sequential identifiers to the components in the message.
+
+            .. versionadded:: 2.11
 
         Raises
         ------
@@ -513,6 +544,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         """
         self.append_item(
             RoleSelect(
+                id=id,
                 custom_id=custom_id,
                 placeholder=placeholder,
                 min_values=min_values,
@@ -534,6 +566,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         default_values: Optional[
             Sequence[SelectDefaultValueMultiInputType[Union[User, Member, Role]]]
         ] = None,
+        id: int = 0,
     ) -> SelectCompatibleActionRowT:
         """Add a mentionable (user/member/role) select menu to the action row. Can only be used if the action
         row holds message components.
@@ -567,6 +600,12 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             Note that unlike other select menu types, this does not support :class:`.Object`\\s due to ambiguities.
 
             .. versionadded:: 2.10
+        id: :class:`int`
+            The numeric identifier for the component.
+            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            sequential identifiers to the components in the message.
+
+            .. versionadded:: 2.11
 
         Raises
         ------
@@ -575,6 +614,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         """
         self.append_item(
             MentionableSelect(
+                id=id,
                 custom_id=custom_id,
                 placeholder=placeholder,
                 min_values=min_values,
@@ -595,6 +635,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         disabled: bool = False,
         channel_types: Optional[List[ChannelType]] = None,
         default_values: Optional[Sequence[SelectDefaultValueInputType[AnyChannel]]] = None,
+        id: int = 0,
     ) -> SelectCompatibleActionRowT:
         """Add a channel select menu to the action row. Can only be used if the action
         row holds message components.
@@ -629,6 +670,12 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
             .. versionadded:: 2.10
+        id: :class:`int`
+            The numeric identifier for the component.
+            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            sequential identifiers to the components in the message.
+
+            .. versionadded:: 2.11
 
         Raises
         ------
@@ -637,6 +684,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         """
         self.append_item(
             ChannelSelect(
+                id=id,
                 custom_id=custom_id,
                 placeholder=placeholder,
                 min_values=min_values,
@@ -659,6 +707,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         required: bool = True,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
+        id: int = 0,
     ) -> TextInputCompatibleActionRowT:
         """Add a text input to the action row. Can only be used if the action
         row holds modal components.
@@ -688,6 +737,12 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             The minimum length of the text input.
         max_length: Optional[:class:`int`]
             The maximum length of the text input.
+        id: :class:`int`
+            The numeric identifier for the component.
+            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            sequential identifiers to the components in the message.
+
+            .. versionadded:: 2.11
 
         Raises
         ------
@@ -696,6 +751,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         """
         self.append_item(
             TextInput(
+                id=id,
                 label=label,
                 custom_id=custom_id,
                 style=style,

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -159,7 +159,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             context of a modal. Combining components from both contexts is not supported.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11
@@ -330,7 +330,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             .. versionadded:: 2.11
         id: :class:`int`
             The numeric identifier for the component.
-            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            If set to ``0`` (the default) when sending a component, the API will assign
             sequential identifiers to the components in the message.
 
             .. versionadded:: 2.11
@@ -398,7 +398,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             Whether the select is disabled or not.
         id: :class:`int`
             The numeric identifier for the component.
-            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            If set to ``0`` (the default) when sending a component, the API will assign
             sequential identifiers to the components in the message.
 
             .. versionadded:: 2.11
@@ -466,7 +466,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             .. versionadded:: 2.10
         id: :class:`int`
             The numeric identifier for the component.
-            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            If set to ``0`` (the default) when sending a component, the API will assign
             sequential identifiers to the components in the message.
 
             .. versionadded:: 2.11
@@ -532,7 +532,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             .. versionadded:: 2.10
         id: :class:`int`
             The numeric identifier for the component.
-            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            If set to ``0`` (the default) when sending a component, the API will assign
             sequential identifiers to the components in the message.
 
             .. versionadded:: 2.11
@@ -602,7 +602,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             .. versionadded:: 2.10
         id: :class:`int`
             The numeric identifier for the component.
-            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            If set to ``0`` (the default) when sending a component, the API will assign
             sequential identifiers to the components in the message.
 
             .. versionadded:: 2.11
@@ -672,7 +672,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             .. versionadded:: 2.10
         id: :class:`int`
             The numeric identifier for the component.
-            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            If set to ``0`` (the default) when sending a component, the API will assign
             sequential identifiers to the components in the message.
 
             .. versionadded:: 2.11
@@ -739,7 +739,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             The maximum length of the text input.
         id: :class:`int`
             The numeric identifier for the component.
-            If left unset (i.e. the default ``0``) when sending a component, the API will assign
+            If set to ``0`` (the default) when sending a component, the API will assign
             sequential identifiers to the components in the message.
 
             .. versionadded:: 2.11

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -128,6 +128,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         .. describe:: len(x)
 
             Returns the number of components in this row.
+            Note that this means empty rows will be considered falsy.
 
             .. versionadded:: 2.6
 
@@ -194,7 +195,6 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
                 )
             self.append_item(component)  # type: ignore
 
-    # FIXME(3.0)?: `bool(ActionRow())` returns False, which may be undesired
     def __len__(self) -> int:
         return len(self._children)
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -201,7 +201,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
     @property
     def children(self) -> Sequence[ActionRowChildT]:
         """Sequence[:class:`WrappedComponent`]:
-        A read-only copy of the UI components stored in this action row. To add/remove
+        A read-only proxy of the UI components stored in this action row. To add/remove
         components to/from the action row, use its methods to directly modify it.
 
         .. versionchanged:: 2.6

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -897,6 +897,10 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
         ordering and rows. Components will be transformed to UI kit components, such that
         they can be easily modified and re-sent as action rows.
 
+        .. note::
+            This only supports :class:`ActionRow`\\s and associated components, i.e. no v2 components.
+            See :func:`.ui.components_from_message` for a function that supports all component types.
+
         .. versionadded:: 2.6
 
         Parameters
@@ -940,6 +944,10 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
     ) -> Generator[Tuple[ActionRow[ActionRowChildT], ActionRowChildT], None, None]:
         """Iterate over the components in a sequence of action rows, yielding each
         individual component together with the action row of which it is a child.
+
+        .. note::
+            This only supports :class:`ActionRow`\\s, i.e. no v2 components.
+            See :func:`.ui.walk_components` for a function that supports all component types.
 
         .. versionadded:: 2.6
 

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -158,7 +158,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildT]):
             Components can now be either valid in the context of a message, or in the
             context of a modal. Combining components from both contexts is not supported.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -68,6 +68,12 @@ class Button(Item[V_co]):
         Premium buttons additionally cannot have a ``label``, ``url``, or ``emoji``.
 
         .. versionadded:: 2.11
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this button belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -99,6 +105,7 @@ class Button(Item[V_co]):
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         sku_id: Optional[int] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -113,6 +120,7 @@ class Button(Item[V_co]):
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         sku_id: Optional[int] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -126,6 +134,7 @@ class Button(Item[V_co]):
         url: Optional[str] = None,
         emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
         sku_id: Optional[int] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None:
         super().__init__()
@@ -155,6 +164,7 @@ class Button(Item[V_co]):
 
         self._underlying = ButtonComponent._raw_construct(
             type=ComponentType.button,
+            id=id,
             custom_id=custom_id,
             url=url,
             disabled=disabled,
@@ -265,6 +275,7 @@ class Button(Item[V_co]):
             url=button.url,
             emoji=button.emoji,
             sku_id=button.sku_id,
+            id=button.id,
             row=None,
         )
 

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -69,7 +69,7 @@ class Button(Item[V_co]):
 
         .. versionadded:: 2.11
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
@@ -349,7 +349,7 @@ def button(
         The emoji of the button. This can be in string form or a :class:`.PartialEmoji`
         or a full :class:`.Emoji`.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -70,7 +70,7 @@ class Button(Item[V_co]):
         .. versionadded:: 2.11
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11
@@ -350,7 +350,7 @@ def button(
         or a full :class:`.Emoji`.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -301,6 +301,7 @@ def button(
     disabled: bool = False,
     style: ButtonStyle = ButtonStyle.secondary,
     emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
+    id: int = 0,
     row: Optional[int] = None,
 ) -> Callable[[ItemCallbackType[V_co, Button[V_co]]], DecoratedItem[Button[V_co]]]: ...
 
@@ -347,6 +348,12 @@ def button(
     emoji: Optional[Union[:class:`str`, :class:`.Emoji`, :class:`.PartialEmoji`]]
         The emoji of the button. This can be in string form or a :class:`.PartialEmoji`
         or a full :class:`.Emoji`.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this button belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, ClassVar, List, Optional, Tuple, Union, cast
 
 from ..colour import Colour
 from ..components import Container as ContainerComponent
@@ -11,6 +11,8 @@ from ..utils import copy_doc
 from .item import UIComponent, ensure_ui_component
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .action_row import ActionRow, ActionRowMessageComponent
     from .file import File
     from .media_gallery import MediaGallery
@@ -103,4 +105,18 @@ class Container(UIComponent):
             components=[comp._underlying for comp in self.components],
             _accent_colour=self.accent_colour.value if self.accent_colour is not None else None,
             spoiler=self.spoiler,
+        )
+
+    @classmethod
+    def from_component(cls, container: ContainerComponent) -> Self:
+        from .action_row import _to_ui_component
+
+        return cls(
+            *cast(
+                "List[ContainerChildUIComponent]",
+                [_to_ui_component(c) for c in container.components],
+            ),
+            accent_colour=container.accent_colour,
+            spoiler=container.spoiler,
+            id=container.id,
         )

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -47,7 +47,7 @@ class Container(UIComponent):
         Whether the container is marked as a spoiler. Defaults to ``False``.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
     Attributes

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, ClassVar, List, Optional, Tuple, Union
 
 from ..colour import Colour
 from ..components import Container as ContainerComponent
 from ..enums import ComponentType
-from ..utils import SequenceProxy, copy_doc
+from ..utils import copy_doc
 from .item import UIComponent, ensure_ui_component
 
 if TYPE_CHECKING:
@@ -52,6 +52,8 @@ class Container(UIComponent):
 
     Attributes
     ----------
+    components: List[Union[:class:`~.ui.ActionRow`, :class:`~.ui.Section`, :class:`~.ui.TextDisplay`, :class:`~.ui.MediaGallery`, :class:`~.ui.File`, :class:`~.ui.Separator`]]
+        The list of components in this container.
     accent_colour: Optional[:class:`.Colour`]
         The accent colour of the container.
     spoiler: :class:`bool`
@@ -59,7 +61,7 @@ class Container(UIComponent):
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
-        "_components",
+        "components",
         "accent_colour",
         "spoiler",
     )
@@ -73,7 +75,9 @@ class Container(UIComponent):
         id: int = 0,
     ) -> None:
         self._id: int = id
-        self._components: List[ContainerChildUIComponent] = [
+        # this list can be modified without any runtime checks later on,
+        # just assume the user knows what they're doing at that point
+        self.components: List[ContainerChildUIComponent] = [
             ensure_ui_component(c, "components") for c in components
         ]
         # FIXME: add accent_color
@@ -91,18 +95,12 @@ class Container(UIComponent):
     def id(self, value: int) -> None:
         self._id = value
 
-    # TODO: consider moving runtime checks from constructor into property setters, also making these fields writable
-    @property
-    def components(self) -> Sequence[ContainerChildUIComponent]:
-        """Sequence[Union[:class:`~.ui.ActionRow`, :class:`~.ui.Section`, :class:`~.ui.TextDisplay`, :class:`~.ui.MediaGallery`, :class:`~.ui.File`, :class:`~.ui.Separator`]]: A read-only proxy of the components in this container."""
-        return SequenceProxy(self._components)
-
     @property
     def _underlying(self) -> ContainerComponent:
         return ContainerComponent._raw_construct(
             type=ComponentType.container,
             id=self._id,
-            components=[comp._underlying for comp in self._components],
+            components=[comp._underlying for comp in self.components],
             _accent_colour=self.accent_colour.value if self.accent_colour is not None else None,
             spoiler=self.spoiler,
         )

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -77,7 +77,7 @@ class Container(UIComponent):
     # TODO: consider moving runtime checks from constructor into property setters, also making these fields writable
     @property
     def components(self) -> Sequence[ContainerChildUIComponent]:
-        """Sequence[Union[:class:`~.ui.ActionRow`, :class:`~.ui.Section`, :class:`~.ui.TextDisplay`, :class:`~.ui.MediaGallery`, :class:`~.ui.File`, :class:`~.ui.Separator`]]: A read-only copy of the components in this container."""
+        """Sequence[Union[:class:`~.ui.ActionRow`, :class:`~.ui.Section`, :class:`~.ui.TextDisplay`, :class:`~.ui.MediaGallery`, :class:`~.ui.File`, :class:`~.ui.Separator`]]: A read-only proxy of the components in this container."""
         return SequenceProxy(self._components)
 
     @property

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -54,8 +54,8 @@ class Container(UIComponent):
 
     Attributes
     ----------
-    components: List[Union[:class:`~.ui.ActionRow`, :class:`~.ui.Section`, :class:`~.ui.TextDisplay`, :class:`~.ui.MediaGallery`, :class:`~.ui.File`, :class:`~.ui.Separator`]]
-        The list of components in this container.
+    children: List[Union[:class:`~.ui.ActionRow`, :class:`~.ui.Section`, :class:`~.ui.TextDisplay`, :class:`~.ui.MediaGallery`, :class:`~.ui.File`, :class:`~.ui.Separator`]]
+        The list of child components in this container.
     accent_colour: Optional[:class:`.Colour`]
         The accent colour of the container.
         An alias exists under ``accent_color``.
@@ -64,7 +64,7 @@ class Container(UIComponent):
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
-        "components",
+        "children",
         "accent_colour",
         "spoiler",
     )
@@ -79,7 +79,7 @@ class Container(UIComponent):
         self._id: int = id
         # this list can be modified without any runtime checks later on,
         # just assume the user knows what they're doing at that point
-        self.components: List[ContainerChildUIComponent] = [
+        self.children: List[ContainerChildUIComponent] = [
             ensure_ui_component(c, "components") for c in components
         ]
         self._accent_colour: Optional[Colour] = accent_colour
@@ -118,7 +118,7 @@ class Container(UIComponent):
         return ContainerComponent._raw_construct(
             type=ComponentType.container,
             id=self._id,
-            components=[comp._underlying for comp in self.components],
+            children=[comp._underlying for comp in self.children],
             accent_colour=self._accent_colour,
             spoiler=self.spoiler,
         )
@@ -130,7 +130,7 @@ class Container(UIComponent):
         return cls(
             *cast(
                 "List[ContainerChildUIComponent]",
-                [_to_ui_component(c) for c in container.components],
+                [_to_ui_component(c) for c in container.children],
             ),
             accent_colour=container.accent_colour,
             spoiler=container.spoiler,

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -54,9 +54,8 @@ class Container(UIComponent):
         Whether the container is marked as a spoiler.
     """
 
-    # unused, but technically required by base type
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
-        "components",
+        "_components",
         "accent_colour",
         "spoiler",
     )
@@ -80,10 +79,6 @@ class Container(UIComponent):
     def components(self) -> Sequence[ContainerChildUIComponent]:
         """Sequence[Union[:class:`~.ui.ActionRow`, :class:`~.ui.Section`, :class:`~.ui.TextDisplay`, :class:`~.ui.MediaGallery`, :class:`~.ui.File`, :class:`~.ui.Separator`]]: A read-only copy of the components in this container."""
         return SequenceProxy(self._components)
-
-    def __repr__(self) -> str:
-        # implemented separately for now, due to SequenceProxy repr
-        return f"<Container components={self._components!r} accent_colour={self.accent_colour!r} spoiler={self.spoiler!r}>"
 
     @property
     def _underlying(self) -> ContainerComponent:

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -58,6 +58,7 @@ class Container(UIComponent):
         The list of components in this container.
     accent_colour: Optional[:class:`.Colour`]
         The accent colour of the container.
+        An alias exists under ``accent_color``.
     spoiler: :class:`bool`
         Whether the container is marked as a spoiler.
     """
@@ -68,7 +69,6 @@ class Container(UIComponent):
         "spoiler",
     )
 
-    # TODO: consider providing sequence operations (append, insert, remove, etc.)
     def __init__(
         self,
         *components: ContainerChildUIComponent,
@@ -82,8 +82,7 @@ class Container(UIComponent):
         self.components: List[ContainerChildUIComponent] = [
             ensure_ui_component(c, "components") for c in components
         ]
-        # FIXME: add accent_color
-        self.accent_colour: Optional[Colour] = accent_colour
+        self._accent_colour: Optional[Colour] = accent_colour
         self.spoiler: bool = spoiler
 
     # these are reimplemented here to store the value in a separate attribute,
@@ -98,12 +97,29 @@ class Container(UIComponent):
         self._id = value
 
     @property
+    def accent_colour(self) -> Optional[Colour]:
+        return self._accent_colour
+
+    @accent_colour.setter
+    def accent_colour(self, value: Optional[Union[int, Colour]]) -> None:
+        if isinstance(value, int):
+            self._accent_colour = Colour(value)
+        elif value is None or isinstance(value, Colour):
+            self._accent_colour = value
+        else:
+            raise TypeError(
+                f"Expected Colour, int, or None but received {type(value).__name__} instead."
+            )
+
+    accent_color = accent_colour
+
+    @property
     def _underlying(self) -> ContainerComponent:
         return ContainerComponent._raw_construct(
             type=ComponentType.container,
             id=self._id,
             components=[comp._underlying for comp in self.components],
-            _accent_colour=self.accent_colour.value if self.accent_colour is not None else None,
+            accent_colour=self._accent_colour,
             spoiler=self.spoiler,
         )
 

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -46,7 +46,7 @@ class Container(UIComponent):
     spoiler: :class:`bool`
         Whether the container is marked as a spoiler. Defaults to ``False``.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Tuple
+from typing import TYPE_CHECKING, ClassVar, Tuple
 
-from ..components import FileComponent
+from ..components import FileComponent, UnfurledMediaItem
 from ..enums import ComponentType
 from ..utils import MISSING
-from .item import UIComponent
+from .item import UIComponent, handle_media_item_input
+
+if TYPE_CHECKING:
+    from ._types import MediaItemInput
 
 __all__ = ("File",)
 
@@ -19,8 +22,9 @@ class File(UIComponent):
 
     Parameters
     ----------
-    file: Any
-        n/a
+    file: Union[:class:`str`, :class:`.UnfurledMediaItem`]
+        The file to display. This **only** supports attachment references (i.e.
+        using the ``attachment://`` syntax), not arbitrary URLs.
     spoiler: :class:`bool`
         Whether the file is marked as a spoiler. Defaults to ``False``.
     """
@@ -34,24 +38,24 @@ class File(UIComponent):
 
     def __init__(
         self,
+        file: MediaItemInput,
         *,
-        file: Any,  # XXX: positional?
         spoiler: bool = False,
     ) -> None:
         self._underlying = FileComponent._raw_construct(
             type=ComponentType.file,
-            file=file,
+            file=handle_media_item_input(file),
             spoiler=spoiler,
         )
 
     @property
-    def file(self) -> Any:
-        """Any: n/a"""
+    def file(self) -> UnfurledMediaItem:
+        """:class:`.UnfurledMediaItem`: The file to display."""
         return self._underlying.file
 
     @file.setter
-    def file(self, value: Any) -> None:
-        self._underlying.file = value
+    def file(self, value: MediaItemInput) -> None:
+        self._underlying.file = handle_media_item_input(value)
 
     @property
     def spoiler(self) -> bool:

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, Tuple
 
-from ..components import FileComponent, UnfurledMediaItem
+from ..components import FileComponent, UnfurledMediaItem, handle_media_item_input
 from ..enums import ComponentType
 from ..utils import MISSING
-from .item import UIComponent, handle_media_item_input
+from .item import UIComponent
 
 if TYPE_CHECKING:
-    from ._types import MediaItemInput
+    from ..components import MediaItemInput
 
 __all__ = ("File",)
 

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -27,6 +27,10 @@ class File(UIComponent):
         using the ``attachment://<filename>`` syntax), not arbitrary URLs.
     spoiler: :class:`bool`
         Whether the file is marked as a spoiler. Defaults to ``False``.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
@@ -41,9 +45,11 @@ class File(UIComponent):
         file: MediaItemInput,
         *,
         spoiler: bool = False,
+        id: int = 0,
     ) -> None:
         self._underlying = FileComponent._raw_construct(
             type=ComponentType.file,
+            id=id,
             file=handle_media_item_input(file),
             spoiler=spoiler,
         )

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Tuple
+from typing import TYPE_CHECKING, ClassVar, Optional, Tuple
 
 from ..components import FileComponent, UnfurledMediaItem, handle_media_item_input
 from ..enums import ComponentType
@@ -82,3 +82,17 @@ class File(UIComponent):
     @spoiler.setter
     def spoiler(self, value: bool) -> None:
         self._underlying.spoiler = value
+
+    @property
+    def name(self) -> Optional[str]:
+        """Optional[:class:`str`]: The name of the file.
+        This is available in objects from the API, and ignored when sending.
+        """
+        return self._underlying.name
+
+    @property
+    def size(self) -> Optional[int]:
+        """Optional[:class:`int`]: The size of the file.
+        This is available in objects from the API, and ignored when sending.
+        """
+        return self._underlying.size

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -68,7 +68,7 @@ class File(UIComponent):
         file_media = handle_media_item_input(value)
         if not file_media.url.startswith("attachment://"):
             raise ValueError("File component does not support external media URLs")
-        self._underlying.file = handle_media_item_input(file_media)
+        self._underlying.file = file_media
 
     @property
     def spoiler(self) -> bool:

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -58,6 +58,8 @@ class File(UIComponent):
             id=id,
             file=file_media,
             spoiler=spoiler,
+            name=None,
+            size=None,
         )
 
     @property

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -22,7 +22,7 @@ class File(UIComponent):
 
     Parameters
     ----------
-    file: Union[:class:`str`, :class:`.AssetMixin`, :class:`.Attachment`, :class:`.UnfurledMediaItem`]
+    file: Union[:class:`str`, :class:`.Asset`, :class:`.Attachment`, :class:`.UnfurledMediaItem`]
         The file to display. This **only** supports attachment references (i.e.
         using the ``attachment://<filename>`` syntax), not arbitrary URLs.
     spoiler: :class:`bool`

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -24,7 +24,7 @@ class File(UIComponent):
     ----------
     file: Union[:class:`str`, :class:`.UnfurledMediaItem`]
         The file to display. This **only** supports attachment references (i.e.
-        using the ``attachment://`` syntax), not arbitrary URLs.
+        using the ``attachment://<filename>`` syntax), not arbitrary URLs.
     spoiler: :class:`bool`
         Whether the file is marked as a spoiler. Defaults to ``False``.
     """

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING, ClassVar, Optional, Tuple
 
 from ..components import FileComponent, UnfurledMediaItem, handle_media_item_input
@@ -105,8 +106,9 @@ class File(UIComponent):
     def from_component(cls, file: FileComponent) -> Self:
         media = file.file
         if not media.url.startswith("attachment://") and file.name:
-            # TODO: does this work correctly with special characters?
-            media = UnfurledMediaItem(f"attachment://{file.name}")
+            # turn cdn url into `attachment://` url, retain other fields
+            media = copy.copy(media)
+            media.url = f"attachment://{file.name}"
 
         self = cls(
             file=media,

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -49,7 +49,9 @@ class File(UIComponent):
     ) -> None:
         file_media = handle_media_item_input(file)
         if not file_media.url.startswith("attachment://"):
-            raise ValueError("File component does not support external media URLs")
+            raise ValueError(
+                "File component only supports `attachment://` references, not external media URLs"
+            )
 
         self._underlying = FileComponent._raw_construct(
             type=ComponentType.file,
@@ -67,7 +69,9 @@ class File(UIComponent):
     def file(self, value: LocalMediaItemInput) -> None:
         file_media = handle_media_item_input(value)
         if not file_media.url.startswith("attachment://"):
-            raise ValueError("File component does not support external media URLs")
+            raise ValueError(
+                "File component only supports `attachment://` references, not external media URLs"
+            )
         self._underlying.file = file_media
 
     @property

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -22,7 +22,7 @@ class File(UIComponent):
 
     Parameters
     ----------
-    file: Union[:class:`str`, :class:`.UnfurledMediaItem`]
+    file: Union[:class:`str`, :class:`.AssetMixin`, :class:`.Attachment`, :class:`.UnfurledMediaItem`]
         The file to display. This **only** supports attachment references (i.e.
         using the ``attachment://<filename>`` syntax), not arbitrary URLs.
     spoiler: :class:`bool`

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -28,7 +28,7 @@ class File(UIComponent):
     spoiler: :class:`bool`
         Whether the file is marked as a spoiler. Defaults to ``False``.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -29,7 +29,7 @@ class File(UIComponent):
         Whether the file is marked as a spoiler. Defaults to ``False``.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """
 

--- a/disnake/ui/file.py
+++ b/disnake/ui/file.py
@@ -10,6 +10,8 @@ from ..utils import MISSING
 from .item import UIComponent
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..components import LocalMediaItemInput
 
 __all__ = ("File",)
@@ -98,3 +100,20 @@ class File(UIComponent):
         This is available in objects from the API, and ignored when sending.
         """
         return self._underlying.size
+
+    @classmethod
+    def from_component(cls, file: FileComponent) -> Self:
+        media = file.file
+        if not media.url.startswith("attachment://") and file.name:
+            # TODO: does this work correctly with special characters?
+            media = UnfurledMediaItem(f"attachment://{file.name}")
+
+        self = cls(
+            file=media,
+            spoiler=file.spoiler,
+            id=file.id,
+        )
+        # copy read-only fields
+        self._underlying.name = file.name
+        self._underlying.size = file.size
+        return self

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -105,6 +105,20 @@ class UIComponent(ABC):
     def type(self) -> ComponentType:
         return self._underlying.type
 
+    @property
+    def id(self) -> int:
+        """:class:`int`: The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+
+        .. versionadded:: 2.11
+        """
+        return self._underlying.id
+
+    @id.setter
+    def id(self, value: int) -> None:
+        self._underlying.id = value
+
     def to_component_dict(self) -> Dict[str, Any]:
         return self._underlying.to_dict()
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -19,6 +19,8 @@ from typing import (
     overload,
 )
 
+from ..components import UnfurledMediaItem
+
 __all__ = (
     "UIComponent",
     "WrappedComponent",
@@ -36,6 +38,7 @@ if TYPE_CHECKING:
     from ..enums import ComponentType
     from ..interactions import MessageInteraction
     from ..types.components import ActionRowChildComponent as ActionRowChildComponentPayload
+    from ._types import MediaItemInput
     from .view import View
 
     ItemCallbackType = Callable[[V_co, I, MessageInteraction], Coroutine[Any, Any, Any]]
@@ -48,6 +51,13 @@ def ensure_ui_component(obj: UIComponentT, name: str) -> UIComponentT:
     if not isinstance(obj, UIComponent):
         raise TypeError(f"{name} should be a valid UI component, got {type(obj).__name__}.")
     return obj
+
+
+# TODO: support `disnake.File`
+def handle_media_item_input(value: MediaItemInput) -> UnfurledMediaItem:
+    if isinstance(value, str):
+        return UnfurledMediaItem(value)
+    return value
 
 
 class UIComponent(ABC):

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -103,6 +103,10 @@ class UIComponent(ABC):
     def to_component_dict(self) -> Dict[str, Any]:
         return self._underlying.to_dict()
 
+    @classmethod
+    def from_component(cls, component: Component, /) -> Self:
+        return cls()
+
 
 # Essentially the same as the base `UIComponent`, with the addition of `width`.
 class WrappedComponent(UIComponent):
@@ -122,13 +126,13 @@ class WrappedComponent(UIComponent):
     """
 
     # the purpose of these two is just more precise typechecking compared to the base type
+    if TYPE_CHECKING:
 
-    @property
-    @abstractmethod
-    def _underlying(self) -> ActionRowChildComponent: ...
+        @property
+        @abstractmethod
+        def _underlying(self) -> ActionRowChildComponent: ...
 
-    def to_component_dict(self) -> ActionRowChildComponentPayload:
-        return self._underlying.to_dict()
+        def to_component_dict(self) -> ActionRowChildComponentPayload: ...
 
     @property
     @abstractmethod
@@ -174,10 +178,6 @@ class Item(WrappedComponent, Generic[V_co]):
 
     def refresh_state(self, interaction: MessageInteraction) -> None:
         return None
-
-    @classmethod
-    def from_component(cls, component: ActionRowChildComponent) -> Self:
-        return cls()
 
     def is_dispatchable(self) -> bool:
         return False

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -83,6 +83,10 @@ class UIComponent(ABC):
         return f"<{type(self).__name__} {attrs}>"
 
     @property
+    def is_v2(self) -> bool:
+        return self._underlying.is_v2
+
+    @property
     def type(self) -> ComponentType:
         return self._underlying.type
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -19,7 +19,10 @@ from typing import (
     overload,
 )
 
+from ..asset import AssetMixin
 from ..components import UnfurledMediaItem
+from ..message import Attachment
+from ..utils import assert_never
 
 __all__ = (
     "UIComponent",
@@ -53,10 +56,16 @@ def ensure_ui_component(obj: UIComponentT, name: str) -> UIComponentT:
     return obj
 
 
-# TODO: support `disnake.File`
 def handle_media_item_input(value: MediaItemInput) -> UnfurledMediaItem:
-    if isinstance(value, str):
+    if isinstance(value, UnfurledMediaItem):
+        return value
+    elif isinstance(value, str):
         return UnfurledMediaItem(value)
+    elif isinstance(value, (AssetMixin, Attachment)):
+        return UnfurledMediaItem(value.url)
+
+    # TODO: raise proper exception (?)
+    assert_never(value)
     return value
 
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -77,7 +77,9 @@ class UIComponent(ABC):
     def _underlying(self) -> Component: ...
 
     def __repr__(self) -> str:
-        attrs = " ".join(f"{key}={getattr(self, key)!r}" for key in self.__repr_attributes__)
+        attrs = " ".join(
+            f"{key.lstrip('_')}={getattr(self, key)!r}" for key in self.__repr_attributes__
+        )
         return f"<{type(self).__name__} {attrs}>"
 
     @property

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -19,11 +19,6 @@ from typing import (
     overload,
 )
 
-from ..asset import AssetMixin
-from ..components import UnfurledMediaItem
-from ..message import Attachment
-from ..utils import assert_never
-
 __all__ = (
     "UIComponent",
     "WrappedComponent",
@@ -41,7 +36,6 @@ if TYPE_CHECKING:
     from ..enums import ComponentType
     from ..interactions import MessageInteraction
     from ..types.components import ActionRowChildComponent as ActionRowChildComponentPayload
-    from ._types import MediaItemInput
     from .view import View
 
     ItemCallbackType = Callable[[V_co, I, MessageInteraction], Coroutine[Any, Any, Any]]
@@ -54,19 +48,6 @@ def ensure_ui_component(obj: UIComponentT, name: str) -> UIComponentT:
     if not isinstance(obj, UIComponent):
         raise TypeError(f"{name} should be a valid UI component, got {type(obj).__name__}.")
     return obj
-
-
-def handle_media_item_input(value: MediaItemInput) -> UnfurledMediaItem:
-    if isinstance(value, UnfurledMediaItem):
-        return value
-    elif isinstance(value, str):
-        return UnfurledMediaItem(value)
-    elif isinstance(value, (AssetMixin, Attachment)):
-        return UnfurledMediaItem(value.url)
-
-    # TODO: raise proper exception (?)
-    assert_never(value)
-    return value
 
 
 class UIComponent(ABC):

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -23,7 +23,7 @@ class MediaGallery(UIComponent):
         The list of images in this gallery.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """
 

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -22,7 +22,7 @@ class MediaGallery(UIComponent):
     *items: :class:`.MediaGalleryItem`
         The list of images in this gallery.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -53,8 +53,6 @@ class MediaGallery(UIComponent):
     @classmethod
     def from_component(cls, media_gallery: MediaGalleryComponent) -> Self:
         return cls(
-            # FIXME: this might not work with items created with `attachment://`
-            # XXX: consider copying items
             *media_gallery.items,
             id=media_gallery.id,
         )

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -21,6 +21,10 @@ class MediaGallery(UIComponent):
     ----------
     *items: :class:`.MediaGalleryItem`
         The list of images in this gallery.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = ("items",)
@@ -28,9 +32,10 @@ class MediaGallery(UIComponent):
     _underlying: MediaGalleryComponent = MISSING
 
     # FIXME: MediaGalleryItem currently isn't user-instantiable
-    def __init__(self, *items: MediaGalleryItem) -> None:
+    def __init__(self, *items: MediaGalleryItem, id: int = 0) -> None:
         self._underlying = MediaGalleryComponent._raw_construct(
             type=ComponentType.media_gallery,
+            id=id,
             items=list(items),
         )
 

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, List, Sequence, Tuple
+from typing import TYPE_CHECKING, ClassVar, List, Sequence, Tuple
 
 from ..components import MediaGallery as MediaGalleryComponent, MediaGalleryItem
 from ..enums import ComponentType
 from ..utils import MISSING
 from .item import UIComponent
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = ("MediaGallery",)
 
@@ -46,3 +49,12 @@ class MediaGallery(UIComponent):
     @items.setter
     def items(self, values: Sequence[MediaGalleryItem]) -> None:
         self._underlying.items = list(values)
+
+    @classmethod
+    def from_component(cls, media_gallery: MediaGalleryComponent) -> Self:
+        return cls(
+            # FIXME: this might not work with items created with `attachment://`
+            # XXX: consider copying items
+            *media_gallery.items,
+            id=media_gallery.id,
+        )

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -31,7 +31,6 @@ class MediaGallery(UIComponent):
     # We have to set this to MISSING in order to overwrite the abstract property from UIComponent
     _underlying: MediaGalleryComponent = MISSING
 
-    # FIXME: MediaGalleryItem currently isn't user-instantiable
     def __init__(self, *items: MediaGalleryItem, id: int = 0) -> None:
         self._underlying = MediaGalleryComponent._raw_construct(
             type=ComponentType.media_gallery,

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -18,6 +18,8 @@ __all__ = ("MediaGallery",)
 class MediaGallery(UIComponent):
     """Represents a UI media gallery.
 
+    This allows displaying up to 10 images in a gallery.
+
     .. versionadded:: 2.11
 
     Parameters

--- a/disnake/ui/media_gallery.py
+++ b/disnake/ui/media_gallery.py
@@ -23,7 +23,7 @@ class MediaGallery(UIComponent):
     Parameters
     ----------
     *items: :class:`.MediaGalleryItem`
-        The list of images in this gallery.
+        The list of images in this gallery (up to 10).
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
         If set to ``0`` (the default) when sending a component, the API will assign

--- a/disnake/ui/modal.py
+++ b/disnake/ui/modal.py
@@ -37,7 +37,8 @@ class Modal:
     title: :class:`str`
         The title of the modal.
     components: |components_type|
-        The components to display in the modal. Up to 5 action rows.
+        The components to display in the modal. A maximum of 5.
+        Currently only supports :class:`.ui.TextInput` (optionally inside :class:`.ui.ActionRow`).
     custom_id: :class:`str`
         The custom ID of the modal. This is usually not required.
         If not given, then a unique one is generated for you.

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -27,7 +27,7 @@ class Section(UIComponent):
     Parameters
     ----------
     *components: :class:`~.ui.TextDisplay`
-        The text items in this section.
+        The text items in this section (up to 3).
     accessory: Union[:class:`~.ui.Thumbnail`, :class:`~.ui.Button`]
         The accessory component displayed next to the section text.
     id: :class:`int`

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -22,6 +22,8 @@ __all__ = ("Section",)
 class Section(UIComponent):
     """Represents a UI section.
 
+    This allows displaying an accessory (thumbnail or button) next to a block of text.
+
     .. versionadded:: 2.11
 
     Parameters

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -37,14 +37,14 @@ class Section(UIComponent):
 
     Attributes
     ----------
-    components: List[:class:`~.ui.TextDisplay`]
+    children: List[:class:`~.ui.TextDisplay`]
         The list of text items in this section.
     accessory: Union[:class:`~.ui.Thumbnail`, :class:`~.ui.Button`]
         The accessory component displayed next to the section text.
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
-        "components",
+        "children",
         "accessory",
     )
 
@@ -58,7 +58,7 @@ class Section(UIComponent):
         self._id: int = id
         # this list can be modified without any runtime checks later on,
         # just assume the user knows what they're doing at that point
-        self.components: List[TextDisplay] = [
+        self.children: List[TextDisplay] = [
             ensure_ui_component(c, "components") for c in components
         ]
         self.accessory: Union[Thumbnail, Button[Any]] = ensure_ui_component(accessory, "accessory")
@@ -79,7 +79,7 @@ class Section(UIComponent):
         return SectionComponent._raw_construct(
             type=ComponentType.section,
             id=self._id,
-            components=[comp._underlying for comp in self.components],
+            children=[comp._underlying for comp in self.children],
             accessory=self.accessory._underlying,
         )
 
@@ -90,7 +90,7 @@ class Section(UIComponent):
         return cls(
             *cast(
                 "List[TextDisplay]",
-                [_to_ui_component(c) for c in section.components],
+                [_to_ui_component(c) for c in section.children],
             ),
             accessory=cast("Union[Thumbnail, Button[Any]]", _to_ui_component(section.accessory)),
             id=section.id,

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -29,7 +29,7 @@ class Section(UIComponent):
     accessory: Union[:class:`~.ui.Thumbnail`, :class:`~.ui.Button`]
         The accessory component displayed next to the section text.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, List, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, ClassVar, List, Sequence, Tuple, Union
 
 from ..components import Section as SectionComponent
 from ..enums import ComponentType
@@ -39,12 +39,12 @@ class Section(UIComponent):
     def __init__(
         self,
         *components: TextDisplay,
-        accessory: Union[Thumbnail, Button],
+        accessory: Union[Thumbnail, Button[Any]],
     ) -> None:
         self._components: List[TextDisplay] = [
             ensure_ui_component(c, "components") for c in components
         ]
-        self._accessory: Union[Thumbnail, Button] = ensure_ui_component(accessory, "accessory")
+        self._accessory: Union[Thumbnail, Button[Any]] = ensure_ui_component(accessory, "accessory")
 
     # TODO: consider moving runtime checks from constructor into property setters, also making these fields writable
     @property
@@ -53,7 +53,7 @@ class Section(UIComponent):
         return SequenceProxy(self._components)
 
     @property
-    def accessory(self) -> Union[Thumbnail, Button]:
+    def accessory(self) -> Union[Thumbnail, Button[Any]]:
         """Union[:class:`~.ui.Thumbnail`, :class:`~.ui.Button`]: The accessory component displayed next to the section text."""
         return self._accessory
 

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -8,12 +8,12 @@ from ..components import Section as SectionComponent
 from ..enums import ComponentType
 from ..utils import copy_doc
 from .item import UIComponent, ensure_ui_component
+from .text_display import TextDisplay
 
 if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .button import Button
-    from .text_display import TextDisplay
     from .thumbnail import Thumbnail
 
 __all__ = ("Section",)
@@ -28,7 +28,7 @@ class Section(UIComponent):
 
     Parameters
     ----------
-    *components: :class:`~.ui.TextDisplay`
+    *components: Union[:class:`str`, :class:`~.ui.TextDisplay`]
         The text items in this section (up to 3).
     accessory: Union[:class:`~.ui.Thumbnail`, :class:`~.ui.Button`]
         The accessory component displayed next to the section text.
@@ -52,7 +52,7 @@ class Section(UIComponent):
 
     def __init__(
         self,
-        *components: TextDisplay,
+        *components: Union[str, TextDisplay],
         accessory: Union[Thumbnail, Button[Any]],
         id: int = 0,
     ) -> None:
@@ -60,7 +60,8 @@ class Section(UIComponent):
         # this list can be modified without any runtime checks later on,
         # just assume the user knows what they're doing at that point
         self.children: List[TextDisplay] = [
-            ensure_ui_component(c, "components") for c in components
+            TextDisplay(c) if isinstance(c, str) else ensure_ui_component(c, "components")
+            for c in components
         ]
         self.accessory: Union[Thumbnail, Button[Any]] = ensure_ui_component(accessory, "accessory")
 

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -49,7 +49,7 @@ class Section(UIComponent):
     # TODO: consider moving runtime checks from constructor into property setters, also making these fields writable
     @property
     def components(self) -> Sequence[TextDisplay]:
-        """Sequence[:class:`~.ui.TextDisplay`]: A read-only copy of the text items in this section."""
+        """Sequence[:class:`~.ui.TextDisplay`]: A read-only proxy of the text items in this section."""
         return SequenceProxy(self._components)
 
     @property

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -30,7 +30,7 @@ class Section(UIComponent):
         The accessory component displayed next to the section text.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """
 

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -30,9 +30,8 @@ class Section(UIComponent):
         The accessory component displayed next to the section text.
     """
 
-    # unused, but technically required by base type
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
-        "components",
+        "_components",
         "accessory",
     )
 
@@ -57,10 +56,6 @@ class Section(UIComponent):
     def accessory(self) -> Union[Thumbnail, Button]:
         """Union[:class:`~.ui.Thumbnail`, :class:`~.ui.Button`]: The accessory component displayed next to the section text."""
         return self._accessory
-
-    def __repr__(self) -> str:
-        # implemented separately for now, due to SequenceProxy repr
-        return f"<Section components={self._components!r} accessory={self._accessory!r}>"
 
     @property
     def _underlying(self) -> SectionComponent:

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, ClassVar, List, Tuple, Union, cast
 
 from ..components import Section as SectionComponent
 from ..enums import ComponentType
@@ -10,6 +10,8 @@ from ..utils import copy_doc
 from .item import UIComponent, ensure_ui_component
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .button import Button
     from .text_display import TextDisplay
     from .thumbnail import Thumbnail
@@ -79,4 +81,17 @@ class Section(UIComponent):
             id=self._id,
             components=[comp._underlying for comp in self.components],
             accessory=self.accessory._underlying,
+        )
+
+    @classmethod
+    def from_component(cls, section: SectionComponent) -> Self:
+        from .action_row import _to_ui_component
+
+        return cls(
+            *cast(
+                "List[TextDisplay]",
+                [_to_ui_component(c) for c in section.components],
+            ),
+            accessory=cast("Union[Thumbnail, Button[Any]]", _to_ui_component(section.accessory)),
+            id=section.id,
         )

--- a/disnake/ui/section.py
+++ b/disnake/ui/section.py
@@ -48,7 +48,6 @@ class Section(UIComponent):
         "accessory",
     )
 
-    # TODO: consider providing sequence operations (append, insert, remove, etc.)
     def __init__(
         self,
         *components: TextDisplay,

--- a/disnake/ui/select/base.py
+++ b/disnake/ui/select/base.py
@@ -90,6 +90,7 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         max_values: int,
         disabled: bool,
         default_values: Optional[Sequence[SelectDefaultValueInputType[SelectValueT]]],
+        id: int,
         row: Optional[int],
     ) -> None:
         super().__init__()
@@ -97,8 +98,9 @@ class BaseSelect(Generic[SelectMenuT, SelectValueT, V_co], Item[V_co], ABC):
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         self._underlying = underlying_type._raw_construct(
-            custom_id=custom_id,
             type=component_type,
+            id=id,
+            custom_id=custom_id,
             placeholder=placeholder,
             min_values=min_values,
             max_values=max_values,

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -73,7 +73,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11
@@ -263,7 +263,7 @@ def channel_select(
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -71,6 +71,12 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -112,6 +118,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
         disabled: bool = False,
         channel_types: Optional[List[ChannelType]] = None,
         default_values: Optional[Sequence[SelectDefaultValueInputType[AnyChannel]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -126,6 +133,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
         disabled: bool = False,
         channel_types: Optional[List[ChannelType]] = None,
         default_values: Optional[Sequence[SelectDefaultValueInputType[AnyChannel]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -139,6 +147,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
         disabled: bool = False,
         channel_types: Optional[List[ChannelType]] = None,
         default_values: Optional[Sequence[SelectDefaultValueInputType[AnyChannel]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None:
         super().__init__(
@@ -150,6 +159,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
             max_values=max_values,
             disabled=disabled,
             default_values=default_values,
+            id=id,
             row=row,
         )
         self._underlying.channel_types = channel_types or None
@@ -164,6 +174,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
             disabled=component.disabled,
             channel_types=component.channel_types,
             default_values=component.default_values,
+            id=component.id,
             row=None,
         )
 

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -72,7 +72,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
@@ -262,7 +262,7 @@ def channel_select(
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -207,6 +207,7 @@ def channel_select(
     disabled: bool = False,
     channel_types: Optional[List[ChannelType]] = None,
     default_values: Optional[Sequence[SelectDefaultValueInputType[AnyChannel]]] = None,
+    id: int = 0,
     row: Optional[int] = None,
 ) -> Callable[
     [ItemCallbackType[V_co, ChannelSelect[V_co]]], DecoratedItem[ChannelSelect[V_co]]
@@ -244,12 +245,6 @@ def channel_select(
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.
-    row: Optional[:class:`int`]
-        The relative row this select menu belongs to. A Discord component can only have 5
-        rows. By default, items are arranged automatically into those 5 rows. If you'd
-        like to control the relative positioning of the row then passing an index is advised.
-        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
-        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
@@ -266,5 +261,17 @@ def channel_select(
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
     return _create_decorator(cls, **kwargs)

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -182,6 +182,7 @@ def mentionable_select(
     default_values: Optional[
         Sequence[SelectDefaultValueMultiInputType[Union[User, Member, Role]]]
     ] = None,
+    id: int = 0,
     row: Optional[int] = None,
 ) -> Callable[
     [ItemCallbackType[V_co, MentionableSelect[V_co]]], DecoratedItem[MentionableSelect[V_co]]
@@ -219,12 +220,6 @@ def mentionable_select(
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.
-    row: Optional[:class:`int`]
-        The relative row this select menu belongs to. A Discord component can only have 5
-        rows. By default, items are arranged automatically into those 5 rows. If you'd
-        like to control the relative positioning of the row then passing an index is advised.
-        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
-        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
@@ -240,5 +235,17 @@ def mentionable_select(
         Note that unlike other select menu types, this does not support :class:`.Object`\\s due to ambiguities.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
     return _create_decorator(cls, **kwargs)

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -70,7 +70,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
@@ -236,7 +236,7 @@ def mentionable_select(
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -69,6 +69,12 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
         Note that unlike other select menu types, this does not support :class:`.Object`\\s due to ambiguities.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -101,6 +107,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
         default_values: Optional[
             Sequence[SelectDefaultValueMultiInputType[Union[User, Member, Role]]]
         ] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -116,6 +123,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
         default_values: Optional[
             Sequence[SelectDefaultValueMultiInputType[Union[User, Member, Role]]]
         ] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -130,6 +138,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
         default_values: Optional[
             Sequence[SelectDefaultValueMultiInputType[Union[User, Member, Role]]]
         ] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None:
         super().__init__(
@@ -141,6 +150,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
             max_values=max_values,
             disabled=disabled,
             default_values=default_values,
+            id=id,
             row=row,
         )
 
@@ -153,6 +163,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
             max_values=component.max_values,
             disabled=component.disabled,
             default_values=component.default_values,
+            id=component.id,
             row=None,
         )
 

--- a/disnake/ui/select/mentionable.py
+++ b/disnake/ui/select/mentionable.py
@@ -71,7 +71,7 @@ class MentionableSelect(BaseSelect[MentionableSelectMenu, "Union[User, Member, R
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11
@@ -237,7 +237,7 @@ def mentionable_select(
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -169,6 +169,7 @@ def role_select(
     max_values: int = 1,
     disabled: bool = False,
     default_values: Optional[Sequence[SelectDefaultValueInputType[Role]]] = None,
+    id: int = 0,
     row: Optional[int] = None,
 ) -> Callable[[ItemCallbackType[V_co, RoleSelect[V_co]]], DecoratedItem[RoleSelect[V_co]]]: ...
 
@@ -204,12 +205,6 @@ def role_select(
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.
-    row: Optional[:class:`int`]
-        The relative row this select menu belongs to. A Discord component can only have 5
-        rows. By default, items are arranged automatically into those 5 rows. If you'd
-        like to control the relative positioning of the row then passing an index is advised.
-        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
-        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
@@ -223,5 +218,17 @@ def role_select(
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
     return _create_decorator(cls, **kwargs)

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -66,7 +66,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
@@ -219,7 +219,7 @@ def role_select(
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -65,6 +65,12 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -94,6 +100,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Role]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -107,6 +114,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Role]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -119,6 +127,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Role]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None:
         super().__init__(
@@ -130,6 +139,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
             max_values=max_values,
             disabled=disabled,
             default_values=default_values,
+            id=id,
             row=row,
         )
 
@@ -142,6 +152,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
             max_values=component.max_values,
             disabled=component.disabled,
             default_values=component.default_values,
+            id=component.id,
             row=None,
         )
 

--- a/disnake/ui/select/role.py
+++ b/disnake/ui/select/role.py
@@ -67,7 +67,7 @@ class RoleSelect(BaseSelect[RoleSelectMenu, "Role", V_co]):
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11
@@ -220,7 +220,7 @@ def role_select(
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -86,6 +86,12 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
 
     disabled: :class:`bool`
         Whether the select is disabled.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -116,6 +122,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         max_values: int = 1,
         options: SelectOptionInput = ...,
         disabled: bool = False,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -129,6 +136,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         max_values: int = 1,
         options: SelectOptionInput = ...,
         disabled: bool = False,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -141,6 +149,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         max_values: int = 1,
         options: SelectOptionInput = MISSING,
         disabled: bool = False,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None:
         super().__init__(
@@ -152,6 +161,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
             max_values=max_values,
             disabled=disabled,
             default_values=None,
+            id=id,
             row=row,
         )
         self._underlying.options = [] if options is MISSING else _parse_select_options(options)
@@ -165,6 +175,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
             max_values=component.max_values,
             options=component.options,
             disabled=component.disabled,
+            id=component.id,
             row=None,
         )
 

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -273,6 +273,7 @@ def string_select(
     max_values: int = 1,
     options: SelectOptionInput = ...,
     disabled: bool = False,
+    id: int = 0,
     row: Optional[int] = None,
 ) -> Callable[[ItemCallbackType[V_co, StringSelect[V_co]]], DecoratedItem[StringSelect[V_co]]]: ...
 
@@ -311,12 +312,6 @@ def string_select(
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.
-    row: Optional[:class:`int`]
-        The relative row this select menu belongs to. A Discord component can only have 5
-        rows. By default, items are arranged automatically into those 5 rows. If you'd
-        like to control the relative positioning of the row then passing an index is advised.
-        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
-        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
@@ -334,6 +329,18 @@ def string_select(
 
     disabled: :class:`bool`
         Whether the select is disabled. Defaults to ``False``.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
     return _create_decorator(cls, **kwargs)
 

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -87,7 +87,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
     disabled: :class:`bool`
         Whether the select is disabled.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
@@ -330,7 +330,7 @@ def string_select(
     disabled: :class:`bool`
         Whether the select is disabled. Defaults to ``False``.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/select/string.py
+++ b/disnake/ui/select/string.py
@@ -88,7 +88,7 @@ class StringSelect(BaseSelect[StringSelectMenu, str, V_co]):
         Whether the select is disabled.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11
@@ -331,7 +331,7 @@ def string_select(
         Whether the select is disabled. Defaults to ``False``.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -171,6 +171,7 @@ def user_select(
     max_values: int = 1,
     disabled: bool = False,
     default_values: Optional[Sequence[SelectDefaultValueInputType[Union[User, Member]]]] = None,
+    id: int = 0,
     row: Optional[int] = None,
 ) -> Callable[[ItemCallbackType[V_co, UserSelect[V_co]]], DecoratedItem[UserSelect[V_co]]]: ...
 
@@ -206,12 +207,6 @@ def user_select(
     custom_id: :class:`str`
         The ID of the select menu that gets received during an interaction.
         It is recommended not to set this parameter to prevent conflicts.
-    row: Optional[:class:`int`]
-        The relative row this select menu belongs to. A Discord component can only have 5
-        rows. By default, items are arranged automatically into those 5 rows. If you'd
-        like to control the relative positioning of the row then passing an index is advised.
-        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
-        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     min_values: :class:`int`
         The minimum number of items that must be chosen for this select menu.
         Defaults to 1 and must be between 1 and 25.
@@ -225,5 +220,17 @@ def user_select(
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
+    row: Optional[:class:`int`]
+        The relative row this select menu belongs to. A Discord component can only have 5
+        rows. By default, items are arranged automatically into those 5 rows. If you'd
+        like to control the relative positioning of the row then passing an index is advised.
+        For example, row=1 will show up before row=2. Defaults to ``None``, which is automatic
+        ordering. The row number must be between 0 and 4 (i.e. zero indexed).
     """
     return _create_decorator(cls, **kwargs)

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -69,7 +69,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11
@@ -222,7 +222,7 @@ def user_select(
         .. versionadded:: 2.10
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -67,6 +67,12 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
         If set, the number of items must be within the bounds set by ``min_values`` and ``max_values``.
 
         .. versionadded:: 2.10
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     row: Optional[:class:`int`]
         The relative row this select menu belongs to. A Discord component can only have 5
         rows. By default, items are arranged automatically into those 5 rows. If you'd
@@ -96,6 +102,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Union[User, Member]]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -109,6 +116,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Union[User, Member]]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None: ...
 
@@ -121,6 +129,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
         max_values: int = 1,
         disabled: bool = False,
         default_values: Optional[Sequence[SelectDefaultValueInputType[Union[User, Member]]]] = None,
+        id: int = 0,
         row: Optional[int] = None,
     ) -> None:
         super().__init__(
@@ -132,6 +141,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
             max_values=max_values,
             disabled=disabled,
             default_values=default_values,
+            id=id,
             row=row,
         )
 
@@ -144,6 +154,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
             max_values=component.max_values,
             disabled=component.disabled,
             default_values=component.default_values,
+            id=component.id,
             row=None,
         )
 

--- a/disnake/ui/select/user.py
+++ b/disnake/ui/select/user.py
@@ -68,7 +68,7 @@ class UserSelect(BaseSelect[UserSelectMenu, "Union[User, Member]", V_co]):
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
@@ -221,7 +221,7 @@ def user_select(
 
         .. versionadded:: 2.10
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/separator.py
+++ b/disnake/ui/separator.py
@@ -25,6 +25,10 @@ class Separator(UIComponent):
     spacing: :class:`.SeparatorSpacingSize`
         The size of the separator.
         Defaults to :attr:`~.SeparatorSpacingSize.small`.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
@@ -39,9 +43,11 @@ class Separator(UIComponent):
         *,
         divider: bool = True,
         spacing: SeparatorSpacingSize = SeparatorSpacingSize.small,
+        id: int = 0,
     ) -> None:
         self._underlying = SeparatorComponent._raw_construct(
             type=ComponentType.separator,
+            id=id,
             divider=divider,
             spacing=spacing,
         )

--- a/disnake/ui/separator.py
+++ b/disnake/ui/separator.py
@@ -23,7 +23,7 @@ class Separator(UIComponent):
         Whether the separator should be visible, instead of just being vertical padding/spacing.
         Defaults to ``True``.
     spacing: :class:`.SeparatorSpacingSize`
-        The size of the separator.
+        The size of the separator padding.
         Defaults to :attr:`~.SeparatorSpacingSize.small`.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.

--- a/disnake/ui/separator.py
+++ b/disnake/ui/separator.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Tuple
+from typing import TYPE_CHECKING, ClassVar, Tuple
 
 from ..components import Separator as SeparatorComponent
 from ..enums import ComponentType, SeparatorSpacingSize
 from ..utils import MISSING
 from .item import UIComponent
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = ("Separator",)
 
@@ -69,3 +72,11 @@ class Separator(UIComponent):
     @spacing.setter
     def spacing(self, value: SeparatorSpacingSize) -> None:
         self._underlying.spacing = value
+
+    @classmethod
+    def from_component(cls, separator: SeparatorComponent) -> Self:
+        return cls(
+            divider=separator.divider,
+            spacing=separator.spacing,
+            id=separator.id,
+        )

--- a/disnake/ui/separator.py
+++ b/disnake/ui/separator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar, Tuple
 
 from ..components import Separator as SeparatorComponent
-from ..enums import ComponentType, SeparatorSpacingSize
+from ..enums import ComponentType, SeparatorSpacing
 from ..utils import MISSING
 from .item import UIComponent
 
@@ -25,9 +25,9 @@ class Separator(UIComponent):
     divider: :class:`bool`
         Whether the separator should be visible, instead of just being vertical padding/spacing.
         Defaults to ``True``.
-    spacing: :class:`.SeparatorSpacingSize`
+    spacing: :class:`.SeparatorSpacing`
         The size of the separator padding.
-        Defaults to :attr:`~.SeparatorSpacingSize.small`.
+        Defaults to :attr:`~.SeparatorSpacing.small`.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
         If set to ``0`` (the default) when sending a component, the API will assign
@@ -45,7 +45,7 @@ class Separator(UIComponent):
         self,
         *,
         divider: bool = True,
-        spacing: SeparatorSpacingSize = SeparatorSpacingSize.small,
+        spacing: SeparatorSpacing = SeparatorSpacing.small,
         id: int = 0,
     ) -> None:
         self._underlying = SeparatorComponent._raw_construct(
@@ -65,12 +65,12 @@ class Separator(UIComponent):
         self._underlying.divider = value
 
     @property
-    def spacing(self) -> SeparatorSpacingSize:
-        """:class:`.SeparatorSpacingSize`: The size of the separator."""
+    def spacing(self) -> SeparatorSpacing:
+        """:class:`.SeparatorSpacing`: The size of the separator."""
         return self._underlying.spacing
 
     @spacing.setter
-    def spacing(self, value: SeparatorSpacingSize) -> None:
+    def spacing(self, value: SeparatorSpacing) -> None:
         self._underlying.spacing = value
 
     @classmethod

--- a/disnake/ui/separator.py
+++ b/disnake/ui/separator.py
@@ -27,7 +27,7 @@ class Separator(UIComponent):
         Defaults to :attr:`~.SeparatorSpacingSize.small`.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """
 

--- a/disnake/ui/separator.py
+++ b/disnake/ui/separator.py
@@ -26,7 +26,7 @@ class Separator(UIComponent):
         The size of the separator.
         Defaults to :attr:`~.SeparatorSpacingSize.small`.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """

--- a/disnake/ui/text_display.py
+++ b/disnake/ui/text_display.py
@@ -22,15 +22,20 @@ class TextDisplay(UIComponent):
     ----------
     content: :class:`str`
         The text displayed by this component.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = ("content",)
     # We have to set this to MISSING in order to overwrite the abstract property from UIComponent
     _underlying: TextDisplayComponent = MISSING
 
-    def __init__(self, content: str) -> None:
+    def __init__(self, content: str, *, id: int = 0) -> None:
         self._underlying = TextDisplayComponent._raw_construct(
             type=ComponentType.text_display,
+            id=id,
             content=content,
         )
 

--- a/disnake/ui/text_display.py
+++ b/disnake/ui/text_display.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 __all__ = ("TextDisplay",)
 
 
-# XXX: `TextDisplay` vs just `Text`
 class TextDisplay(UIComponent):
     """Represents a UI text display.
 

--- a/disnake/ui/text_display.py
+++ b/disnake/ui/text_display.py
@@ -23,7 +23,7 @@ class TextDisplay(UIComponent):
     content: :class:`str`
         The text displayed by this component.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """

--- a/disnake/ui/text_display.py
+++ b/disnake/ui/text_display.py
@@ -36,7 +36,7 @@ class TextDisplay(UIComponent):
         self._underlying = TextDisplayComponent._raw_construct(
             type=ComponentType.text_display,
             id=id,
-            content=content,
+            content=str(content),
         )
 
     @property
@@ -46,5 +46,4 @@ class TextDisplay(UIComponent):
 
     @content.setter
     def content(self, value: str) -> None:
-        # TODO: consider str cast?
-        self._underlying.content = value
+        self._underlying.content = str(value)

--- a/disnake/ui/text_display.py
+++ b/disnake/ui/text_display.py
@@ -24,7 +24,7 @@ class TextDisplay(UIComponent):
         The text displayed by this component.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """
 

--- a/disnake/ui/text_display.py
+++ b/disnake/ui/text_display.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Tuple
+from typing import TYPE_CHECKING, ClassVar, Tuple
 
 from ..components import TextDisplay as TextDisplayComponent
 from ..enums import ComponentType
 from ..utils import MISSING
 from .item import UIComponent
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = ("TextDisplay",)
 
@@ -47,3 +50,10 @@ class TextDisplay(UIComponent):
     @content.setter
     def content(self, value: str) -> None:
         self._underlying.content = str(value)
+
+    @classmethod
+    def from_component(cls, text_display: TextDisplayComponent) -> Self:
+        return cls(
+            content=text_display.content,
+            id=text_display.id,
+        )

--- a/disnake/ui/text_input.py
+++ b/disnake/ui/text_input.py
@@ -37,6 +37,12 @@ class TextInput(WrappedComponent):
         The minimum length of the text input.
     max_length: Optional[:class:`int`]
         The maximum length of the text input.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+
+        .. versionadded:: 2.11
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
@@ -63,9 +69,11 @@ class TextInput(WrappedComponent):
         required: bool = True,
         min_length: Optional[int] = None,
         max_length: Optional[int] = None,
+        id: int = 0,
     ) -> None:
         self._underlying = TextInputComponent._raw_construct(
             type=ComponentType.text_input,
+            id=id,
             style=style,
             label=label,
             custom_id=custom_id,

--- a/disnake/ui/text_input.py
+++ b/disnake/ui/text_input.py
@@ -38,7 +38,7 @@ class TextInput(WrappedComponent):
     max_length: Optional[:class:`int`]
         The maximum length of the text input.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 

--- a/disnake/ui/text_input.py
+++ b/disnake/ui/text_input.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Optional, Tuple
+from typing import TYPE_CHECKING, ClassVar, Optional, Tuple
 
 from ..components import TextInput as TextInputComponent
 from ..enums import ComponentType, TextInputStyle
 from ..utils import MISSING
 from .item import WrappedComponent
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = ("TextInput",)
 
@@ -159,3 +162,17 @@ class TextInput(WrappedComponent):
     @max_length.setter
     def max_length(self, value: Optional[int]) -> None:
         self._underlying.max_length = value
+
+    @classmethod
+    def from_component(cls, text_input: TextInputComponent) -> Self:
+        return cls(
+            label=text_input.label or "",
+            custom_id=text_input.custom_id,
+            style=text_input.style,
+            placeholder=text_input.placeholder,
+            value=text_input.value,
+            required=text_input.required,
+            min_length=text_input.min_length,
+            max_length=text_input.max_length,
+            id=text_input.id,
+        )

--- a/disnake/ui/text_input.py
+++ b/disnake/ui/text_input.py
@@ -39,7 +39,7 @@ class TextInput(WrappedComponent):
         The maximum length of the text input.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
 
         .. versionadded:: 2.11

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -32,7 +32,7 @@ class Thumbnail(UIComponent):
     spoiler: :class:`bool`
         Whether the thumbnail is marked as a spoiler. Defaults to ``False``.
     id: :class:`int`
-        The numeric identifier for the component.
+        The numeric identifier for the component. Must be unique within the message.
         If left unset (i.e. the default ``0``) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, Optional, Tuple
 
-from ..components import Thumbnail as ThumbnailComponent, UnfurledMediaItem
+from ..components import Thumbnail as ThumbnailComponent, UnfurledMediaItem, handle_media_item_input
 from ..enums import ComponentType
 from ..utils import MISSING
-from .item import UIComponent, handle_media_item_input
+from .item import UIComponent
 
 if TYPE_CHECKING:
-    from ._types import MediaItemInput
+    from ..components import MediaItemInput
 
 __all__ = ("Thumbnail",)
 

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -93,7 +93,6 @@ class Thumbnail(UIComponent):
     @classmethod
     def from_component(cls, thumbnail: ThumbnailComponent) -> Self:
         return cls(
-            # FIXME: this might not work with items created with `attachment://`
             media=thumbnail.media,
             description=thumbnail.description,
             spoiler=thumbnail.spoiler,

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -10,6 +10,8 @@ from ..utils import MISSING
 from .item import UIComponent
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from ..components import MediaItemInput
 
 __all__ = ("Thumbnail",)
@@ -87,3 +89,13 @@ class Thumbnail(UIComponent):
     @spoiler.setter
     def spoiler(self, value: bool) -> None:
         self._underlying.spoiler = value
+
+    @classmethod
+    def from_component(cls, thumbnail: ThumbnailComponent) -> Self:
+        return cls(
+            # FIXME: this might not work with items created with `attachment://`
+            media=thumbnail.media,
+            description=thumbnail.description,
+            spoiler=thumbnail.spoiler,
+            id=thumbnail.id,
+        )

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -33,7 +33,7 @@ class Thumbnail(UIComponent):
         Whether the thumbnail is marked as a spoiler. Defaults to ``False``.
     id: :class:`int`
         The numeric identifier for the component. Must be unique within the message.
-        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        If set to ``0`` (the default) when sending a component, the API will assign
         sequential identifiers to the components in the message.
     """
 

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -25,7 +25,8 @@ class Thumbnail(UIComponent):
     Parameters
     ----------
     media: Union[:class:`str`, :class:`.UnfurledMediaItem`]
-        The media item to display. Can be an arbitrary URL or attachment reference.
+        The media item to display. Can be an arbitrary URL or attachment
+        reference (``attachment://<filename>``).
     description: Optional[:class:`str`]
         The thumbnail's description ("alt text"), if any.
     spoiler: :class:`bool`

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -24,7 +24,7 @@ class Thumbnail(UIComponent):
 
     Parameters
     ----------
-    media: Union[:class:`str`, :class:`.UnfurledMediaItem`]
+    media: Union[:class:`str`, :class:`.AssetMixin`, :class:`.Attachment`, :class:`.UnfurledMediaItem`]
         The media item to display. Can be an arbitrary URL or attachment
         reference (``attachment://<filename>``).
     description: Optional[:class:`str`]

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -31,6 +31,10 @@ class Thumbnail(UIComponent):
         The thumbnail's description ("alt text"), if any.
     spoiler: :class:`bool`
         Whether the thumbnail is marked as a spoiler. Defaults to ``False``.
+    id: :class:`int`
+        The numeric identifier for the component.
+        If left unset (i.e. the default ``0``) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
     """
 
     __repr_attributes__: ClassVar[Tuple[str, ...]] = (
@@ -47,9 +51,11 @@ class Thumbnail(UIComponent):
         description: Optional[str] = None,
         *,
         spoiler: bool = False,
+        id: int = 0,
     ) -> None:
         self._underlying = ThumbnailComponent._raw_construct(
             type=ComponentType.thumbnail,
+            id=id,
             media=handle_media_item_input(media),
             description=description,
             spoiler=spoiler,

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Optional, Tuple
+from typing import TYPE_CHECKING, ClassVar, Optional, Tuple
 
-from ..components import Thumbnail as ThumbnailComponent
+from ..components import Thumbnail as ThumbnailComponent, UnfurledMediaItem
 from ..enums import ComponentType
 from ..utils import MISSING
-from .item import UIComponent
+from .item import UIComponent, handle_media_item_input
+
+if TYPE_CHECKING:
+    from ._types import MediaItemInput
 
 __all__ = ("Thumbnail",)
 
@@ -21,8 +24,8 @@ class Thumbnail(UIComponent):
 
     Parameters
     ----------
-    media: Any
-        n/a
+    media: Union[:class:`str`, :class:`.UnfurledMediaItem`]
+        The media item to display. Can be an arbitrary URL or attachment reference.
     description: Optional[:class:`str`]
         The thumbnail's description ("alt text"), if any.
     spoiler: :class:`bool`
@@ -39,26 +42,26 @@ class Thumbnail(UIComponent):
 
     def __init__(
         self,
-        media: Any,
+        media: MediaItemInput,
         description: Optional[str] = None,
         *,
         spoiler: bool = False,
     ) -> None:
         self._underlying = ThumbnailComponent._raw_construct(
             type=ComponentType.thumbnail,
-            media=media,
+            media=handle_media_item_input(media),
             description=description,
             spoiler=spoiler,
         )
 
     @property
-    def media(self) -> Any:
-        """Any: n/a"""
+    def media(self) -> UnfurledMediaItem:
+        """:class:`.UnfurledMediaItem`: The media item to display."""
         return self._underlying.media
 
     @media.setter
-    def media(self, value: Any) -> None:
-        self._underlying.media = value
+    def media(self, value: MediaItemInput) -> None:
+        self._underlying.media = handle_media_item_input(value)
 
     @property
     def description(self) -> Optional[str]:

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -39,9 +39,9 @@ class Thumbnail(UIComponent):
 
     def __init__(
         self,
-        *,
-        media: Any,  # XXX: positional?
+        media: Any,
         description: Optional[str] = None,
+        *,
         spoiler: bool = False,
     ) -> None:
         self._underlying = ThumbnailComponent._raw_construct(

--- a/disnake/ui/thumbnail.py
+++ b/disnake/ui/thumbnail.py
@@ -24,7 +24,7 @@ class Thumbnail(UIComponent):
 
     Parameters
     ----------
-    media: Union[:class:`str`, :class:`.AssetMixin`, :class:`.Attachment`, :class:`.UnfurledMediaItem`]
+    media: Union[:class:`str`, :class:`.Asset`, :class:`.Attachment`, :class:`.UnfurledMediaItem`]
         The media item to display. Can be an arbitrary URL or attachment
         reference (``attachment://<filename>``).
     description: Optional[:class:`str`]

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -27,10 +27,9 @@ from ..components import (
     ActionRowMessageComponent,
     Button as ButtonComponent,
     _component_factory,
-    _walk_all_components,
 )
 from ..enums import try_enum_to_int
-from .action_row import _message_component_to_item
+from .action_row import _message_component_to_item, walk_components
 from .button import Button
 from .item import Item
 
@@ -230,7 +229,7 @@ class View:
         """
         view = View(timeout=timeout)
         # FIXME: preserve rows
-        for component in _walk_all_components(message.components):
+        for component in walk_components(message.components):
             if isinstance(component, ActionRowComponent):
                 continue
             elif not isinstance(component, VALID_ACTION_ROW_MESSAGE_COMPONENT_TYPES):

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -562,11 +562,7 @@ class ViewStore:
         view = self._synced_message_views[message_id]
 
         rows = [
-            _component_factory(
-                d,
-                state=self._state,
-                type=ActionRowComponent[ActionRowMessageComponent],
-            )
+            _component_factory(d, type=ActionRowComponent[ActionRowMessageComponent])
             for d in components
         ]
         for row in rows:

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -562,7 +562,11 @@ class ViewStore:
         view = self._synced_message_views[message_id]
 
         rows = [
-            _component_factory(d, type=ActionRowComponent[ActionRowMessageComponent])
+            _component_factory(
+                d,
+                state=self._state,
+                type=ActionRowComponent[ActionRowMessageComponent],
+            )
             for d in components
         ]
         for row in rows:

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -193,6 +193,7 @@ class View:
             components.append(
                 {
                     "type": 1,
+                    "id": 0,
                     "components": children,
                 }
             )

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -240,11 +240,12 @@ def isoformat_utc(dt: Optional[datetime.datetime]) -> Optional[str]:
     return None
 
 
-def copy_doc(original: Callable) -> Callable[[T], T]:
-    def decorator(overriden: T) -> T:
-        overriden.__doc__ = original.__doc__
-        overriden.__signature__ = _signature(original)  # type: ignore
-        return overriden
+def copy_doc(original: Union[Callable, property]) -> Callable[[T], T]:
+    def decorator(overridden: T) -> T:
+        overridden.__doc__ = original.__doc__
+        if callable(original):
+            overridden.__signature__ = _signature(original)  # type: ignore
+        return overridden
 
     return decorator
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -876,7 +876,8 @@ class WebhookMessage(Message):
 
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             .. versionadded:: 2.11
 
@@ -1709,8 +1710,9 @@ class Webhook(BaseWebhook):
 
         flags: :class:`MessageFlags`
             The flags to set for this message.
-            Only :attr:`~MessageFlags.suppress_embeds`, :attr:`~MessageFlags.ephemeral`
-            and :attr:`~MessageFlags.suppress_notifications` are supported.
+            Only :attr:`~MessageFlags.suppress_embeds`, :attr:`~MessageFlags.ephemeral`,
+            :attr:`~MessageFlags.suppress_notifications`, and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             If parameters ``suppress_embeds`` or ``ephemeral`` are provided,
             they will override the corresponding setting of this ``flags`` parameter.
@@ -1972,7 +1974,8 @@ class Webhook(BaseWebhook):
 
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
-            Only :attr:`~MessageFlags.suppress_embeds` is supported.
+            Only :attr:`~MessageFlags.suppress_embeds` and :attr:`~MessageFlags.is_components_v2`
+            are supported.
 
             .. versionadded:: 2.11
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -868,6 +868,12 @@ class WebhookMessage(Message):
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content`` and ``embeds`` fields.
+                If the message previously had any of these fields set, you must set them to ``None``.
+
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
             Only :attr:`~MessageFlags.suppress_embeds` is supported.
@@ -885,9 +891,10 @@ class WebhookMessage(Message):
         Forbidden
             Edited a message that is not yours.
         TypeError
-            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``
+            You specified both ``embed`` and ``embeds`` or ``file`` and ``files``.
         ValueError
-            The length of ``embeds`` was invalid
+            The length of ``embeds`` was invalid, or
+            you tried to send v2 components together with ``content`` or ``embeds``.
         WebhookTokenMissing
             There was no token associated with this webhook.
 
@@ -1654,6 +1661,11 @@ class Webhook(BaseWebhook):
 
             .. versionadded:: 2.4
 
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content``, ``embeds``, and ``poll`` fields.
+
         thread: :class:`~disnake.abc.Snowflake`
             The thread to send this message to.
 
@@ -1727,7 +1739,8 @@ class Webhook(BaseWebhook):
         WebhookTokenMissing
             There was no token associated with this webhook.
         ValueError
-            The length of ``embeds`` was invalid.
+            The length of ``embeds`` was invalid, or
+            you tried to send v2 components together with ``content``, ``embeds``, or ``poll``.
 
         Returns
         -------
@@ -1945,10 +1958,17 @@ class Webhook(BaseWebhook):
 
             .. versionadded:: 2.0
 
-        components: |components_type|
+        components: Optional[|components_type|]
             A list of components to update this message with. This cannot be mixed with ``view``.
+            If ``None`` is passed then the components are removed.
 
             .. versionadded:: 2.4
+
+            .. note::
+                Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
+                Setting this flag cannot be reverted. Note that this also disables the
+                ``content`` and ``embeds`` fields.
+                If the message previously had any of these fields set, you must set them to ``None``.
 
         flags: :class:`MessageFlags`
             The new flags to set for this message. Overrides existing flags.
@@ -1977,7 +1997,8 @@ class Webhook(BaseWebhook):
         WebhookTokenMissing
             There was no token associated with this webhook.
         ValueError
-            The length of ``embeds`` was invalid
+            The length of ``embeds`` was invalid, or
+            you tried to send v2 components together with ``content`` or ``embeds``.
 
         Returns
         -------

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -291,8 +291,9 @@ class AsyncWebhookAdapter:
         files: Optional[List[File]] = None,
         thread_id: Optional[int] = None,
         wait: bool = False,
+        with_components: bool = True,
     ) -> Response[Optional[MessagePayload]]:
-        params = {"wait": int(wait)}
+        params = {"wait": int(wait), "with_components": int(with_components)}
         if thread_id:
             params["thread_id"] = thread_id
 
@@ -1666,6 +1667,10 @@ class Webhook(BaseWebhook):
                 Passing v2 components here automatically sets the :attr:`~MessageFlags.is_components_v2` flag.
                 Setting this flag cannot be reverted. Note that this also disables the
                 ``content``, ``embeds``, and ``poll`` fields.
+
+            .. note::
+                Non-application-owned webhooks can only send non-interactive components,
+                e.g. link buttons or v2 layout components.
 
         thread: :class:`~disnake.abc.Snowflake`
             The thread to send this message to.

--- a/docs/api/components.rst
+++ b/docs/api/components.rst
@@ -141,6 +141,16 @@ TextDisplay
     :members:
     :inherited-members:
 
+
+UnfurledMediaItem
+~~~~~~~~~~~~~~~~~
+
+.. attributetable:: UnfurledMediaItem
+
+.. autoclass:: UnfurledMediaItem()
+    :members:
+    :inherited-members:
+
 Thumbnail
 ~~~~~~~~~
 

--- a/docs/api/components.rst
+++ b/docs/api/components.rst
@@ -231,8 +231,8 @@ SelectDefaultValueType
 .. autoclass:: SelectDefaultValueType()
     :members:
 
-SeparatorSpacingSize
-~~~~~~~~~~~~~~~~~~~~
+SeparatorSpacing
+~~~~~~~~~~~~~~~~
 
-.. autoclass:: SeparatorSpacingSize()
+.. autoclass:: SeparatorSpacing()
     :members:

--- a/docs/api/ui.rst
+++ b/docs/api/ui.rst
@@ -219,3 +219,5 @@ Functions
     :decorator:
 
 .. autofunction:: walk_components
+
+.. autofunction:: components_from_message

--- a/docs/api/ui.rst
+++ b/docs/api/ui.rst
@@ -217,3 +217,5 @@ Functions
 
 .. autofunction:: user_select(cls=UserSelect, *, custom_id=..., placeholder=None, min_values=1, max_values=1, disabled=False, default_values=None, row=None)
     :decorator:
+
+.. autofunction:: walk_components

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,7 @@ rst_prolog = """
 .. |coro| replace:: This function is a |coroutine_link|_.
 .. |maybecoro| replace:: This function *could be a* |coroutine_link|_.
 .. |coroutine_link| replace:: *coroutine*
-.. |components_type| replace:: Union[:class:`disnake.ui.UIComponent`, List[Union[:class:`disnake.ui.UIComponent`, List[:class:`disnake.ui.WrappedComponent`]]]]
+.. |components_type| replace:: Union[:class:`~disnake.ui.UIComponent`, List[Union[:class:`~disnake.ui.UIComponent`, List[:class:`~disnake.ui.WrappedComponent`]]]]
 .. |resource_type| replace:: Union[:class:`bytes`, :class:`.Asset`, :class:`.Emoji`, :class:`.PartialEmoji`, :class:`.StickerItem`, :class:`.Sticker`]
 .. _coroutine_link: https://docs.python.org/3/library/asyncio-task.html#coroutine
 """

--- a/examples/components_v2.py
+++ b/examples/components_v2.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+
+"""An example showcasing v2/layout components."""
+
+import os
+from typing import Any
+
+from disnake import ui
+from disnake.ext import commands
+
+bot = commands.Bot(command_prefix=commands.when_mentioned)
+
+
+@bot.command()
+async def send_components(ctx: commands.Context):
+    media_data: Any = ...  # placeholder for actual data
+
+    await ctx.send(
+        components=[
+            ui.TextDisplay("@user's current activity:"),
+            ui.Container(
+                ui.Section(
+                    f"Listening to {media_data.title}",
+                    accessory=ui.Thumbnail(media_data.album_cover.url),
+                ),
+                ui.ActionRow(ui.Button(label="Open in Browser", url=media_data.link)),
+            ),
+        ]
+    )
+
+
+@bot.event
+async def on_ready():
+    print(f"Logged in as {bot.user} (ID: {bot.user.id})\n------")
+
+
+if __name__ == "__main__":
+    bot.run(os.getenv("BOT_TOKEN"))

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -206,7 +206,7 @@ class TestActionRow:
         assert_type(ActionRow(button1, select), ActionRow[ActionRowMessageComponent])
         assert_type(ActionRow(select, button1), ActionRow[ActionRowMessageComponent])
 
-        # TODO: no longer works since the overload changed for normalize_components. may revisit this.
+        # FIXME: no longer works since the overload changed for normalize_components. may revisit this.
         # # these should fail to type-check - if they pass, there will be an error
         # # because of the unnecessary ignore comment
         # ActionRow(button1, text_input)

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -16,7 +16,7 @@ from disnake.ui import (
     WrappedComponent,
 )
 from disnake.ui._types import ActionRowMessageComponent, ActionRowModalComponent
-from disnake.ui.action_row import components_to_dict, normalize_components
+from disnake.ui.action_row import normalize_components, normalize_components_to_dict
 
 button1 = Button()
 button2 = Button()
@@ -279,8 +279,8 @@ def test_normalize_components__invalid() -> None:
             normalize_components(value)  # type: ignore
 
 
-def test_components_to_dict() -> None:
-    result = components_to_dict([button1, button2, select, ActionRow(button3)])
+def test_normalize_components_to_dict() -> None:
+    result, is_v2 = normalize_components_to_dict([button1, button2, select, ActionRow(button3)])
     assert result == [
         {
             "type": 1,
@@ -298,3 +298,9 @@ def test_components_to_dict() -> None:
             "components": [button3.to_component_dict()],
         },
     ]
+    assert not is_v2
+
+
+def test_normalize_components_to_dict__v2() -> None:
+    _, is_v2 = normalize_components_to_dict([button1, separator, button2])
+    assert is_v2

--- a/tests/ui/test_action_row.py
+++ b/tests/ui/test_action_row.py
@@ -263,14 +263,17 @@ def test_components_to_dict() -> None:
     assert result == [
         {
             "type": 1,
+            "id": 0,
             "components": [button1.to_component_dict(), button2.to_component_dict()],
         },
         {
             "type": 1,
+            "id": 0,
             "components": [select.to_component_dict()],
         },
         {
             "type": 1,
+            "id": 0,
             "components": [button3.to_component_dict()],
         },
     ]

--- a/tests/ui/test_components.py
+++ b/tests/ui/test_components.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+
+import inspect
+from typing import List, Type
+
+import pytest
+
+from disnake import ui
+
+all_ui_component_types: List[Type[ui.UIComponent]] = [
+    c
+    for c in ui.__dict__.values()
+    if isinstance(c, type) and issubclass(c, ui.UIComponent) and not inspect.isabstract(c)
+]
+
+all_ui_component_objects: List[ui.UIComponent] = [
+    ui.ActionRow(),
+    ui.Button(),
+    ui.ChannelSelect(),
+    ui.MentionableSelect(),
+    ui.RoleSelect(),
+    ui.StringSelect(),
+    ui.UserSelect(),
+    ui.TextInput(label="", custom_id=""),
+    ui.Section(accessory=ui.Button()),
+    ui.TextDisplay(""),
+    ui.Thumbnail(""),
+    ui.MediaGallery(),
+    ui.File(""),
+    ui.Separator(),
+    ui.Container(),
+]
+
+_missing = set(all_ui_component_types) ^ set(map(type, all_ui_component_objects))
+assert not _missing, f"missing component objects: {_missing}"
+
+
+@pytest.mark.parametrize(
+    "obj",
+    all_ui_component_objects,
+    ids=[type(o).__name__ for o in all_ui_component_objects],
+)
+def test_id_property(obj: ui.UIComponent) -> None:
+    assert obj.id == 0
+    obj.id = 1234
+    assert obj.id == 1234
+
+    if isinstance(obj, ui.Item):
+        obj2 = type(obj).from_component(obj._underlying)
+        assert obj2.id == 1234

--- a/tests/ui/test_components.py
+++ b/tests/ui/test_components.py
@@ -26,7 +26,7 @@ all_ui_component_objects: List[ui.UIComponent] = [
     ui.TextDisplay(""),
     ui.Thumbnail(""),
     ui.MediaGallery(),
-    ui.File(""),
+    ui.File("attachment://x"),
     ui.Separator(),
     ui.Container(),
 ]

--- a/tests/ui/test_components.py
+++ b/tests/ui/test_components.py
@@ -45,6 +45,5 @@ def test_id_property(obj: ui.UIComponent) -> None:
     obj.id = 1234
     assert obj.id == 1234
 
-    if isinstance(obj, ui.Item):
-        obj2 = type(obj).from_component(obj._underlying)
-        assert obj2.id == 1234
+    obj2 = type(obj).from_component(obj._underlying)
+    assert obj2.id == 1234


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/af1843d15bca8fffb76e1421fbb060761361d469

This implements the new v2 components, including:
- `Section`: displays a thumbnail or button next to some text
- `TextDisplay`: plaintext, but as a component
- `MediaGallery`: gallery/mosaic for up to 10 images
- `File`: non-image attachments
- `Separator`: vertical spacer/separator
- `Container`: can be considered similar to an `Embed`

These new components are all non-interactive and intended for layout only, they are quite a bit more flexible than the previous `content`/`embeds`/`attachments`/`components` combo, and allow for much nicer looking/better structured messages.

### Scope
I feel like it's worth clarifying that this is about as straightforward as the interface could be, only building on the existing implementation/functionality for components. There may very well be better ways (in terms of DX) to implement these components (namely, builder pattern, yippee), but I've considered this out of scope from the start.
I've intentionally not implemented support for the new components in `View`s, given the intended scope of this PR and the complexities that somehow integrating them would bring, especially since all of the components are non-interactive.
The goal with this PR was to get just about *the* most basic implementation going, any further work building on top of it will be in separate future PRs.

### Example
<details><summary>code</summary>

```py
components: Sequence[ui.UIComponent] = [
    ui.TextDisplay("test"),
    ui.Separator(),
    ui.Container(
        ui.TextDisplay("this is text inside a container"),
        ui.MediaGallery(
            disnake.MediaGalleryItem(
                media="https://placecats.com/900/600",
                description="a cool media item",
            ),
            disnake.MediaGalleryItem(
                media="https://placecats.com/800/600",
                description="more kitty",
                spoiler=True,
            ),
        ),
        ui.Section(
            ui.TextDisplay(
                "What an incredible media gallery.\nOkay, that's all the time I've got. I got to get back to playing Animal Crossing New Leaf on my Nintendo 3DS."
            ),
            accessory=ui.Thumbnail(
                media="https://i.kym-cdn.com/entries/icons/facebook/000/026/585/reggie_animalcrossingtour.jpg",
                description="desc",
            ),
        ),
        ui.Separator(spacing=disnake.SeparatorSpacingSize.large),
        ui.ActionRow(disnake.ui.ChannelSelect(placeholder="Choose a Channel!")),
        accent_colour=disnake.Colour(0xEE99CC),
        spoiler=False,
    ),
]

await inter.response.send_message(components=components, flags=disnake.MessageFlags(is_components_v2=True))
```
</details>

![image](https://github.com/user-attachments/assets/5154e6dd-c4da-4c25-be8c-d363f239d8d1)


## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
