### PR TITLE
feat: add recurrence rule support to GuildScheduledEvent

### DIFF
--- a/changelog/1295.feature.rst
+++ b/changelog/1295.feature.rst
@@ -1,0 +1,1 @@
+Added support for recurrence rules to ``GuildScheduledEvent`` via the ``recurrence_rule`` parameter.

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -59,6 +59,9 @@ __all__ = (
     "GuildScheduledEventEntityType",
     "GuildScheduledEventStatus",
     "GuildScheduledEventPrivacyLevel",
+    "GuildScheduledEventFrequency",
+    "GuildScheduledEventWeekday",
+    "GuildScheduledEventMonth",
     "ThreadArchiveDuration",
     "WidgetStyle",
     "Locale",
@@ -1450,6 +1453,59 @@ class GuildScheduledEventStatus(Enum):
 
     .. versionadded:: 2.6
     """
+
+
+class GuildScheduledEventFrequency(Enum):
+    """Represents the frequency of recurrence for a scheduled event.
+
+    This determines how often the event should repeat, such as daily, weekly, monthly, or yearly.
+
+    .. versionadded:: 2.11
+    """
+
+    YEARLY = 0
+    MONTHLY = 1
+    WEEKLY = 2
+    DAILY = 3
+
+
+class GuildScheduledEventWeekday(Enum):
+    """Represents the day of the week used in recurrence rules.
+
+    Used for specifying which days an event should recur on.
+
+    .. versionadded:: 2.11
+    """
+
+    MONDAY = 0
+    TUESDAY = 1
+    WEDNESDAY = 2
+    THURSDAY = 3
+    FRIDAY = 4
+    SATURDAY = 5
+    SUNDAY = 6
+
+
+class GuildScheduledEventMonth(Enum):
+    """Represents the month of the year used in recurrence rules.
+
+    Used for specifying which months an event should recur on.
+
+    .. versionadded:: 2.11
+    """
+
+    JANUARY = 1
+    FEBRUARY = 2
+    MARCH = 3
+    APRIL = 4
+    MAY = 5
+    JUNE = 6
+    JULY = 7
+    AUGUST = 8
+    SEPTEMBER = 9
+    OCTOBER = 10
+    NOVEMBER = 11
+    DECEMBER = 12
 
 
 class GuildScheduledEventPrivacyLevel(Enum):

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -2579,7 +2579,7 @@ class Guild(Hashable):
         Based on the recurrence frequency, there are different restrictions regarding other parameter values, as shown below:
 
         .. csv-table::
-            :header: "`Frequency`", "`A`llowed Fields`", "`Notes`"
+            :header: "``Frequency``", "``A`llowed Fields``", "``Notes``"
             :widths: 15, 35, 50
 
             "Daily (3)", "by_weekday", "Must match one of the approved weekday sets (e.g. Mon-Fri, Sat-Sun)"

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -335,7 +335,7 @@ class GuildScheduledEvent(Hashable):
         "entity_type",
         "entity_id",
         "entity_metadata",
-        "recurrence_rulecreator",
+        "recurrence_rule",
         "user_count",
         "_image",
         "_cs_guild",

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, overload
 
+from disnake import utils
+
 from .asset import Asset
 from .enums import (
     ChannelType,
@@ -211,7 +213,7 @@ class GuildScheduledEventRecurrenceRule:
 
     def to_dict(self) -> GuildScheduledEventRecurrenceRulePayload:
         data: GuildScheduledEventRecurrenceRulePayload = {
-            "start": self.start.isoformat(),
+            "start": utils.isoformat_utc(self.start),
             "frequency": self.frequency.value,
             "interval": self.interval,
         }

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -137,8 +137,8 @@ class GuildScheduledEventRecurrenceRule:
 
         Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.WEEKLY` if greater than ``1``.
 
-    by_weekday: Optional[List[:class:`int`]]
-        A list of integers representing weekdays the event repeats on (0 = Monday, ..., 6 = Sunday).
+    by_weekday: Optional[List[:class:`GuildScheduledEventWeekday`]]
+        A list of :class:`GuildScheduledEventWeekday` values indicating the weekdays the event repeats on.
 
         Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.DAILY` or
         :attr:`GuildScheduledEventFrequency.WEEKLY`.
@@ -146,7 +146,7 @@ class GuildScheduledEventRecurrenceRule:
         - For ``DAILY`` frequency: Must match one of the allowed weekday sets.
         - For ``WEEKLY`` frequency: May only contain one entry.
 
-    by_n_weekday: List[:class:`GuildScheduledEventNWeekday`]
+    by_n_weekday: Optional[List[:class:`GuildScheduledEventNWeekday`]]
         A list of weekday-within-week combinations, such as "2nd Tuesday".
 
         Each item represents a specific week (1-5) and a weekday (0 = Monday, ..., 6 = Sunday),
@@ -155,14 +155,14 @@ class GuildScheduledEventRecurrenceRule:
         - Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.MONTHLY`.
         - Must contain exactly one item.
 
-    by_month: List[:class:`int`]
-        A list of month numbers (1 = January, ..., 12 = December).
+    by_month: Optional[List[:class:`GuildScheduledEventMonth`]]
+        A list of month values, represented by :class:`GuildScheduledEventMonth`.
 
         - Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.YEARLY`.
         - Must be used together with ``by_month_day``.
         - Must contain exactly one item.
 
-    by_month_day: List[:class:`int`]
+    by_month_day: Optional[List[:class:`int`]]
         A list of days in the month (1-31).
 
         - Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.YEARLY`.

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -235,19 +235,28 @@ class GuildScheduledEventRecurrenceRule:
             start=datetime.fromisoformat(data["start"]),
             frequency=GuildScheduledEventFrequency(data["frequency"]),
             interval=data.get("interval", 1),
-            by_weekday=[GuildScheduledEventWeekday(d) for d in data.get("by_weekday", [])]
-            if "by_weekday" in data
-            else None,
-            by_n_weekday=[
-                GuildScheduledEventNWeekday(n=nd["n"], day=GuildScheduledEventWeekday(nd["day"]))
-                for nd in data.get("by_n_weekday", [])
-            ]
-            if "by_n_weekday" in data
-            else None,
-            by_month=[GuildScheduledEventMonth(m) for m in data.get("by_month", [])]
-            if "by_month" in data
-            else None,
-            by_month_day=data.get("by_month_day"),
+            by_weekday=(
+                [GuildScheduledEventWeekday(d) for d in data.get("by_weekday", [])]
+                if data.get("by_weekday") is not None
+                else None
+            ),
+            by_n_weekday=(
+                [
+                    GuildScheduledEventNWeekday(
+                        n=nd["n"],
+                        day=GuildScheduledEventWeekday(nd["day"]),
+                    )
+                    for nd in data.get("by_n_weekday", [])
+                ]
+                if data.get("by_n_weekday") is not None
+                else None
+            ),
+            by_month=(
+                [GuildScheduledEventMonth(m) for m in data.get("by_month", [])]
+                if data.get("by_month") is not None
+                else None
+            ),
+            by_month_day=(data["by_month_day"] if data.get("by_month_day") is not None else None),
         )
 
 

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -9,8 +9,11 @@ from .asset import Asset
 from .enums import (
     ChannelType,
     GuildScheduledEventEntityType,
+    GuildScheduledEventFrequency,
+    GuildScheduledEventMonth,
     GuildScheduledEventPrivacyLevel,
     GuildScheduledEventStatus,
+    GuildScheduledEventWeekday,
     try_enum,
 )
 from .mixins import Hashable
@@ -33,11 +36,48 @@ if TYPE_CHECKING:
     from .types.guild_scheduled_event import (
         GuildScheduledEvent as GuildScheduledEventPayload,
         GuildScheduledEventEntityMetadata as GuildScheduledEventEntityMetadataPayload,
+        GuildScheduledEventNWeekday as GuildScheduledEventNWeekdayPayload,
+        GuildScheduledEventRecurrenceRule as GuildScheduledEventRecurrenceRulePayload,
     )
     from .user import User
 
+__all__ = (
+    "GuildScheduledEventMetadata",
+    "GuildScheduledEvent",
+    "GuildScheduledEventRecurrenceRule",
+    "GuildScheduledEventNWeekday",
+)
 
-__all__ = ("GuildScheduledEventMetadata", "GuildScheduledEvent")
+
+class GuildScheduledEventNWeekday:
+    """Represents a specific weekday occurrence within a month for recurrence rules.
+
+    .. versionadded:: 2.11
+
+    Attributes
+    ----------
+    n: :class:`int`
+        The week number (1-5) that the event should occur on.
+
+    day: :class:`GuildScheduledEventWeekday`
+        The day of the week (e.g. :attr:`GuildScheduledEventWeekday.TUESDAY`) the event should occur on.
+    """
+
+    __slots__ = ("n", "day")
+
+    def __init__(self, *, n: int, day: GuildScheduledEventWeekday) -> None:
+        self.n = n
+        self.day = day
+
+    def __repr__(self) -> str:
+        return f"<GuildScheduledEventNWeekday n={self.n!r} day={self.day!r}>"
+
+    def to_dict(self) -> GuildScheduledEventNWeekdayPayload:
+        return {"n": self.n, "day": self.day.value}
+
+    @classmethod
+    def from_dict(cls, data: GuildScheduledEventNWeekdayPayload) -> GuildScheduledEventNWeekday:
+        return cls(n=data["n"], day=GuildScheduledEventWeekday(data["day"]))
 
 
 class GuildScheduledEventMetadata:
@@ -70,6 +110,131 @@ class GuildScheduledEventMetadata:
         cls, data: GuildScheduledEventEntityMetadataPayload
     ) -> GuildScheduledEventMetadata:
         return GuildScheduledEventMetadata(location=data.get("location"))
+
+
+class GuildScheduledEventRecurrenceRule:
+    """Represents the recurrence rule payload used when creating a scheduled event.
+
+    This structure defines how and when a scheduled event repeats.
+
+    Certain combinations and values are restricted by the Discord client.
+    See the `official Discord documentation on recurrence rules <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-recurrence-rule-object>`__
+    for detailed constraints and valid combinations.
+
+    .. versionadded:: 2.11
+
+    Attributes
+    ----------
+    start: :class:`str`
+        An ISO8601 timestamp representing the start time of the recurrence interval.
+
+    frequency: :class:`GuildScheduledEventFrequency`
+        How often the event repeats.
+
+    interval: :class:`int`
+        The spacing between each occurrence. For example, a value of ``2`` with a
+        weekly frequency would mean "every other week".
+
+        Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.WEEKLY` if greater than ``1``.
+
+    by_weekday: Optional[List[:class:`int`]]
+        A list of integers representing weekdays the event repeats on (0 = Monday, ..., 6 = Sunday).
+
+        Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.DAILY` or
+        :attr:`GuildScheduledEventFrequency.WEEKLY`.
+
+        - For ``DAILY`` frequency: Must match one of the allowed weekday sets.
+        - For ``WEEKLY`` frequency: May only contain one entry.
+
+    by_n_weekday: List[:class:`GuildScheduledEventNWeekday`]
+        A list of weekday-within-week combinations, such as "2nd Tuesday".
+
+        Each item represents a specific week (1-5) and a weekday (0 = Monday, ..., 6 = Sunday),
+        indicating a recurring event like "third Friday of every month".
+
+        - Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.MONTHLY`.
+        - Must contain exactly one item.
+
+    by_month: List[:class:`int`]
+        A list of month numbers (1 = January, ..., 12 = December).
+
+        - Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.YEARLY`.
+        - Must be used together with ``by_month_day``.
+        - Must contain exactly one item.
+
+    by_month_day: List[:class:`int`]
+        A list of days in the month (1-31).
+
+        - Valid only when ``frequency`` is :attr:`GuildScheduledEventFrequency.YEARLY`.
+        - Must be used together with ``by_month``.
+        - Must contain exactly one item.
+    """
+
+    __slots__ = (
+        "start",
+        "frequency",
+        "interval",
+        "by_weekday",
+        "by_n_weekday",
+        "by_month",
+        "by_month_day",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<GuildScheduledEventRecurrenceRule "
+            f"start={self.start!r} frequency={self.frequency.name} interval={self.interval} "
+            f"by_weekday={self.by_weekday!r} "
+            f"by_n_weekday={self.by_n_weekday!r} "
+            f"by_month={self.by_month!r} "
+            f"by_month_day={self.by_month_day!r}>"
+        )
+
+    def __init__(self, data: GuildScheduledEventRecurrenceRulePayload) -> None:
+        self.start = datetime.fromisoformat(data["start"])
+        self.frequency = GuildScheduledEventFrequency(data["frequency"])
+        self.interval = data.get("interval", 1)
+        self.by_weekday = (
+            [GuildScheduledEventWeekday(d) for d in data["by_weekday"]]
+            if "by_weekday" in data
+            else None
+        )
+        self.by_n_weekday = (
+            [
+                GuildScheduledEventNWeekday(n=nd["n"], day=GuildScheduledEventWeekday(nd["day"]))
+                for nd in data["by_n_weekday"]
+            ]
+            if "by_n_weekday" in data
+            else None
+        )
+        self.by_month = (
+            [GuildScheduledEventMonth(m) for m in data["by_month"]] if "by_month" in data else None
+        )
+        self.by_month_day = data.get("by_month_day")
+
+    def to_dict(self) -> GuildScheduledEventRecurrenceRulePayload:
+        data: GuildScheduledEventRecurrenceRulePayload = {
+            "start": self.start.isoformat(),
+            "frequency": self.frequency.value,
+            "interval": self.interval,
+        }
+
+        if self.by_weekday:
+            data["by_weekday"] = [d.value for d in self.by_weekday]
+        if self.by_n_weekday:
+            data["by_n_weekday"] = [{"n": n.n, "day": n.day.value} for n in self.by_n_weekday]
+        if self.by_month:
+            data["by_month"] = [m.value for m in self.by_month]
+        if self.by_month_day:
+            data["by_month_day"] = self.by_month_day
+
+        return data
+
+    @classmethod
+    def from_dict(
+        cls, data: GuildScheduledEventRecurrenceRulePayload
+    ) -> GuildScheduledEventRecurrenceRule:
+        return cls(data)
 
 
 class GuildScheduledEvent(Hashable):
@@ -124,6 +289,9 @@ class GuildScheduledEvent(Hashable):
         The ID of an entity associated with the guild scheduled event.
     entity_metadata: :class:`GuildScheduledEventMetadata`
         Additional metadata for the guild scheduled event.
+    recurrence_rule: :class:`GuildScheduledEventRecurrenceRule`
+        An optional recurrence rule that specifies how the event should repeat over time.
+        This allows for recurring scheduled events such as weekly meetings or monthly check-ins.
     user_count: Optional[:class:`int`]
         The number of users subscribed to the guild scheduled event.
         If the guild scheduled event was fetched with ``with_user_count`` set to ``False``, this field is ``None``.
@@ -144,7 +312,7 @@ class GuildScheduledEvent(Hashable):
         "entity_type",
         "entity_id",
         "entity_metadata",
-        "creator",
+        "recurrence_rulecreator",
         "user_count",
         "_image",
         "_cs_guild",
@@ -178,6 +346,13 @@ class GuildScheduledEvent(Hashable):
             None if metadata is None else GuildScheduledEventMetadata.from_dict(metadata)
         )
 
+        recurrence_rule = data.get("recurrence_rule")
+        self.recurrence_rule: Optional[GuildScheduledEventRecurrenceRule] = (
+            None
+            if recurrence_rule is None
+            else GuildScheduledEventRecurrenceRule.from_dict(recurrence_rule)
+        )
+
         creator_data = data.get("creator")
         self.creator: Optional[User]
         if creator_data is not None:
@@ -201,6 +376,7 @@ class GuildScheduledEvent(Hashable):
             ("status", self.status),
             ("entity_type", self.entity_type),
             ("entity_metadata", self.entity_metadata),
+            ("recurrence_rule", self.recurrence_rule),
             ("creator", self.creator),
         )
         inner = " ".join(f"{k!s}={v!r}" for k, v in attrs)

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -326,6 +326,7 @@ class GuildScheduledEvent(Hashable):
         "guild_id",
         "channel_id",
         "creator_id",
+        "creator",
         "name",
         "description",
         "scheduled_start_time",

--- a/disnake/guild_scheduled_event.py
+++ b/disnake/guild_scheduled_event.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, overload
 
 from .asset import Asset
 from .enums import (
@@ -190,27 +190,24 @@ class GuildScheduledEventRecurrenceRule:
             f"by_month_day={self.by_month_day!r}>"
         )
 
-    def __init__(self, data: GuildScheduledEventRecurrenceRulePayload) -> None:
-        self.start = datetime.fromisoformat(data["start"])
-        self.frequency = GuildScheduledEventFrequency(data["frequency"])
-        self.interval = data.get("interval", 1)
-        self.by_weekday = (
-            [GuildScheduledEventWeekday(d) for d in data["by_weekday"]]
-            if "by_weekday" in data
-            else None
-        )
-        self.by_n_weekday = (
-            [
-                GuildScheduledEventNWeekday(n=nd["n"], day=GuildScheduledEventWeekday(nd["day"]))
-                for nd in data["by_n_weekday"]
-            ]
-            if "by_n_weekday" in data
-            else None
-        )
-        self.by_month = (
-            [GuildScheduledEventMonth(m) for m in data["by_month"]] if "by_month" in data else None
-        )
-        self.by_month_day = data.get("by_month_day")
+    def __init__(
+        self,
+        *,
+        start: datetime,
+        frequency: GuildScheduledEventFrequency,
+        interval: int = 1,
+        by_weekday: Optional[List[GuildScheduledEventWeekday]] = None,
+        by_n_weekday: Optional[List[GuildScheduledEventNWeekday]] = None,
+        by_month: Optional[List[GuildScheduledEventMonth]] = None,
+        by_month_day: Optional[List[int]] = None,
+    ) -> None:
+        self.start = start
+        self.frequency = frequency
+        self.interval = interval
+        self.by_weekday = by_weekday
+        self.by_n_weekday = by_n_weekday
+        self.by_month = by_month
+        self.by_month_day = by_month_day
 
     def to_dict(self) -> GuildScheduledEventRecurrenceRulePayload:
         data: GuildScheduledEventRecurrenceRulePayload = {
@@ -234,7 +231,24 @@ class GuildScheduledEventRecurrenceRule:
     def from_dict(
         cls, data: GuildScheduledEventRecurrenceRulePayload
     ) -> GuildScheduledEventRecurrenceRule:
-        return cls(data)
+        return cls(
+            start=datetime.fromisoformat(data["start"]),
+            frequency=GuildScheduledEventFrequency(data["frequency"]),
+            interval=data.get("interval", 1),
+            by_weekday=[GuildScheduledEventWeekday(d) for d in data.get("by_weekday", [])]
+            if "by_weekday" in data
+            else None,
+            by_n_weekday=[
+                GuildScheduledEventNWeekday(n=nd["n"], day=GuildScheduledEventWeekday(nd["day"]))
+                for nd in data.get("by_n_weekday", [])
+            ]
+            if "by_n_weekday" in data
+            else None,
+            by_month=[GuildScheduledEventMonth(m) for m in data.get("by_month", [])]
+            if "by_month" in data
+            else None,
+            by_month_day=data.get("by_month_day"),
+        )
 
 
 class GuildScheduledEvent(Hashable):

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2141,6 +2141,7 @@ class HTTPClient:
         entity_type: int,
         channel_id: Optional[Snowflake] = None,
         entity_metadata: Optional[Dict[str, Any]] = None,
+        recurrence_rule: Optional[Dict[str, Any]] = None,
         scheduled_end_time: Optional[str] = None,
         description: Optional[str] = None,
         image: Optional[str] = None,
@@ -2168,6 +2169,9 @@ class HTTPClient:
 
         if image is not None:
             payload["image"] = image
+
+        if recurrence_rule is not None:
+            payload["recurrence_rule"] = recurrence_rule
 
         return self.request(r, json=payload, reason=reason)
 

--- a/disnake/types/guild_scheduled_event.py
+++ b/disnake/types/guild_scheduled_event.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-from typing import Literal, Optional, TypedDict
+from typing import List, Literal, Optional, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -11,6 +11,7 @@ from .user import User
 GuildScheduledEventPrivacyLevel = Literal[2]
 GuildScheduledEventStatus = Literal[1, 2, 3, 4]
 GuildScheduledEventEntityType = Literal[1, 2, 3]
+GuildScheduledEventFrequency = Literal[0, 1, 2, 3]
 
 
 class GuildScheduledEventUser(TypedDict):
@@ -21,6 +22,22 @@ class GuildScheduledEventUser(TypedDict):
 
 class GuildScheduledEventEntityMetadata(TypedDict, total=False):
     location: str
+
+
+class GuildScheduledEventNWeekday(TypedDict):
+    n: int
+    day: int  # Matches Weekday enum int value (0-6)
+
+
+class GuildScheduledEventRecurrenceRule(TypedDict, total=False):
+    start: str  # ISO8601 string
+    frequency: GuildScheduledEventFrequency  # YEARLY, MONTHLY, WEEKLY, DAILY
+    interval: int
+
+    by_weekday: List[int]  # List of Weekday int values (0-6)
+    by_n_weekday: List[GuildScheduledEventNWeekday]
+    by_month: List[int]  # 1-12
+    by_month_day: List[int]  # 1-31
 
 
 class GuildScheduledEvent(TypedDict):
@@ -40,3 +57,4 @@ class GuildScheduledEvent(TypedDict):
     creator: NotRequired[User]
     user_count: NotRequired[int]
     image: NotRequired[Optional[str]]
+    recurrence_rule: Optional[GuildScheduledEventRecurrenceRule]

--- a/docs/api/guild_scheduled_events.rst
+++ b/docs/api/guild_scheduled_events.rst
@@ -10,6 +10,14 @@ This section documents everything related to Guild Scheduled Events.
 Discord Models
 ---------------
 
+GuildScheduledEventRecurrenceRule
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: GuildScheduledEventRecurrenceRule
+
+.. autoclass:: GuildScheduledEventRecurrenceRule()
+    :members:
+
 GuildScheduledEvent
 ~~~~~~~~~~~~~~~~~~~
 
@@ -37,6 +45,14 @@ GuildScheduledEventMetadata
 .. autoclass:: GuildScheduledEventMetadata
     :members:
 
+GuildScheduledEventNWeekday
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: GuildScheduledEventNWeekday
+
+.. autoclass:: GuildScheduledEventNWeekday
+    :members:
+
 Enumerations
 ------------
 
@@ -57,6 +73,131 @@ GuildScheduledEventPrivacyLevel
 
 .. autoclass:: GuildScheduledEventPrivacyLevel()
     :members:
+
+GuildScheduledEventFrequency
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: GuildScheduledEventFrequency
+
+    Represents the frequency of recurrence for a scheduled event.
+
+    This determines how often the event should repeat, such as daily, weekly, monthly, or yearly.
+
+    .. versionadded:: 2.11
+
+    .. attribute:: YEARLY
+
+        The event occurs once a year.
+
+    .. attribute:: MONTHLY
+
+        The event occurs once a month.
+
+    .. attribute:: WEEKLY
+
+        The event occurs once a week.
+
+    .. attribute:: DAILY
+
+        The event occurs every day.
+
+GuildScheduledEventWeekday
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: GuildScheduledEventWeekday
+
+    Represents the day of the week used in recurrence rules.
+
+    Used for specifying which days an event should recur on.
+
+    .. versionadded:: 2.11
+
+    .. attribute:: MONDAY
+
+        Monday.
+
+    .. attribute:: TUESDAY
+
+        Tuesday.
+
+    .. attribute:: WEDNESDAY
+
+        Wednesday.
+
+    .. attribute:: THURSDAY
+
+        Thursday.
+
+    .. attribute:: FRIDAY
+
+        Friday.
+
+    .. attribute:: SATURDAY
+
+        Saturday.
+
+    .. attribute:: SUNDAY
+
+        Sunday.
+
+GuildScheduledEventMonth
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: GuildScheduledEventMonth
+
+    Represents the month of the year used in recurrence rules.
+
+    Used for specifying which months an event should recur on.
+
+    .. versionadded:: 2.11
+
+    .. attribute:: JANUARY
+
+        January.
+
+    .. attribute:: FEBRUARY
+
+        February.
+
+    .. attribute:: MARCH
+
+        March.
+
+    .. attribute:: APRIL
+
+        April.
+
+    .. attribute:: MAY
+
+        May.
+
+    .. attribute:: JUNE
+
+        June.
+
+    .. attribute:: JULY
+
+        July.
+
+    .. attribute:: AUGUST
+
+        August.
+
+    .. attribute:: SEPTEMBER
+
+        September.
+
+    .. attribute:: OCTOBER
+
+        October.
+
+    .. attribute:: NOVEMBER
+
+        November.
+
+    .. attribute:: DECEMBER
+
+        December.
 
 Events
 ------


### PR DESCRIPTION
## Summary

This pull request adds support for recurrence rules to `GuildScheduledEvent`.

- Introduces a new `recurrence_rule` parameter to `Guild.create_scheduled_event` and `GuildScheduledEvent`.
- Adds the `GuildScheduledEventRecurrenceRule` and `GuildScheduledEventNWeekday` classes to represent and serialize recurrence data.
- Recurrence rules support weekly, monthly, and yearly patterns in accordance with Discord's official API schema.
- Includes validation logic for allowed field combinations and constraints defined by the Discord client.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
