### PR TITLE
feat: drop pdm, switch to UV

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@
 
 - [ ] If code changes were made, then they have been tested
     - [ ] I have updated the documentation to reflect the changes
-    - [ ] I have formatted the code properly by running `pdm lint`
-    - [ ] I have type-checked the code by running `pdm pyright`
+    - [ ] I have formatted the code properly by running `uv run task lint`
+    - [ ] I have type-checked the code by running `uv run task pyright`
 - [ ] This PR fixes an issue
 - [ ] This PR adds something new (e.g. new method or parameters)
 - [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)

--- a/.github/actions/cache-uv/action.yml
+++ b/.github/actions/cache-uv/action.yml
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: MIT
 
-name: Configure PDM cache
+name: Configure UV cache
 description: .
 inputs:
   env-already-initialized:
-    description: Whether Python/PDM is already configured
+    description: Whether Python/UV is already configured
     required: false
     default: 'true'
+  python-version:
+    description: Python version to use
+    required: false
+    default: '3.8'
 
 runs:
   using: composite
@@ -22,21 +26,21 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          pdm.lock
+          uv.lock
         # cache lockfile for the current day, roughly
-        key: pdm-${{ steps.get-cache-meta.outputs.date }}-${{ hashFiles('pyproject.toml') }}
-        # pdm lockfiles should be platform-agnostic
+        key: uv-${{ steps.get-cache-meta.outputs.date }}-${{ hashFiles('pyproject.toml') }}
+        # uv lockfiles should be platform-agnostic
         enableCrossOsArchive: true
 
     - if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.env-already-initialized != 'true' }}
-      name: Set up PDM
-      uses: pdm-project/setup-pdm@v4
+      name: Set up UV
+      uses: astral-sh/setup-uv@5
       with:
-        python-version: 3.8
-        version: "2.20.1"
+        python-version: ${{ inputs.python-version }}
+        version: "0.6.6"
 
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Lock all dependencies
       shell: bash
       run: |
-        pdm lock -G:all  # create pdm.lock
+       uv lock

--- a/.github/actions/cache-uv/action.yml
+++ b/.github/actions/cache-uv/action.yml
@@ -34,10 +34,10 @@ runs:
 
     - if: ${{ steps.cache.outputs.cache-hit != 'true' && inputs.env-already-initialized != 'true' }}
       name: Set up UV
-      uses: astral-sh/setup-uv@5
+      uses: astral-sh/setup-uv@6
       with:
         python-version: ${{ inputs.python-version }}
-        version: "0.6.6"
+        version: "0.8.13"
 
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Lock all dependencies

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -14,31 +14,13 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up pdm with python ${{ inputs.python-version }}
+    - name: Set up uv with python ${{ inputs.python-version }}
       id: setup-python
-      uses: pdm-project/setup-pdm@v4
+      uses: astral-sh/setup-uv@6
       with:
         python-version: ${{ inputs.python-version }}
-        version: "2.20.1"  # last version to support python 3.8
+        version: "0.8.13"
         cache: false
-
-    - name: Disable PDM version check
-      shell: bash
-      run: |
-        pdm config check_update false
-
-    - name: Ignore saved pythons
-      shell: bash
-      run: |
-        echo "PDM_IGNORE_SAVED_PYTHON=1" >> $GITHUB_ENV
-
-    - name: Update pip, wheel, setuptools
-      shell: bash
-      run: python -m pip install -U pip wheel setuptools
-
-    - name: Install nox
-      shell: bash
-      run: pip install nox
 
     - name: Set python version
       id: python-version

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -46,4 +46,4 @@ runs:
       run: echo "python-version=$(python -c 'import sys; print(".".join(map(str,sys.version_info[:2])))')" >> $GITHUB_OUTPUT
 
     - name: Configure cache
-      uses: ./.github/actions/cache-pdm
+      uses: ./.github/actions/cache-uv

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Instead of setup-env, we call the cache-pdm action here directly.
+    # Instead of setup-env, we call the cache-uv action here directly.
     # This avoids having to install PDM, only to find out the cache is already up to date sometimes.
     - name: Configure cache
-      uses: ./.github/actions/cache-pdm
+      uses: ./.github/actions/cache-uv
       with:
         env-already-initialized: false
 
@@ -83,14 +83,11 @@ jobs:
     - name: Set up environment
       id: setup-env
       uses: ./.github/actions/setup-env
-      env:
-        PDM_USE_VENV: true
-        PDM_VENV_IN_PROJECT: true
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: pdm install -d -Gspeed -Gdocs -Gvoice
+      run: uv sync --all-extras
 
     - name: Add .venv/bin to PATH
       run: dirname "$(pdm info --python)" >> $GITHUB_PATH

--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,7 @@ venvs/
 .coverage*
 coverage.xml
 __pypackages__/
-.pdm.toml
-.pdm-python
-pdm.lock
+.python-version
 uv.lock
 
 !test_bot/locale/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ __pypackages__/
 .pdm.toml
 .pdm-python
 pdm.lock
+uv.lock
 
 !test_bot/locale/*.json

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,13 +7,16 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.8"
+  jobs:
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs
+    install:
+      - "true"
+
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: false
   builder: html
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ If you're unsure about some aspect of development, feel free to use existing fil
 The general workflow can be summarized as follows:
 
 1. Fork + clone the repository.
-2. Initialize the development environment: `pdm run setup_env`.
+2. Initialize the development environment: `uv run setup_env`.
 3. Create a new branch.
 4. Commit your changes, update documentation if required.
 5. Add a changelog entry (e.g. `changelog/1234.feature.rst`).
@@ -63,11 +63,12 @@ Specific development aspects are further explained below.
 
 ### Initial setup
 
-We use [`PDM`](https://pdm-project.org/) as our dependency manager. If it isn't already installed on your system, you can follow the installation steps [here](https://pdm-project.org/latest/#installation) to get started.
+We use [`UV`][uv] as our dependency manager. If it isn't already installed on your system, you can follow the installation steps [here](https://docs.astral.sh/uv/getting-started/installation/) to get started.
 
-Once PDM is installed, use the following command to initialize a virtual environment, install the necessary development dependencies, and install the [`pre-commit`](#pre-commit) hooks.
+Once UV is installed, use the following commands to initialize a virtual environment, install the necessary development dependencies, and install the [`pre-commit`](#pre-commit) hooks.
 ```
-$ pdm run setup_env
+uv sync --all-extras --all-groups
+uv run pre-commit install --install-hooks
 ```
 
 Other tools used in this project include [ruff](https://docs.astral.sh/ruff) (formatter and linter), and [pyright](https://microsoft.github.io/pyright/#/) (type-checker). For the most part, these automatically run on every commit with no additional action required - see below for details.
@@ -107,7 +108,7 @@ Most of the time, running pre-commit will automatically fix any issues that aris
 
 ### Pyright
 
-For type-checking, run `pdm run pyright` (append `-w` to have it automatically re-check on every file change).
+For type-checking, run `uv run task pyright` (append `-w` to have it automatically re-check on every file change).
 > [!NOTE]
 > If you're using VSCode and pylance, it will use the same type-checking settings, which generally means that you don't necessarily have to run `pyright` separately.  
 > However, since we use a specific version of `pyright` (which may not match pylance's version), there can be version differences which may lead to different results.
@@ -120,4 +121,7 @@ We use [towncrier](https://github.com/twisted/towncrier) for managing our change
 
 ### Documentation
 We use Sphinx to build the project's documentation, which includes [automatically generating](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) the API Reference from docstrings using the [NumPy style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).  
-To build the documentation locally, use `pdm run docs` and visit http://127.0.0.1:8009/ once built.
+To build the documentation locally, use `uv run task docs` and visit http://127.0.0.1:8009/ once built.
+
+
+[uv]: https://docs.astral.sh/uv

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,4 @@ include disnake/py.typed
 include disnake/ext/commands/py.typed
 include disnake/ext/tasks/py.typed
 global-exclude *.py[cod]
-exclude pdm.lock
+exclude uv.lock

--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -34,7 +34,7 @@ If you are not sure what issue type to use, don't hesitate to ask in your PR.
 ``towncrier`` preserves multiple paragraphs and formatting (code blocks, lists, and so on), but for entries
 other than ``features`` it is usually better to stick to a single paragraph to keep it concise.
 
-You can also run ``pdm run docs`` to build the documentation
+You can also run ``uv run task docs`` to build the documentation
 with the draft changelog (http://127.0.0.1:8009/whats_new.html) if you want to get a preview of how your change will look in the final release notes.
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ os.environ.update(
 
 nox.options.error_on_external_run = True
 nox.options.reuse_venv = "yes"
-nox.options.default_venv_backend = "uv"
+nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.sessions = [
     "lint",
     "check-manifest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 from typing import TYPE_CHECKING, Callable, Dict, List, Tuple, TypeVar
 
@@ -17,14 +16,6 @@ if TYPE_CHECKING:
     NoxSessionFunc = Callable[Concatenate[nox.Session, P], T]
 
 PYPROJECT = nox.project.load_toml()
-
-# see https://pdm-project.org/latest/usage/advanced/#use-nox-as-the-runner
-os.environ.update(
-    {
-        "PDM_IGNORE_SAVED_PYTHON": "1",
-    },
-)
-
 
 nox.options.error_on_external_run = True
 nox.options.reuse_venv = "yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,8 @@ build = [
 ]
 
 [tool.uv]
-default-groups = ['nox', 'tools', 'changelog', 'codemod', 'typing', 'test', 'build',]
+required-version = ">=0.8.4"
+default-groups = "all"
 
 [tool.taskipy.settings]
 use_vars = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ tools = [
     "python-dotenv~=1.0.0",
     "check-manifest==0.49",
     "ruff==0.9.3",
+    "taskipy==1.14.1",
 ]
 changelog = [
     "towncrier==23.6.0",
@@ -104,20 +105,25 @@ build = [
     "twine~=5.1.1",
 ]
 
+[tool.uv]
+default-groups = ['nox', 'tools', 'changelog', 'codemod', 'typing', 'test', 'build',]
 
-[tool.pdm]
-# Ignore `requires-python` warnings when locking, the latest versions of some
-# dependencies already require >=3.9
-# See also https://pdm-project.org/en/latest/usage/config/#ignore-package-warnings
-ignore_package_warnings = ["*"]
+[tool.taskipy.settings]
+use_vars = true
 
-[tool.pdm.scripts]
-docs = { cmd = "nox -Rs docs --", help = "Build the documentation for development" }
-lint = { cmd = "nox -Rs lint --", help = "Check all files for linting errors" }
-pyright = { cmd = "nox -Rs pyright --", help = "Run pyright" }
-setup_env = { cmd = "{pdm} install -G:all", help = "Set up the local environment and all dependencies" }
-post_setup_env = { composite = ["python -m ensurepip --default-pip", "pre-commit install --install-hooks"] }
-test = { cmd = "nox -Rs test --", help = "Run pytest" }
+[tool.taskipy.variables]
+nox = "nox -Rs"
+
+[tool.taskipy.tasks]
+pre_build = "{nox} check-manifest"
+build = { cmd = "uv run -m build", help = "Build a safe version of disnake" }
+ci = { cmd = "{nox}", help = "Run all valid CI" }
+codemod = { cmd = "{nox} codemod autotyping --" }
+docs = { cmd = "{nox} docs --", help = "Build the documentation for development" }
+lint = { cmd = "{nox} lint --", help = "Check all files for linting errors" }
+pyright = { cmd = "{nox} pyright --", help = "Run pyright" }
+setup_env = { cmd = "pre-commit install --install-hooks && nox --install-only", use_vars = false }
+test = { cmd = "{nox} test --", help = "Run pytest" }
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,15 +54,6 @@ voice = [
     "PyNaCl>=1.5.0,<1.6",
     'audioop-lts==0.2.1; python_version >= "3.13"'
 ]
-docs = [
-    "sphinx==7.0.1",
-    "sphinxcontrib-trio~=1.1.2",
-    "sphinx-hoverxref==1.3.0",
-    "sphinx-autobuild~=2021.3",
-    "sphinxcontrib-towncrier==0.3.2a0",
-    "towncrier==23.6.0",
-    "sphinx-notfound-page==0.8.3",
-]
 
 [dependency-groups]
 nox = [
@@ -103,6 +94,15 @@ build = [
     "wheel~=0.40.0",
     "build~=0.10.0",
     "twine~=5.1.1",
+]
+docs = [
+    "sphinx==7.0.1",
+    "sphinxcontrib-trio~=1.1.2",
+    "sphinx-hoverxref==1.3.0",
+    "sphinx-autobuild~=2021.3",
+    "sphinxcontrib-towncrier==0.3.2a0",
+    "towncrier==23.6.0",
+    "sphinx-notfound-page==0.8.3",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ docs = [
 
 [dependency-groups]
 nox = [
-    "nox==2022.11.21",
+    "nox>=2025.2.9",
 ]
 tools = [
     "pre-commit~=3.0",


### PR DESCRIPTION
## Summary

Our current solution uses pdm for setting up and synchronizing dependencies. However, PDM is frankly, *slow*.

Testing has shown that: testing both with a cold cache, 

### Timings

#### New venv

PDM: `pdm sync  387.22s user 28.61s system 349% cpu 1:58.84 total`
uv: `uv sync --all-groups --all-extras  293.67s user 19.47s system 464% cpu 1:07.38 total`

Though, these need to be retested, as both times it included building libcst from source.

#### `nox --install-only`

PDM: `pdm run nox --install-only  282.30s user 32.77s system 116% cpu 4:31.28 total`
uv: `uv run nox --install-only  15.84s user 5.75s system 83% cpu 25.862 total`

That said, at the moment, our nox dependencies are *NOT* pinned, they use the latest version that matches the spec as we have in our pyproject.toml file.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
