### PR TITLE
fix: use ClientWSTimeout for timeout to WS

### DIFF
--- a/changelog/1324.bugfix.rst
+++ b/changelog/1324.bugfix.rst
@@ -1,0 +1,1 @@
+Properly support aiohttp 3.12 without deprecation warnings.

--- a/changelog/1324.bugfix.rst
+++ b/changelog/1324.bugfix.rst
@@ -1,1 +1,1 @@
-Properly support aiohttp 3.12 without deprecation warnings.
+Properly support aiohttp 3.11 without deprecation warnings.

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -258,7 +258,7 @@ class HTTPClient:
 
     async def ws_connect(self, url: str, *, compress: int = 0) -> aiohttp.ClientWebSocketResponse:
         if hasattr(aiohttp, "ClientWSTimeout"):
-            timeout = aiohttp.ClientWSTimeout(ws_receive=30.0, ws_close=30.0)  # pyright: ignore[reportGeneralTypeIssues]
+            timeout = aiohttp.ClientWSTimeout(ws_close=30.0)  # pyright: ignore[reportGeneralTypeIssues]
         else:
             timeout = 30.0
         return await self.__session.ws_connect(

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -257,12 +257,16 @@ class HTTPClient:
             )
 
     async def ws_connect(self, url: str, *, compress: int = 0) -> aiohttp.ClientWebSocketResponse:
+        if hasattr(aiohttp, "ClientWSTimeout"):
+            timeout = aiohttp.ClientWSTimeout(ws_receive=30.0, ws_close=30.0)  # pyright: ignore[reportGeneralTypeIssues]
+        else:
+            timeout = 30.0
         return await self.__session.ws_connect(
             url,
             proxy_auth=self.proxy_auth,
             proxy=self.proxy,
             max_msg_size=0,
-            timeout=30.0,
+            timeout=timeout,
             autoclose=False,
             headers={
                 "User-Agent": self.user_agent,


### PR DESCRIPTION
## Summary

Surfaced from migrating to uv, and seeing that our dependencies are, as a reminder, not bound to what is supported on python 3.8.

tested with the latest aiohttp version and had some deprecated warnings.

Have not tested.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
