### PR TITLE
chore: run pyrefly infer over the project

### DIFF
--- a/disnake/__main__.py
+++ b/disnake/__main__.py
@@ -5,7 +5,7 @@ import importlib.metadata
 import platform
 import sys
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 
 import aiohttp
 
@@ -232,7 +232,7 @@ _base_table = {**_ascii_table, **_byte_table}
 _translation_table = str.maketrans(_base_table)
 
 
-def to_path(parser, name: Union[str, Path], *, replace_spaces: bool = False):
+def to_path(parser, name: Union[str, Path], *, replace_spaces: bool = False) -> Path:
     if isinstance(name, Path):
         return name
 
@@ -399,7 +399,7 @@ def add_newcog_args(subparser) -> None:
     parser.add_argument("--full", help="add all special methods as well", action="store_true")
 
 
-def parse_args():
+def parse_args() -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
     parser = argparse.ArgumentParser(prog="disnake", description="Tools for helping with disnake")
     parser.add_argument("-v", "--version", action="store_true", help="shows the library version")
     parser.set_defaults(func=core)

--- a/disnake/activity.py
+++ b/disnake/activity.py
@@ -607,7 +607,7 @@ class Streaming(BaseActivity):
         return f"<Streaming name={self.name!r}>"
 
     @property
-    def twitch_name(self):
+    def twitch_name(self) -> Optional[str]:
         """Optional[:class:`str`]: If provided, the twitch name of the user streaming.
 
         This corresponds to the ``large_image`` key of the :attr:`Streaming.assets`

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -149,7 +149,7 @@ class OptionChoice:
         return payload
 
     @classmethod
-    def from_dict(cls, data: ApplicationCommandOptionChoicePayload):
+    def from_dict(cls, data: ApplicationCommandOptionChoicePayload) -> OptionChoice:
         return OptionChoice(
             name=Localized(data["name"], data=data.get("name_localizations")),
             value=data["value"],
@@ -1250,7 +1250,7 @@ class ApplicationCommandPermissions:
     def __repr__(self) -> str:
         return f"<ApplicationCommandPermissions id={self.id!r} type={self.type!r} permission={self.permission!r}>"
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return (
             self.id == other.id and self.type == other.type and self.permission == other.permission
         )

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -5133,7 +5133,9 @@ class PartialMessageable(disnake.abc.Messageable, Hashable):
         return PartialMessage(channel=self, id=message_id)
 
 
-def _guild_channel_factory(channel_type: int):
+def _guild_channel_factory(
+    channel_type: int,
+) -> Tuple[Union[Type[GuildChannelType], None], ChannelType]:
     value = try_enum(ChannelType, channel_type)
     if value is ChannelType.text:
         return TextChannel, value
@@ -5153,7 +5155,9 @@ def _guild_channel_factory(channel_type: int):
         return None, value
 
 
-def _channel_factory(channel_type: int):
+def _channel_factory(
+    channel_type: int,
+) -> Tuple[Union[Type[GuildChannelType], Type[DMChannel], Type[GroupChannel], None], ChannelType]:
     cls, value = _guild_channel_factory(channel_type)
     if value is ChannelType.private:
         return DMChannel, value
@@ -5163,14 +5167,21 @@ def _channel_factory(channel_type: int):
         return cls, value
 
 
-def _threaded_channel_factory(channel_type: int):
+def _threaded_channel_factory(
+    channel_type: int,
+) -> Tuple[
+    Union[Type[GuildChannelType], Type[DMChannel], Type[GroupChannel], Type[Thread], None],
+    ChannelType,
+]:
     cls, value = _channel_factory(channel_type)
     if value in (ChannelType.private_thread, ChannelType.public_thread, ChannelType.news_thread):
         return Thread, value
     return cls, value
 
 
-def _threaded_guild_channel_factory(channel_type: int):
+def _threaded_guild_channel_factory(
+    channel_type: int,
+) -> Tuple[Union[Type[GuildChannelType], Type[Thread], None], ChannelType]:
     cls, value = _guild_channel_factory(channel_type)
     if value in (ChannelType.private_thread, ChannelType.public_thread, ChannelType.news_thread):
         return Thread, value

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1347,7 +1347,7 @@ class Client:
             raise TypeError("activity must derive from BaseActivity.")
 
     @property
-    def status(self):
+    def status(self) -> Status:
         """:class:`.Status`: The status being used upon logging on to Discord.
 
         .. versionadded:: 2.0

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -834,7 +834,7 @@ class Embed:
         return result
 
     @classmethod
-    def set_default_colour(cls, value: Optional[Union[int, Colour]]):
+    def set_default_colour(cls, value: Optional[Union[int, Colour]]) -> Colour | None:
         """Set the default colour of all new embeds.
 
         .. versionadded:: 2.4

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -109,7 +109,7 @@ def _create_value_cls(name: str, comparable: bool) -> Type[_EnumValueBase]:
     return type(f"{parent.__name__}_{name}", (parent,), {"_cls_name": name})  # type: ignore
 
 
-def _is_descriptor(obj):
+def _is_descriptor(obj) -> bool:
     return hasattr(obj, "__get__") or hasattr(obj, "__set__") or hasattr(obj, "__delete__")
 
 

--- a/disnake/ext/commands/bot_base.py
+++ b/disnake/ext/commands/bot_base.py
@@ -84,7 +84,7 @@ def when_mentioned_or(*prefixes: str) -> Callable[[BotBase, Message], List[str]]
     :func:`.when_mentioned`
     """
 
-    def inner(bot, msg):
+    def inner(bot, msg) -> List[str]:
         r = list(prefixes)
         r = when_mentioned(bot, msg) + r
         return r

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -1297,7 +1297,7 @@ async def _actual_conversion(
         raise BadArgument(f'Converting to "{name}" failed for parameter "{param.name}".') from exc
 
 
-async def run_converters(ctx: Context, converter, argument: str, param: inspect.Parameter):
+async def run_converters(ctx: Context, converter: Any, argument: str, param: inspect.Parameter):
     """|coro|
 
     Runs converters for a given converter, argument, and parameter.

--- a/disnake/ext/commands/flags.py
+++ b/disnake/ext/commands/flags.py
@@ -138,11 +138,11 @@ class CommandSyncFlags(BaseFlags):
         return self
 
     @property
-    def _sync_enabled(self):
+    def _sync_enabled(self) -> bool:
         return self.sync_global_commands or self.sync_guild_commands
 
     @alias_flag_value
-    def sync_commands(self):
+    def sync_commands(self) -> int:
         """:class:`bool`: Whether to sync global and guild app commands.
 
         This controls the :attr:`sync_global_commands` and :attr:`sync_guild_commands` attributes.
@@ -152,17 +152,17 @@ class CommandSyncFlags(BaseFlags):
         return 1 << 3 | 1 << 4
 
     @flag_value
-    def sync_commands_debug(self):
+    def sync_commands_debug(self) -> int:
         """:class:`bool`: Whether or not to show app command sync debug messages."""
         return 1 << 0
 
     @flag_value
-    def sync_on_cog_actions(self):
+    def sync_on_cog_actions(self) -> int:
         """:class:`bool`: Whether or not to sync app commands on cog load, unload, or reload."""
         return 1 << 1
 
     @flag_value
-    def allow_command_deletion(self):
+    def allow_command_deletion(self) -> int:
         """:class:`bool`: Whether to allow commands to be deleted by automatic command sync.
 
         Current implementation of commands sync of renamed commands means that a rename of a command *will* result
@@ -171,11 +171,11 @@ class CommandSyncFlags(BaseFlags):
         return 1 << 2
 
     @flag_value
-    def sync_global_commands(self):
+    def sync_global_commands(self) -> int:
         """:class:`bool`: Whether to sync global commands."""
         return 1 << 3
 
     @flag_value
-    def sync_guild_commands(self):
+    def sync_guild_commands(self) -> int:
         """:class:`bool`: Whether to sync per-guild commands."""
         return 1 << 4

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -80,7 +80,7 @@ class _Diff(TypedDict):
     delete_ignored: NotRequired[List[ApplicationCommand]]
 
 
-def _get_to_send_from_diff(diff: _Diff):
+def _get_to_send_from_diff(diff: _Diff) -> list[ApplicationCommand]:
     return diff["no_changes"] + diff["upsert"] + diff["edit"] + diff.get("delete_ignored", [])
 
 

--- a/disnake/ext/commands/view.py
+++ b/disnake/ext/commands/view.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+from typing import Optional
+
 from .errors import ExpectedClosingQuoteError, InvalidEndOfQuotedStringError, UnexpectedQuoteError
 
 # map from opening quotes to closing quotes
@@ -33,17 +35,17 @@ class StringView:
         self.previous = 0
 
     @property
-    def current(self):
+    def current(self) -> Optional[str]:
         return None if self.eof else self.buffer[self.index]
 
     @property
-    def eof(self):
+    def eof(self) -> bool:
         return self.index >= self.end
 
     def undo(self) -> None:
         self.index = self.previous
 
-    def skip_ws(self):
+    def skip_ws(self) -> bool:
         pos = 0
         while not self.eof:
             try:
@@ -66,19 +68,19 @@ class StringView:
             return True
         return False
 
-    def read_rest(self):
+    def read_rest(self) -> str:
         result = self.buffer[self.index :]
         self.previous = self.index
         self.index = self.end
         return result
 
-    def read(self, n):
+    def read(self, n) -> str:
         result = self.buffer[self.index : self.index + n]
         self.previous = self.index
         self.index += n
         return result
 
-    def get(self):
+    def get(self) -> Optional[str]:
         try:
             result = self.buffer[self.index + 1]
         except IndexError:
@@ -88,7 +90,7 @@ class StringView:
         self.index += 1
         return result
 
-    def get_word(self):
+    def get_word(self) -> str:
         pos = 0
         while not self.eof:
             try:
@@ -103,7 +105,7 @@ class StringView:
         self.index += pos
         return result
 
-    def get_quoted_word(self):
+    def get_quoted_word(self) -> Optional[str]:
         current = self.current
         if current is None:
             return None

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -138,7 +138,7 @@ class Loop(Generic[LF]):
         else:
             await coro(*args, **kwargs)
 
-    def _try_sleep_until(self, dt: datetime.datetime):
+    def _try_sleep_until(self, dt: datetime.datetime) -> asyncio.Future[bool]:
         self._handle = SleepHandle(dt=dt, loop=self.loop)
         return self._handle.wait()
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -482,7 +482,7 @@ class SystemChannelFlags(BaseFlags, inverted=True):
         return 1 << 3
 
     @flag_value
-    def role_subscription_purchase_notifications(self):
+    def role_subscription_purchase_notifications(self) -> int:
         """:class:`bool`: Returns ``True`` if the system channel shows role
         subscription purchase/renewal notifications.
 
@@ -491,7 +491,7 @@ class SystemChannelFlags(BaseFlags, inverted=True):
         return 1 << 4
 
     @flag_value
-    def role_subscription_purchase_notification_replies(self):
+    def role_subscription_purchase_notification_replies(self) -> int:
         """:class:`bool`: Returns ``True`` if the system channel shows sticker reply
         buttons for role subscription purchase/renewal notifications.
 
@@ -612,27 +612,27 @@ class MessageFlags(BaseFlags):
         ) -> None: ...
 
     @flag_value
-    def crossposted(self):
+    def crossposted(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is the original crossposted message."""
         return 1 << 0
 
     @flag_value
-    def is_crossposted(self):
+    def is_crossposted(self) -> int:
         """:class:`bool`: Returns ``True`` if the message was crossposted from another channel."""
         return 1 << 1
 
     @flag_value
-    def suppress_embeds(self):
+    def suppress_embeds(self) -> int:
         """:class:`bool`: Returns ``True`` if the message's embeds have been suppressed."""
         return 1 << 2
 
     @flag_value
-    def source_message_deleted(self):
+    def source_message_deleted(self) -> int:
         """:class:`bool`: Returns ``True`` if the source message for this crosspost has been deleted."""
         return 1 << 3
 
     @flag_value
-    def urgent(self):
+    def urgent(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is an urgent message.
 
         An urgent message is one sent by Discord Trust and Safety.
@@ -640,7 +640,7 @@ class MessageFlags(BaseFlags):
         return 1 << 4
 
     @flag_value
-    def has_thread(self):
+    def has_thread(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is associated with a thread.
 
         .. versionadded:: 2.0
@@ -648,7 +648,7 @@ class MessageFlags(BaseFlags):
         return 1 << 5
 
     @flag_value
-    def ephemeral(self):
+    def ephemeral(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is ephemeral.
 
         .. versionadded:: 2.0
@@ -656,7 +656,7 @@ class MessageFlags(BaseFlags):
         return 1 << 6
 
     @flag_value
-    def loading(self):
+    def loading(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is a deferred
         interaction response and shows a "thinking" state.
 
@@ -665,7 +665,7 @@ class MessageFlags(BaseFlags):
         return 1 << 7
 
     @flag_value
-    def failed_to_mention_roles_in_thread(self):
+    def failed_to_mention_roles_in_thread(self) -> int:
         """:class:`bool`: Returns ``True`` if the message failed to
         mention some roles and add their members to the thread.
 
@@ -674,7 +674,7 @@ class MessageFlags(BaseFlags):
         return 1 << 8
 
     @flag_value
-    def suppress_notifications(self):
+    def suppress_notifications(self) -> int:
         """:class:`bool`: Returns ``True`` if the message does not
         trigger push and desktop notifications.
 
@@ -683,7 +683,7 @@ class MessageFlags(BaseFlags):
         return 1 << 12
 
     @flag_value
-    def is_voice_message(self):
+    def is_voice_message(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is a voice message.
 
         Messages with this flag will have a single audio attachment, and no other content.
@@ -693,7 +693,7 @@ class MessageFlags(BaseFlags):
         return 1 << 13
 
     @flag_value
-    def has_snapshot(self):
+    def has_snapshot(self) -> int:
         """:class:`bool`: Returns ``True`` if the message is a forward message.
 
         Messages with this flag will have only the forward data, and no other content.
@@ -703,7 +703,7 @@ class MessageFlags(BaseFlags):
         return 1 << 14
 
     @flag_value
-    def is_components_v2(self):
+    def is_components_v2(self) -> int:
         """:class:`bool`: Returns ``True`` if the message uses the Components V2 system.
 
         Messages with this flag will use specific components for content layout,
@@ -835,72 +835,72 @@ class PublicUserFlags(BaseFlags):
         ) -> None: ...
 
     @flag_value
-    def staff(self):
+    def staff(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a Discord Employee."""
         return UserFlags.staff.value
 
     @flag_value
-    def partner(self):
+    def partner(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a Discord Partner."""
         return UserFlags.partner.value
 
     @flag_value
-    def hypesquad(self):
+    def hypesquad(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a HypeSquad Events member."""
         return UserFlags.hypesquad.value
 
     @flag_value
-    def bug_hunter(self):
+    def bug_hunter(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a Bug Hunter"""
         return UserFlags.bug_hunter.value
 
     @flag_value
-    def hypesquad_bravery(self):
+    def hypesquad_bravery(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a HypeSquad Bravery member."""
         return UserFlags.hypesquad_bravery.value
 
     @flag_value
-    def hypesquad_brilliance(self):
+    def hypesquad_brilliance(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a HypeSquad Brilliance member."""
         return UserFlags.hypesquad_brilliance.value
 
     @flag_value
-    def hypesquad_balance(self):
+    def hypesquad_balance(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a HypeSquad Balance member."""
         return UserFlags.hypesquad_balance.value
 
     @flag_value
-    def early_supporter(self):
+    def early_supporter(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is an Early Supporter."""
         return UserFlags.early_supporter.value
 
     @flag_value
-    def team_user(self):
+    def team_user(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a Team User."""
         return UserFlags.team_user.value
 
     @flag_value
-    def system(self):
+    def system(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a system user (i.e. represents Discord officially)."""
         return UserFlags.system.value
 
     @flag_value
-    def bug_hunter_level_2(self):
+    def bug_hunter_level_2(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a Bug Hunter Level 2"""
         return UserFlags.bug_hunter_level_2.value
 
     @flag_value
-    def verified_bot(self):
+    def verified_bot(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a Verified Bot."""
         return UserFlags.verified_bot.value
 
     @flag_value
-    def verified_bot_developer(self):
+    def verified_bot_developer(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is an Early Verified Bot Developer."""
         return UserFlags.verified_bot_developer.value
 
     @alias_flag_value
-    def early_verified_bot_developer(self):
+    def early_verified_bot_developer(self) -> int:
         """:class:`bool`: An alias for :attr:`verified_bot_developer`.
 
         .. versionadded:: 1.5
@@ -908,7 +908,7 @@ class PublicUserFlags(BaseFlags):
         return UserFlags.verified_bot_developer.value
 
     @flag_value
-    def moderator_programs_alumni(self):
+    def moderator_programs_alumni(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a Discord Moderator Programs Alumni.
 
         .. versionadded:: 2.8
@@ -916,7 +916,7 @@ class PublicUserFlags(BaseFlags):
         return UserFlags.discord_certified_moderator.value
 
     @alias_flag_value
-    def discord_certified_moderator(self):
+    def discord_certified_moderator(self) -> int:
         """:class:`bool`: An alias for :attr:`moderator_programs_alumni`.
 
         .. versionadded:: 2.0
@@ -924,7 +924,7 @@ class PublicUserFlags(BaseFlags):
         return UserFlags.discord_certified_moderator.value
 
     @flag_value
-    def http_interactions_bot(self):
+    def http_interactions_bot(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is a bot that only uses HTTP interactions.
 
         .. versionadded:: 2.3
@@ -932,7 +932,7 @@ class PublicUserFlags(BaseFlags):
         return UserFlags.http_interactions_bot.value
 
     @flag_value
-    def spammer(self):
+    def spammer(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is marked as a spammer.
 
         .. versionadded:: 2.3
@@ -940,7 +940,7 @@ class PublicUserFlags(BaseFlags):
         return UserFlags.spammer.value
 
     @flag_value
-    def active_developer(self):
+    def active_developer(self) -> int:
         """:class:`bool`: Returns ``True`` if the user is an Active Developer.
 
         .. versionadded:: 2.8
@@ -1138,7 +1138,7 @@ class Intents(BaseFlags):
         return self
 
     @flag_value
-    def guilds(self):
+    def guilds(self) -> int:
         """:class:`bool`: Whether guild related events are enabled.
 
         This corresponds to the following events:
@@ -1164,7 +1164,7 @@ class Intents(BaseFlags):
         return 1 << 0
 
     @flag_value
-    def members(self):
+    def members(self) -> int:
         """:class:`bool`: Whether guild member related events are enabled.
 
         This corresponds to the following events:
@@ -1202,7 +1202,7 @@ class Intents(BaseFlags):
         return 1 << 1
 
     @flag_value
-    def moderation(self):
+    def moderation(self) -> int:
         """:class:`bool`: Whether guild moderation related events are enabled.
 
         This corresponds to the following events:
@@ -1216,7 +1216,7 @@ class Intents(BaseFlags):
         return 1 << 2
 
     @alias_flag_value
-    def bans(self):
+    def bans(self) -> int:
         """:class:`bool`: Alias of :attr:`.moderation`.
 
         .. versionchanged:: 2.8
@@ -1225,7 +1225,7 @@ class Intents(BaseFlags):
         return 1 << 2
 
     @flag_value
-    def expressions(self):
+    def expressions(self) -> int:
         """:class:`bool`: Whether events related to guild emojis, stickers, and
         soundboard sounds are enabled.
 
@@ -1255,7 +1255,7 @@ class Intents(BaseFlags):
         return 1 << 3
 
     @alias_flag_value
-    def emojis_and_stickers(self):
+    def emojis_and_stickers(self) -> int:
         """:class:`bool`: Alias of :attr:`.expressions`.
 
         .. versionadded:: 2.0
@@ -1266,7 +1266,7 @@ class Intents(BaseFlags):
         return 1 << 3
 
     @alias_flag_value
-    def emojis(self):
+    def emojis(self) -> int:
         """:class:`bool`: Alias of :attr:`.expressions`.
 
         .. versionchanged:: 2.0
@@ -1275,7 +1275,7 @@ class Intents(BaseFlags):
         return 1 << 3
 
     @flag_value
-    def integrations(self):
+    def integrations(self) -> int:
         """:class:`bool`: Whether guild integration related events are enabled.
 
         This corresponds to the following events:
@@ -1290,7 +1290,7 @@ class Intents(BaseFlags):
         return 1 << 4
 
     @flag_value
-    def webhooks(self):
+    def webhooks(self) -> int:
         """:class:`bool`: Whether guild webhook related events are enabled.
 
         This corresponds to the following events:
@@ -1302,7 +1302,7 @@ class Intents(BaseFlags):
         return 1 << 5
 
     @flag_value
-    def invites(self):
+    def invites(self) -> int:
         """:class:`bool`: Whether guild invite related events are enabled.
 
         This corresponds to the following events:
@@ -1315,7 +1315,7 @@ class Intents(BaseFlags):
         return 1 << 6
 
     @flag_value
-    def voice_states(self):
+    def voice_states(self) -> int:
         """:class:`bool`: Whether guild voice state related events are enabled.
 
         This corresponds to the following events:
@@ -1337,7 +1337,7 @@ class Intents(BaseFlags):
         return 1 << 7
 
     @flag_value
-    def presences(self):
+    def presences(self) -> int:
         """:class:`bool`: Whether guild presence related events are enabled.
 
         This corresponds to the following events:
@@ -1361,7 +1361,7 @@ class Intents(BaseFlags):
         return 1 << 8
 
     @alias_flag_value
-    def messages(self):
+    def messages(self) -> int:
         """:class:`bool`: Whether guild and direct message related events are enabled.
 
         This is a shortcut to set or get both :attr:`guild_messages` and :attr:`dm_messages`.
@@ -1392,7 +1392,7 @@ class Intents(BaseFlags):
         return (1 << 9) | (1 << 12)
 
     @flag_value
-    def guild_messages(self):
+    def guild_messages(self) -> int:
         """:class:`bool`: Whether guild message related events are enabled.
 
         See also :attr:`dm_messages` for DMs or :attr:`messages` for both.
@@ -1419,7 +1419,7 @@ class Intents(BaseFlags):
         return 1 << 9
 
     @flag_value
-    def dm_messages(self):
+    def dm_messages(self) -> int:
         """:class:`bool`: Whether direct message related events are enabled.
 
         See also :attr:`guild_messages` for guilds or :attr:`messages` for both.
@@ -1446,7 +1446,7 @@ class Intents(BaseFlags):
         return 1 << 12
 
     @flag_value
-    def message_content(self):
+    def message_content(self) -> int:
         """:class:`bool`: Whether messages will have access to message content.
 
         .. versionadded:: 2.5
@@ -1480,7 +1480,7 @@ class Intents(BaseFlags):
         return 1 << 15
 
     @alias_flag_value
-    def reactions(self):
+    def reactions(self) -> int:
         """:class:`bool`: Whether guild and direct message reaction related events are enabled.
 
         This is a shortcut to set or get both :attr:`guild_reactions` and :attr:`dm_reactions`.
@@ -1501,7 +1501,7 @@ class Intents(BaseFlags):
         return (1 << 10) | (1 << 13)
 
     @flag_value
-    def guild_reactions(self):
+    def guild_reactions(self) -> int:
         """:class:`bool`: Whether guild reaction related events are enabled.
 
         See also :attr:`dm_reactions` for DMs or :attr:`reactions` for both.
@@ -1522,7 +1522,7 @@ class Intents(BaseFlags):
         return 1 << 10
 
     @flag_value
-    def dm_reactions(self):
+    def dm_reactions(self) -> int:
         """:class:`bool`: Whether direct message reaction related events are enabled.
 
         See also :attr:`guild_reactions` for guilds or :attr:`reactions` for both.
@@ -1543,7 +1543,7 @@ class Intents(BaseFlags):
         return 1 << 13
 
     @alias_flag_value
-    def typing(self):
+    def typing(self) -> int:
         """:class:`bool`: Whether guild and direct message typing related events are enabled.
 
         This is a shortcut to set or get both :attr:`guild_typing` and :attr:`dm_typing`.
@@ -1557,7 +1557,7 @@ class Intents(BaseFlags):
         return (1 << 11) | (1 << 14)
 
     @flag_value
-    def guild_typing(self):
+    def guild_typing(self) -> int:
         """:class:`bool`: Whether guild typing related events are enabled.
 
         See also :attr:`dm_typing` for DMs or :attr:`typing` for both.
@@ -1571,7 +1571,7 @@ class Intents(BaseFlags):
         return 1 << 11
 
     @flag_value
-    def dm_typing(self):
+    def dm_typing(self) -> int:
         """:class:`bool`: Whether direct message typing related events are enabled.
 
         See also :attr:`guild_typing` for guilds or :attr:`typing` for both.
@@ -1585,7 +1585,7 @@ class Intents(BaseFlags):
         return 1 << 14
 
     @flag_value
-    def guild_scheduled_events(self):
+    def guild_scheduled_events(self) -> int:
         """:class:`bool`: Whether guild scheduled event related events are enabled.
 
         .. versionadded:: 2.3
@@ -1609,7 +1609,7 @@ class Intents(BaseFlags):
         return 1 << 16
 
     @flag_value
-    def automod_configuration(self):
+    def automod_configuration(self) -> int:
         """:class:`bool`: Whether auto moderation configuration related events are enabled.
 
         .. versionadded:: 2.6
@@ -1625,7 +1625,7 @@ class Intents(BaseFlags):
         return 1 << 20
 
     @flag_value
-    def automod_execution(self):
+    def automod_execution(self) -> int:
         """:class:`bool`: Whether auto moderation execution related events are enabled.
 
         .. versionadded:: 2.6
@@ -1639,7 +1639,7 @@ class Intents(BaseFlags):
         return 1 << 21
 
     @alias_flag_value
-    def automod(self):
+    def automod(self) -> int:
         """:class:`bool`: Whether auto moderation related events are enabled.
 
         .. versionadded:: 2.6
@@ -1658,7 +1658,7 @@ class Intents(BaseFlags):
         return (1 << 20) | (1 << 21)
 
     @alias_flag_value
-    def polls(self):
+    def polls(self) -> int:
         """:class:`bool`: Whether guild and direct message polls related events are enabled.
 
         This is a shortcut to set or get both :attr:`guild_polls` and :attr:`dm_polls`.
@@ -1673,7 +1673,7 @@ class Intents(BaseFlags):
         return (1 << 24) | (1 << 25)
 
     @flag_value
-    def guild_polls(self):
+    def guild_polls(self) -> int:
         """:class:`bool`: Whether guild polls related events are enabled.
 
         .. versionadded:: 2.10
@@ -1693,7 +1693,7 @@ class Intents(BaseFlags):
         return 1 << 24
 
     @flag_value
-    def dm_polls(self):
+    def dm_polls(self) -> int:
         """:class:`bool`: Whether direct message polls related events are enabled.
 
         .. versionadded:: 2.10
@@ -1845,7 +1845,7 @@ class MemberCacheFlags(BaseFlags):
         return self
 
     @property
-    def _empty(self):
+    def _empty(self) -> bool:
         return self.value == self.DEFAULT_VALUE
 
     @flag_value
@@ -1900,7 +1900,7 @@ class MemberCacheFlags(BaseFlags):
             raise ValueError("MemberCacheFlags.joined requires Intents.members")
 
     @property
-    def _voice_only(self):
+    def _voice_only(self) -> bool:
         return self.value == 1
 
 
@@ -2011,66 +2011,66 @@ class ApplicationFlags(BaseFlags):
         ) -> None: ...
 
     @flag_value
-    def application_auto_moderation_rule_create_badge(self):
+    def application_auto_moderation_rule_create_badge(self) -> int:
         """:class:`bool`: Returns ``True`` if the application uses the Auto Moderation API."""
         return 1 << 6
 
     @flag_value
-    def gateway_presence(self):
+    def gateway_presence(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is verified and is allowed to
         receive presence information over the gateway.
         """
         return 1 << 12
 
     @flag_value
-    def gateway_presence_limited(self):
+    def gateway_presence_limited(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is allowed to receive limited
         presence information over the gateway.
         """
         return 1 << 13
 
     @flag_value
-    def gateway_guild_members(self):
+    def gateway_guild_members(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is verified and is allowed to
         receive guild members information over the gateway.
         """
         return 1 << 14
 
     @flag_value
-    def gateway_guild_members_limited(self):
+    def gateway_guild_members_limited(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is allowed to receive limited
         guild members information over the gateway.
         """
         return 1 << 15
 
     @flag_value
-    def verification_pending_guild_limit(self):
+    def verification_pending_guild_limit(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is currently pending verification
         and has hit the guild limit.
         """
         return 1 << 16
 
     @flag_value
-    def embedded(self):
+    def embedded(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is embedded within the Discord client."""
         return 1 << 17
 
     @flag_value
-    def gateway_message_content(self):
+    def gateway_message_content(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is verified and is allowed to
         receive message content over the gateway.
         """
         return 1 << 18
 
     @flag_value
-    def gateway_message_content_limited(self):
+    def gateway_message_content_limited(self) -> int:
         """:class:`bool`: Returns ``True`` if the application is verified and is allowed to
         receive limited message content over the gateway.
         """
         return 1 << 19
 
     @flag_value
-    def application_command_badge(self):
+    def application_command_badge(self) -> int:
         """:class:`bool`: Returns ``True`` if the application has registered global application commands.
 
         .. versionadded:: 2.6
@@ -2178,7 +2178,7 @@ class ChannelFlags(BaseFlags):
         ) -> None: ...
 
     @flag_value
-    def pinned(self):
+    def pinned(self) -> int:
         """:class:`bool`: Returns ``True`` if the thread is pinned.
 
         This only applies to threads that are part of a :class:`ForumChannel` or :class:`MediaChannel`.
@@ -2186,7 +2186,7 @@ class ChannelFlags(BaseFlags):
         return 1 << 1
 
     @flag_value
-    def require_tag(self):
+    def require_tag(self) -> int:
         """:class:`bool`: Returns ``True`` if the channel requires all newly created threads to have a tag.
 
         This only applies to channels of types :class:`ForumChannel` or :class:`MediaChannel`.
@@ -2196,7 +2196,7 @@ class ChannelFlags(BaseFlags):
         return 1 << 4
 
     @flag_value
-    def hide_media_download_options(self):
+    def hide_media_download_options(self) -> int:
         """:class:`bool`: Returns ``True`` if the channel hides the embedded media download options.
 
         This only applies to channels of type :class:`MediaChannel`.
@@ -2297,21 +2297,21 @@ class AutoModKeywordPresets(ListBaseFlags):
         return self
 
     @flag_value
-    def profanity(self):
+    def profanity(self) -> int:
         """:class:`bool`: Returns ``True`` if the profanity preset is enabled
         (contains words that may be considered swearing or cursing).
         """
         return 1 << 1
 
     @flag_value
-    def sexual_content(self):
+    def sexual_content(self) -> int:
         """:class:`bool`: Returns ``True`` if the sexual content preset is enabled
         (contains sexually explicit words).
         """
         return 1 << 2
 
     @flag_value
-    def slurs(self):
+    def slurs(self) -> int:
         """:class:`bool`: Returns ``True`` if the slurs preset is enabled
         (contains insults or words that may be considered hate speech).
         """
@@ -2405,27 +2405,27 @@ class MemberFlags(BaseFlags):
         ) -> None: ...
 
     @flag_value
-    def did_rejoin(self):
+    def did_rejoin(self) -> int:
         """:class:`bool`: Returns ``True`` if the member has left and rejoined the guild."""
         return 1 << 0
 
     @flag_value
-    def completed_onboarding(self):
+    def completed_onboarding(self) -> int:
         """:class:`bool`: Returns ``True`` if the member has completed onboarding."""
         return 1 << 1
 
     @flag_value
-    def bypasses_verification(self):
+    def bypasses_verification(self) -> int:
         """:class:`bool`: Returns ``True`` if the member is able to bypass guild verification requirements."""
         return 1 << 2
 
     @flag_value
-    def started_onboarding(self):
+    def started_onboarding(self) -> int:
         """:class:`bool`: Returns ``True`` if the member has started onboarding."""
         return 1 << 3
 
     @flag_value
-    def is_guest(self):
+    def is_guest(self) -> int:
         """:class:`bool`: Returns ``True`` if the member is a guest and can only access the voice channel they were invited to.
 
         .. versionadded:: 2.10
@@ -2433,7 +2433,7 @@ class MemberFlags(BaseFlags):
         return 1 << 4
 
     @flag_value
-    def started_home_actions(self):
+    def started_home_actions(self) -> int:
         """:class:`bool`: Returns ``True`` if the member has started the Server Guide actions.
 
         .. versionadded:: 2.10
@@ -2441,7 +2441,7 @@ class MemberFlags(BaseFlags):
         return 1 << 5
 
     @flag_value
-    def completed_home_actions(self):
+    def completed_home_actions(self) -> int:
         """:class:`bool`: Returns ``True`` if the member has completed the Server Guide actions.
 
         .. versionadded:: 2.10
@@ -2449,7 +2449,7 @@ class MemberFlags(BaseFlags):
         return 1 << 6
 
     @flag_value
-    def automod_quarantined_username(self):
+    def automod_quarantined_username(self) -> int:
         """:class:`bool`: Returns ``True`` if the member's username, display name, or nickname is blocked by AutoMod.
 
         .. versionadded:: 2.10
@@ -2457,7 +2457,7 @@ class MemberFlags(BaseFlags):
         return 1 << 7
 
     @flag_value
-    def dm_settings_upsell_acknowledged(self):
+    def dm_settings_upsell_acknowledged(self) -> int:
         """:class:`bool`: Returns ``True`` if the member has dismissed the DM settings upsell.
 
         .. versionadded:: 2.10
@@ -2465,7 +2465,7 @@ class MemberFlags(BaseFlags):
         return 1 << 9
 
     @flag_value
-    def automod_quarantined_guild_tag(self):
+    def automod_quarantined_guild_tag(self) -> int:
         """:class:`bool`: Returns ``True`` if the member's guild tag is blocked by AutoMod.
 
         .. versionadded:: 2.11
@@ -2547,7 +2547,7 @@ class RoleFlags(BaseFlags):
         def __init__(self, *, in_prompt: bool = ...) -> None: ...
 
     @flag_value
-    def in_prompt(self):
+    def in_prompt(self) -> int:
         """:class:`bool`: Returns ``True`` if the role can be selected by members in an onboarding prompt."""
         return 1 << 0
 
@@ -2626,7 +2626,7 @@ class AttachmentFlags(BaseFlags):
         def __init__(self, *, is_remix: bool = ...) -> None: ...
 
     @flag_value
-    def is_remix(self):
+    def is_remix(self) -> int:
         """:class:`bool`: Returns ``True`` if the attachment has been edited using the Remix feature."""
         return 1 << 2
 
@@ -2711,17 +2711,17 @@ class SKUFlags(BaseFlags):
         ) -> None: ...
 
     @flag_value
-    def available(self):
+    def available(self) -> int:
         """:class:`bool`: Returns ``True`` if the SKU can be purchased."""
         return 1 << 2
 
     @flag_value
-    def guild_subscription(self):
+    def guild_subscription(self) -> int:
         """:class:`bool`: Returns ``True`` if the SKU is an application subscription applied to a guild."""
         return 1 << 7
 
     @flag_value
-    def user_subscription(self):
+    def user_subscription(self) -> int:
         """:class:`bool`: Returns ``True`` if the SKU is an application subscription applied to a user."""
         return 1 << 8
 
@@ -2809,12 +2809,12 @@ class ApplicationInstallTypes(ListBaseFlags):
         return self
 
     @flag_value
-    def guild(self):
+    def guild(self) -> int:
         """:class:`bool`: Returns ``True`` if installable to guilds."""
         return 1 << 0
 
     @flag_value
-    def user(self):
+    def user(self) -> int:
         """:class:`bool`: Returns ``True`` if installable to users."""
         return 1 << 1
 
@@ -2904,16 +2904,16 @@ class InteractionContextTypes(ListBaseFlags):
         return self
 
     @flag_value
-    def guild(self):
+    def guild(self) -> int:
         """:class:`bool`: Returns ``True`` if the command is usable in guilds."""
         return 1 << 0
 
     @flag_value
-    def bot_dm(self):
+    def bot_dm(self) -> int:
         """:class:`bool`: Returns ``True`` if the command is usable in DMs with the bot."""
         return 1 << 1
 
     @flag_value
-    def private_channel(self):
+    def private_channel(self) -> int:
         """:class:`bool`: Returns ``True`` if the command is usable in DMs and group DMs with other users."""
         return 1 << 2

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -100,7 +100,9 @@ if TYPE_CHECKING:
     from .state import ConnectionState
     from .template import Template
     from .threads import AnyThreadArchiveDuration, ForumTag
-    from .types.channel import PermissionOverwrite as PermissionOverwritePayload
+    from .types.channel import (
+        PermissionOverwrite as PermissionOverwritePayload,
+    )
     from .types.guild import (
         Ban as BanPayload,
         CreateGuildPlaceholderChannel,
@@ -109,7 +111,7 @@ if TYPE_CHECKING:
         GuildFeature,
         MFALevel,
     )
-    from .types.integration import IntegrationType
+    from .types.integration import Integration as IntegrationPayload, IntegrationType
     from .types.role import CreateRole as CreateRolePayload
     from .types.sticker import CreateGuildSticker as CreateStickerPayload
     from .types.threads import Thread as ThreadPayload, ThreadArchiveDurationLiteral
@@ -3302,7 +3304,9 @@ class Guild(Hashable):
         """
         data = await self._state.http.get_all_integrations(self.id)
 
-        def convert(d):
+        def convert(
+            d: IntegrationPayload,
+        ) -> Integration:
             factory, _ = _integration_factory(d["type"])
             return factory(guild=self, data=d)
 

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -43,6 +43,7 @@ from ..errors import (
 )
 from ..flags import InteractionContextTypes, MessageFlags
 from ..guild import Guild
+from ..http import HTTPClient
 from ..i18n import Localized
 from ..member import Member
 from ..message import Attachment, AuthorizingIntegrationOwners, Message
@@ -1611,17 +1612,17 @@ class _InteractionMessageState:
         self._interaction: Interaction = interaction
         self._parent: ConnectionState = parent
 
-    def _get_guild(self, guild_id):
+    def _get_guild(self, guild_id) -> Guild | None:
         return self._parent._get_guild(guild_id)
 
-    def store_user(self, data):
+    def store_user(self, data) -> User:
         return self._parent.store_user(data)
 
-    def create_user(self, data):
+    def create_user(self, data) -> User:
         return self._parent.create_user(data)
 
     @property
-    def http(self):
+    def http(self) -> HTTPClient:
         return self._parent.http
 
     def __getattr__(self, attr):

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -57,10 +57,12 @@ if TYPE_CHECKING:
         AuditLogEvent,
     )
     from .types.entitlement import Entitlement as EntitlementPayload
+    from .types.gateway import GuildMemberUpdateEvent as GuildMemberUpdateEventPayload
     from .types.guild import Ban as BanPayload, Guild as GuildPayload
     from .types.guild_scheduled_event import (
         GuildScheduledEventUser as GuildScheduledEventUserPayload,
     )
+    from .types.member import MemberWithUser as MemberWithUserPayload
     from .types.message import Message as MessagePayload
     from .types.subscription import Subscription as SubscriptionPayload
     from .types.threads import Thread as ThreadPayload
@@ -326,7 +328,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
         except asyncio.QueueEmpty:
             raise NoMoreItems from None
 
-    def _get_retrieve(self):
+    def _get_retrieve(self) -> bool:
         limit = self.limit
         if limit is None or limit > 100:
             retrieve = 100
@@ -355,7 +357,7 @@ class HistoryIterator(_AsyncIterator["Message"]):
             for element in data:
                 await self.messages.put(self.state.create_message(channel=channel, data=element))
 
-    async def _retrieve_messages(self, retrieve) -> List[MessagePayload]:
+    async def _retrieve_messages(self, retrieve: int) -> List[MessagePayload]:
         """Retrieve messages and update next parameters."""
         raise NotImplementedError
 
@@ -576,7 +578,7 @@ class AuditLogIterator(_AsyncIterator["AuditLogEntry"]):
         except asyncio.QueueEmpty:
             raise NoMoreItems from None
 
-    def _get_retrieve(self):
+    def _get_retrieve(self) -> bool:
         limit = self.limit
         if limit is None or limit > 100:
             retrieve = 100
@@ -703,12 +705,12 @@ class GuildIterator(_AsyncIterator["Guild"]):
 
         if self.before:
             self.reverse = True
-            self._retrieve_guilds = self._retrieve_guilds_before_strategy  # type: ignore
+            self._retrieve_guilds = self._retrieve_guilds_before_strategy
             if self.after:
                 self._filter = lambda m: int(m["id"]) > self.after.id  # type: ignore
         else:
             self.reverse = False
-            self._retrieve_guilds = self._retrieve_guilds_after_strategy  # type: ignore
+            self._retrieve_guilds = self._retrieve_guilds_after_strategy
 
     async def next(self) -> Guild:
         if self.guilds.empty():
@@ -719,7 +721,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         except asyncio.QueueEmpty:
             raise NoMoreItems from None
 
-    def _get_retrieve(self):
+    def _get_retrieve(self) -> bool:
         limit = self.limit
         if limit is None or limit > 200:
             retrieve = 200
@@ -728,7 +730,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
         self.retrieve = retrieve
         return retrieve > 0
 
-    def create_guild(self, data):
+    def create_guild(self, data: GuildPayload) -> Guild:
         from .guild import Guild
 
         return Guild(state=self.state, data=data)
@@ -747,11 +749,11 @@ class GuildIterator(_AsyncIterator["Guild"]):
             for element in data:
                 await self.guilds.put(self.create_guild(element))
 
-    async def _retrieve_guilds(self, retrieve) -> List[Guild]:
+    async def _retrieve_guilds(self, retrieve: int) -> List[GuildPayload]:
         """Retrieve guilds and update next parameters."""
         raise NotImplementedError
 
-    async def _retrieve_guilds_before_strategy(self, retrieve):
+    async def _retrieve_guilds_before_strategy(self, retrieve: int) -> List[GuildPayload]:
         """Retrieve guilds using before parameter."""
         before = self.before.id if self.before else None
         data: List[GuildPayload] = await self.get_guilds(
@@ -763,7 +765,7 @@ class GuildIterator(_AsyncIterator["Guild"]):
             self.before = Object(id=int(data[0]["id"]))
         return data
 
-    async def _retrieve_guilds_after_strategy(self, retrieve):
+    async def _retrieve_guilds_after_strategy(self, retrieve: int) -> List[GuildPayload]:
         """Retrieve guilds using after parameter."""
         after = self.after.id if self.after else None
         data: List[GuildPayload] = await self.get_guilds(
@@ -798,7 +800,7 @@ class MemberIterator(_AsyncIterator["Member"]):
         except asyncio.QueueEmpty:
             raise NoMoreItems from None
 
-    def _get_retrieve(self):
+    def _get_retrieve(self) -> bool:
         limit = self.limit
         if limit is None or limit > 1000:
             retrieve = 1000
@@ -823,7 +825,7 @@ class MemberIterator(_AsyncIterator["Member"]):
             for element in reversed(data):
                 await self.members.put(self.create_member(element))
 
-    def create_member(self, data):
+    def create_member(self, data: MemberWithUserPayload | GuildMemberUpdateEventPayload) -> Member:
         from .member import Member
 
         return Member(data=data, guild=self.guild, state=self.state)

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -1538,7 +1538,7 @@ class Message(Hashable):
             }
             transformations.update(role_transforms)
 
-        def repl(obj):
+        def repl(obj) -> str:
             return transformations.get(re.escape(obj.group(0)), "")
 
         pattern = re.compile("|".join(transformations.keys()))

--- a/disnake/permissions.py
+++ b/disnake/permissions.py
@@ -1093,10 +1093,10 @@ def _augment_from_permissions(cls):
             continue
 
         # god bless Python
-        def getter(self, x=key):
+        def getter(self, x: str = key):
             return self._values.get(x)
 
-        def setter(self, value, x=key) -> None:
+        def setter(self, value, x: str = key) -> None:
             self._set(x, value)
 
         prop = property(getter, setter)

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -1470,7 +1470,7 @@ class ConnectionState:
             return await request.wait()
         return request.get_future()
 
-    async def _chunk_and_dispatch(self, guild, unavailable) -> None:
+    async def _chunk_and_dispatch(self, guild: Guild, unavailable: bool | None) -> None:
         try:
             await asyncio.wait_for(self.chunk_guild(guild), timeout=60.0)
         except asyncio.TimeoutError:

--- a/disnake/template.py
+++ b/disnake/template.py
@@ -46,13 +46,13 @@ class _PartialTemplateState:
     def member_cache_flags(self):
         return self.__state.member_cache_flags
 
-    def store_emoji(self, guild, packet):
+    def store_emoji(self, guild, packet) -> None:
         return None
 
-    def _get_voice_client(self, id):
+    def _get_voice_client(self, id) -> None:
         return None
 
-    def _get_message(self, id):
+    def _get_message(self, id) -> None:
         return None
 
     def _get_guild(self, id):

--- a/disnake/ui/select/channel.py
+++ b/disnake/ui/select/channel.py
@@ -185,7 +185,7 @@ class ChannelSelect(BaseSelect[ChannelSelectMenu, "AnyChannel", V_co]):
         return self._underlying.channel_types
 
     @channel_types.setter
-    def channel_types(self, value: Optional[List[ChannelType]]):
+    def channel_types(self, value: Optional[List[ChannelType]]) -> None:
         if value is not None:
             if not isinstance(value, list):
                 raise TypeError("channel_types must be a list of ChannelType")

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -505,7 +505,7 @@ class VoiceClient(VoiceProtocol):
 
     # audio related
 
-    def _get_voice_packet(self, data):
+    def _get_voice_packet(self, data: bytes):
         header = bytearray(12)
 
         # Formulate rtp header
@@ -518,7 +518,7 @@ class VoiceClient(VoiceProtocol):
         encrypt_packet = getattr(self, f"_encrypt_{self.mode}")
         return encrypt_packet(header, data)
 
-    def _get_nonce(self, pad: int):
+    def _get_nonce(self, pad: int) -> Tuple[bytes, bytes]:
         # returns (nonce, padded_nonce).
         # n.b. all currently implemented modes use the same nonce size (192 bits / 24 bytes)
         nonce = struct.pack(">I", self._lite_nonce)

--- a/disnake/webhook/sync.py
+++ b/disnake/webhook/sync.py
@@ -879,7 +879,7 @@ class SyncWebhook(BaseWebhook):
 
     def _create_message(
         self, data, *, thread: Optional[Snowflake] = None, thread_name: Optional[str] = None
-    ):
+    ) -> SyncWebhookMessage:
         # see async webhook's _create_message for details
         channel_id = int(data["channel_id"])
         if self.channel_id != channel_id and thread_name:

--- a/docs/extensions/collapse.py
+++ b/docs/extensions/collapse.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, List
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -36,7 +36,7 @@ class CollapseDirective(Directive):
 
     option_spec: ClassVar[OptionSpec] = {"open": directives.flag}
 
-    def run(self):
+    def run(self) -> List[collapse]:
         self.assert_has_content()
         node = collapse(
             "\n".join(self.content),

--- a/docs/extensions/exception_hierarchy.py
+++ b/docs/extensions/exception_hierarchy.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
@@ -28,7 +28,7 @@ def depart_exception_hierarchy_node(self: HTMLTranslator, node: nodes.Element) -
 class ExceptionHierarchyDirective(Directive):
     has_content = True
 
-    def run(self):
+    def run(self) -> List[exception_hierarchy]:
         self.assert_has_content()
         node = exception_hierarchy("\n".join(self.content))
         self.state.nested_parse(self.content, self.content_offset, node)

--- a/docs/extensions/fulltoc.py
+++ b/docs/extensions/fulltoc.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 GROUPED_SECTIONS = {"api/": "api/index", "ext/commands/api/": "ext/commands/api/index"}
 
 
-def html_page_context(app: Sphinx, docname: str, templatename, context, doctree):
+def html_page_context(app: Sphinx, docname: str, templatename, context, doctree) -> None:
     """Event handler for the html-page-context signal.
 
     Modifies the context directly, if `docname` matches one of the items in `GROUPED_SECTIONS`.
@@ -85,7 +85,7 @@ def html_page_context(app: Sphinx, docname: str, templatename, context, doctree)
     context["parent_index"] = index
 
 
-def get_rendered_toctree(builder: StandaloneHTMLBuilder, docname: str, index: str, **kwargs):
+def get_rendered_toctree(builder: StandaloneHTMLBuilder, docname: str, index: str, **kwargs) -> str:
     """Build the toctree relative to the named document,
     with the given parameters, and then return the rendered
     HTML fragment.
@@ -100,7 +100,9 @@ def get_rendered_toctree(builder: StandaloneHTMLBuilder, docname: str, index: st
     return rendered_toc
 
 
-def build_full_toctree(builder: StandaloneHTMLBuilder, docname: str, index: str, **kwargs):
+def build_full_toctree(
+    builder: StandaloneHTMLBuilder, docname: str, index: str, **kwargs
+) -> nodes.bullet_list:
     """Return a single toctree starting from docname containing all
     sub-document doctrees.
 

--- a/docs/extensions/redirects.py
+++ b/docs/extensions/redirects.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 SCRIPT_PATH = "_templates/api_redirect.js_t"
 
 
-def collect_redirects(app: Sphinx):
+def collect_redirects(app: Sphinx) -> Dict[str, str]:
     # mapping of html node id (i.e., thing after "#" in URLs) to the correct page name
     # e.g, api.html#disnake.Thread => api/channels.html
     mapping: Dict[str, str] = {}

--- a/scripts/codemods/typed_flags.py
+++ b/scripts/codemods/typed_flags.py
@@ -57,7 +57,7 @@ class FlagTypings(BaseCodemodCommand):
         # no reason to continue into classes
         return False
 
-    def leave_ClassDef(self, _: cst.ClassDef, node: cst.ClassDef):
+    def leave_ClassDef(self, _: cst.ClassDef, node: cst.ClassDef) -> cst.ClassDef:
         if not m.matches(node.name, m.OneOf(*map(m.Name, self.flag_classes))):
             return node
 

--- a/test_bot/cogs/injections.py
+++ b/test_bot/cogs/injections.py
@@ -11,7 +11,7 @@ import disnake
 from disnake.ext import commands
 
 
-def injected(user: disnake.User, channel: disnake.TextChannel):
+def injected(user: disnake.User, channel: disnake.TextChannel) -> Tuple[int, str]:
     """An injection callback. This description should not be shown.
 
     Parameters
@@ -31,7 +31,7 @@ class PrefixConverter:
         self.prefix = prefix
         self.suffix = suffix
 
-    def __call__(self, inter: disnake.CommandInteraction[commands.Bot], a: str = "init"):
+    def __call__(self, inter: disnake.CommandInteraction[commands.Bot], a: str = "init") -> str:
         return self.prefix + a + self.suffix
 
 

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -20,7 +20,7 @@ class DecoratorMeta:
 
 
 @pytest.fixture(params=["slash", "user", "message"])
-def meta(request):
+def meta(request) -> DecoratorMeta:
     return DecoratorMeta(request.param)
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,7 +41,7 @@ class freeze_time(ContextManager):
         dt = dt or datetime.datetime.now(datetime.timezone.utc)
         assert dt.tzinfo
 
-        def fake_now(tz=None):
+        def fake_now(tz=None) -> datetime.datetime:
             return dt.astimezone(tz).replace(tzinfo=tz)
 
         self.mock_datetime = mock.MagicMock(wraps=datetime.datetime)

--- a/tests/interactions/test_base.py
+++ b/tests/interactions/test_base.py
@@ -26,7 +26,7 @@ class TestInteractionResponse:
         return disnake.InteractionResponse(inter)
 
     @pytest.fixture
-    def adapter(self):
+    def adapter(self) -> mock.AsyncMock:
         adapter = mock.AsyncMock()
         disnake.interactions.base.async_context.set(adapter)
         return adapter
@@ -132,14 +132,14 @@ class TestInteractionResponse:
 class TestInteractionDataResolved:
     # TODO: use proper mock models once we have state/guild mocks
     @pytest.fixture
-    def state(self):
+    def state(self) -> mock.Mock:
         s = mock.Mock(spec=ConnectionState)
         s._get_guild.return_value = None
         s.user = mock.Mock()
         return s
 
     @pytest.fixture
-    def interaction(self, state):
+    def interaction(self, state) -> mock.Mock:
         i = mock.Mock(spec_set=Interaction)
         i._state = state
         i.guild_id = 1234

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -14,7 +14,7 @@ from disnake.utils import MISSING
 class TestGuildChannelEdit:
     # TODO: use proper mock models once we have state/guild mocks
     @pytest.fixture
-    def channel(self):
+    def channel(self) -> mock.Mock:
         ch = mock.Mock(GuildChannel, id=123, category_id=456)
         ch._state = mock.Mock(http=mock.AsyncMock())
         ch.guild = mock.Mock()

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,27 +12,27 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def activity():
+def activity() -> _activity.Activity:
     return _activity.Activity()
 
 
 @pytest.fixture
-def game():
+def game() -> _activity.Game:
     return _activity.Game(name="Celeste")
 
 
 @pytest.fixture
-def custom_activity():
+def custom_activity() -> _activity.CustomActivity:
     return _activity.CustomActivity(name="custom")
 
 
 @pytest.fixture
-def streaming():
+def streaming() -> _activity.Streaming:
     return _activity.Streaming(name="me", url="https://disnake.dev")
 
 
 @pytest.fixture
-def spotify():
+def spotify() -> _activity.Spotify:
     return _activity.Spotify()
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -10,12 +10,12 @@ from disnake.ext import commands
 
 # n.b. the specific choice of events used in this file is irrelevant
 @pytest.fixture
-def client():
+def client() -> disnake.Client:
     return disnake.Client()
 
 
 @pytest.fixture
-def bot():
+def bot() -> commands.Bot:
     return commands.Bot(
         command_prefix=commands.when_mentioned,
         command_sync_flags=commands.CommandSyncFlags.none(),

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -15,23 +15,23 @@ class TestFlags(flags.BaseFlags):
     __test__ = False
 
     @flags.flag_value
-    def one(self):
+    def one(self) -> int:
         return 1 << 0
 
     @flags.flag_value
-    def two(self):
+    def two(self) -> int:
         return 1 << 1
 
     @flags.flag_value
-    def four(self):
+    def four(self) -> int:
         return 1 << 2
 
     @flags.alias_flag_value
-    def three(self):
+    def three(self) -> int:
         return 1 << 0 | 1 << 1
 
     @flags.flag_value
-    def sixteen(self):
+    def sixteen(self) -> int:
         return 1 << 4
 
 
@@ -39,7 +39,7 @@ class OtherTestFlags(flags.BaseFlags):
     """Another test class for flag testing."""
 
     @flags.flag_value
-    def other_one(self):
+    def other_one(self) -> int:
         return 1 << 0
 
 
@@ -62,23 +62,23 @@ def test_flag_creation() -> None:
 def test_flag_creation_inverted() -> None:
     class InvertedFlags(flags.BaseFlags, inverted=True):
         @flags.flag_value
-        def one(self):
+        def one(self) -> int:
             return 1 << 0
 
         @flags.flag_value
-        def two(self):
+        def two(self) -> int:
             return 1 << 1
 
         @flags.flag_value
-        def four(self):
+        def four(self) -> int:
             return 1 << 2
 
         @flags.alias_flag_value
-        def three(self):
+        def three(self) -> int:
             return 1 << 0 | 1 << 1
 
         @flags.flag_value
-        def sixteen(self):
+        def sixteen(self) -> int:
             return 1 << 4
 
     assert InvertedFlags.VALID_FLAGS == {
@@ -451,15 +451,15 @@ class TestBaseFlags:
 
 class _ListFlags(flags.ListBaseFlags):
     @flags.flag_value
-    def flag1(self):
+    def flag1(self) -> int:
         return 1 << 0
 
     @flags.flag_value
-    def flag2(self):
+    def flag2(self) -> int:
         return 1 << 1
 
     @flags.flag_value
-    def flag3(self):
+    def flag3(self) -> int:
         return 1 << 2
 
 


### PR DESCRIPTION
## Summary

Increase typing within the project.

Ran pyrefly over the project but then had to do a *lot* of manual fixes.

Command used: `uvx pyrefly infer --python-version 3.8 --return-types true --parameter-types true --imports true disnake tests test_bot scripts examples`



However, it increases the type completeness a bit.

```diff
  Symbols exported by "disnake": 10090
-   With known type: 7969
+   With known type: 8008
-   With ambiguous type: 204
+   With ambiguous type: 208
-   With unknown type: 1917
+   With unknown type: 1874

  Other symbols referenced but not exported by "disnake": 3458
    With known type: 2972
    With ambiguous type: 129
    With unknown type: 357

  Symbols without documentation:
    Functions without docstring: 1559
    Functions without default param: 57
    Classes without docstring: 629

- Type completeness score: 79%
+ Type completeness score: 79.4%

  Completed in 4.151sec
```


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
