### PR TITLE
fix(iterators): make `MemberIterator` and `ArchivedThreadIterator` consistently respect upper limit

### DIFF
--- a/changelog/1331.bugfix.rst
+++ b/changelog/1331.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :meth:`Guild.fetch_members` and :meth:`TextChannel.archived_threads` iterators returning more elements than specified by ``limit`` under certain circumstances.

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -815,6 +815,8 @@ class MemberIterator(_AsyncIterator["Member"]):
                 # no data, terminate
                 return
 
+            if self.limit is not None:
+                self.limit -= self.retrieve
             if len(data) < 1000:
                 self.limit = 0  # terminate loop
 

--- a/disnake/iterators.py
+++ b/disnake/iterators.py
@@ -899,10 +899,10 @@ class ArchivedThreadIterator(_AsyncIterator["Thread"]):
         if not self.has_more:
             raise NoMoreItems
 
-        limit = 50 if self.limit is None else max(self.limit, 50)
+        # endpoint requires at least 2, for unknown reasons
+        limit = 100 if self.limit is None else max(2, min(self.limit, 100))
         data = await self.endpoint(self.channel_id, before=self.before, limit=limit)
 
-        # This stuff is obviously WIP because 'members' is always empty
         threads: List[ThreadPayload] = data.get("threads", [])
         for d in reversed(threads):
             self.queue.put_nowait(self.create_thread(d))


### PR DESCRIPTION
## Summary

`MemberIterator` and `ArchivedThreadIterator` would previously yield more items than specified by the `limit` parameter, when called with `limit > 1000` and `limit < 50` respectively. Additionally, requesting more than 100 archived threads failed entirely due to incorrect limit handling.

#### `MemberIterator`
|  | `limit` | result |
|--------|--------|--------|
| **before** | 100 | 100 |
|  | 1500 | **2503** |
|  | None | 2503 |
|  |  |
| **after** | 100 | 100 |
|  | 1500 | 1500 |
|  | None | 2503 |

#### `ArchivedThreadIterator`
|  | `limit` | result |
|--------|--------|--------|
| **before** | 1 | **50** |
|  | 3 | **50** |
|  | 101 | *error* |
|  | None | 151 |
|  |  |
| **after** | 1 | 1 |
|  | 3 | 3 |
|  | 101 | 101 |
|  | None | 151 |

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
