### PR TITLE
feat(ci): add libcst diff as a check summary to GH actions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -23,6 +23,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  GITHUB_STEP_SUMMARY_HEADER: "<details><summary>#name#</summary>\n<pre>"
+  GITHUB_STEP_SUMMARY_FOOTER: "</pre></details>\n"
+
 jobs:
   lock-dependencies:
     # The only purpose of this is to create a lockfile, which will be cached
@@ -171,9 +175,6 @@ jobs:
           nox -s codemod -- run-all
 
       - name: Check for changes made by libcst codemod
-        env:
-          GITHUB_STEP_SUMMARY_HEADER: "<details><summary>#name#</summary>\n<pre>"
-          GITHUB_STEP_SUMMARY_FOOTER: "</pre></details>\n"
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error::Please run 'nox -s codemod -- run-all' locally and commit the changes." >&2;
@@ -198,11 +199,6 @@ jobs:
         experimental: [false]
       fail-fast: true
     continue-on-error: ${{ matrix.experimental }}
-
-    env:
-      GITHUB_STEP_SUMMARY_HEADER: "<details><summary>#name#</summary>\n<pre>"
-      GITHUB_STEP_SUMMARY_FOOTER: "</pre></details>\n"
-
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -169,11 +169,20 @@ jobs:
       - name: libcst codemod
         run: |
           nox -s codemod -- run-all
+
+      - name: Check for changes made by libcst codemod
+        env:
+          GITHUB_STEP_SUMMARY_HEADER: "<details><summary>#name#</summary>\n<pre>"
+          GITHUB_STEP_SUMMARY_FOOTER: "</pre></details>\n"
+        run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error::Please run 'nox -s codemod -- run-all' locally and commit the changes." >&2;
+            echo "$GITHUB_STEP_SUMMARY_HEADER" | sed "s/#name#/LibCST Codemod/" >> $GITHUB_STEP_SUMMARY
+            echo "The libcst codemod made changes to the codebase. Please run 'nox -s codemod -- run-all' locally and commit the changes." >> $GITHUB_STEP_SUMMARY
             echo "::group::git diff"
-            git diff
+            git diff |& tee -a $GITHUB_STEP_SUMMARY
             echo "::endgroup::"
+            echo "$GITHUB_STEP_SUMMARY_FOOTER" >> $GITHUB_STEP_SUMMARY
             exit 1;
           else
             exit 0;


### PR DESCRIPTION
## Summary

While working on #1322, I was in desperate need of being able to see some artifacts that our ci does not currently have great logging, this has libcst provide the diff as a job summary as well as in-line in the logs. 

see https://github.com/DisnakeDev/disnake/actions/runs/17488021841?pr=1336 for an example.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
