### PR TITLE
fix: change `Option.from_dict` to return cls instance instead of specifically `Option`

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -149,8 +149,8 @@ class OptionChoice:
         return payload
 
     @classmethod
-    def from_dict(cls, data: ApplicationCommandOptionChoicePayload):
-        return OptionChoice(
+    def from_dict(cls, data: ApplicationCommandOptionChoicePayload) -> Self:
+        return cls(
             name=Localized(data["name"], data=data.get("name_localizations")),
             value=data["value"],
         )
@@ -347,8 +347,8 @@ class Option:
         )
 
     @classmethod
-    def from_dict(cls, data: ApplicationCommandOptionPayload) -> Option:
-        return Option(
+    def from_dict(cls, data: ApplicationCommandOptionPayload) -> Self:
+        return cls(
             name=Localized(data["name"], data=data.get("name_localizations")),
             description=Localized(
                 data.get("description"), data=data.get("description_localizations")


### PR DESCRIPTION
## Summary

fixes #1338. There's no difference in practice, it's just an unusual pattern.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
