### PR TITLE
ci: run ci with specific environment definitions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,6 +18,7 @@ runs:
       id: setup-python
       uses: pdm-project/setup-pdm@v4
       with:
+        allow-python-prereleases: true
         python-version: ${{ inputs.python-version }}
         version: "2.20.1"  # last version to support python 3.8
         cache: false

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -149,6 +149,7 @@ jobs:
           NOXSESSION: ${{ matrix.session.name }}
           NOX_DEFAULT_VENV_BACKEND: "none"
           ## needed to install specific dependencies
+          ## used internally when nox calls pip to install a dependency in the venv
           PIP_PYTHON: ${{ steps.venv-bin.outputs.python }}
         run: |
           nox --install-only

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -55,7 +55,7 @@ jobs:
       min-python: ${{ steps.set-matrix.outputs.min-python }}
       docs: ${{ steps.set-matrix.outputs.docs }}
       libcst: ${{ steps.set-matrix.outputs.libcst }}
-      pyright: ${{ steps.set-matrix.outputs.tests }}
+      pyright-sessions: ${{ steps.set-matrix.outputs.pyright-sessions }}
       tests: ${{ steps.set-matrix.outputs.tests }}
     steps:
       - uses: actions/checkout@v4
@@ -71,6 +71,7 @@ jobs:
           echo docs=$(nox -s docs --list --json | jq -rc '.[].python') | tee --append $GITHUB_OUTPUT
           echo libcst=$(nox -s codemod --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
           echo tests=$(nox -s test --list --json | jq -c '[.[].python]') | tee --append $GITHUB_OUTPUT
+          echo pyright-sessions=$(nox -s pyright -l --json | jq -c '[.[] | [.python, .session, .call_spec.pyright_group.directories, .call_spec.pyright_group.experimental]]') | tee --append $GITHUB_OUTPUT
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -111,10 +112,10 @@ jobs:
     strategy:
       matrix:
         # TODO: add 3.14 once we switch to uv
-        python-version: ${{ fromJson(needs.python-versions.outputs.pyright) }}
+        session: ${{ fromJson(needs.python-versions.outputs.pyright-sessions) }}
         experimental: [false]
       fail-fast: false
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.session[3] || matrix.experimental }}
 
     steps:
       - uses: actions/checkout@v4
@@ -126,14 +127,15 @@ jobs:
           PDM_USE_VENV: true
           PDM_VENV_IN_PROJECT: true
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.session[0] }}
 
       - name: Install dependencies
         # `--no-venv` to install in the main pdm venv instead of nox's pyright-specific one
         # because nox uses pdm internally to install, this means that the venv that is used is
         # the one that pdm would create in project: `.venv`
+        # python is NOT forced here because the session name is explicit
         run: |
-          nox -s pyright --no-venv --install-only --force-python ${{ steps.setup-env.outputs.python-version }}
+          nox -s '${{ matrix.session[1] }}' --no-venv --install-only
 
       - name: Add .venv/bin to PATH
         run: dirname "$(pdm info --python)" >> $GITHUB_PATH
@@ -150,8 +152,9 @@ jobs:
           version: ${{ steps.pyright-version.outputs.pyright-version }}
           python-version: ${{ steps.setup-env.outputs.python-version }}
           python-platform: "Linux"
-          annotate: ${{ matrix.python-version == needs.python-versions.outputs.min-python }} # only add comments for one version
+          annotate: ${{ matrix.session[0] == needs.python-versions.outputs.min-python }} # only add comments for one version
           warnings: true
+          extra-args: ${{join(matrix.session[2], ' ')}}
 
       - name: Run pyright (Windows)
         uses: jakebailey/pyright-action@v2.2.1
@@ -162,6 +165,7 @@ jobs:
           python-platform: "Windows"
           annotate: false # only add comments for one platform (see above)
           warnings: true
+          extra-args: ${{join(matrix.session[2], ' ')}}
 
   misc:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -72,8 +72,8 @@ jobs:
           echo min-python=$(nox -s test --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
           echo docs=$(nox -s docs --list --json | jq -rc '.[].python') | tee --append $GITHUB_OUTPUT
           echo libcst=$(nox -s codemod --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
-          echo test-sessions=$(nox -s test --list --json | jq -c '[.[] | { python: .python, name: .session, extras: .call_spec.execution_group_dict.extras, experimental: (.call_spec.execution_group_dict.experimental == true) }]') | tee --append $GITHUB_OUTPUT
-          echo pyright-sessions=$(nox -s pyright --list --json | jq -c '[.[] | {python: .python, name: .session, paths: .call_spec.execution_group_dict.paths, experimental: (.call_spec.execution_group_dict.experimental == true) }]') | tee --append $GITHUB_OUTPUT
+          echo test-sessions=$(nox -s test --list --json | jq -c '[.[] | { python: .python, name: .session, extras: .call_spec.execution_group.extras, experimental: (.call_spec.execution_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
+          echo pyright-sessions=$(nox -s pyright --list --json | jq -c '[.[] | {python: .python, name: .session, paths: .call_spec.execution_group.paths, experimental: (.call_spec.execution_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -71,7 +71,7 @@ jobs:
           echo docs=$(nox -s docs --list --json | jq -rc '.[].python') | tee --append $GITHUB_OUTPUT
           echo libcst=$(nox -s codemod --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
           echo tests=$(nox -s test --list --json | jq -c '[.[].python]') | tee --append $GITHUB_OUTPUT
-          echo pyright-sessions=$(nox -s pyright -l --json | jq -c '[.[] | [.python, .session, .call_spec.pyright_group.directories, .call_spec.pyright_group.experimental]]') | tee --append $GITHUB_OUTPUT
+          echo pyright-sessions=$(nox -s pyright -l --json | jq -c '[.[] | {python: .python, name: .session, directories: .call_spec.pyright_group.directories, experimental: (.call_spec.pyright_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -115,7 +115,7 @@ jobs:
         session: ${{ fromJson(needs.python-versions.outputs.pyright-sessions) }}
         experimental: [false]
       fail-fast: false
-    continue-on-error: ${{ matrix.session[3] || matrix.experimental }}
+    continue-on-error: ${{ matrix.session.experimental || matrix.experimental }}
 
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
           PDM_USE_VENV: true
           PDM_VENV_IN_PROJECT: true
         with:
-          python-version: ${{ matrix.session[0] }}
+          python-version: ${{ matrix.session.python }}
 
       - name: Install dependencies
         # `--no-venv` to install in the main pdm venv instead of nox's pyright-specific one
@@ -135,7 +135,7 @@ jobs:
         # the one that pdm would create in project: `.venv`
         # python is NOT forced here because the session name is explicit
         run: |
-          nox -s '${{ matrix.session[1] }}' --no-venv --install-only
+          nox -s '${{ matrix.session.name }}' --no-venv --install-only
 
       - name: Add .venv/bin to PATH
         run: dirname "$(pdm info --python)" >> $GITHUB_PATH
@@ -152,9 +152,9 @@ jobs:
           version: ${{ steps.pyright-version.outputs.pyright-version }}
           python-version: ${{ steps.setup-env.outputs.python-version }}
           python-platform: "Linux"
-          annotate: ${{ matrix.session[0] == needs.python-versions.outputs.min-python }} # only add comments for one version
+          annotate: ${{ matrix.session.python == needs.python-versions.outputs.min-python }} # only add comments for one version
           warnings: true
-          extra-args: ${{join(matrix.session[2], ' ')}}
+          extra-args: ${{join(matrix.session.directories, ' ')}}
 
       - name: Run pyright (Windows)
         uses: jakebailey/pyright-action@v2.2.1
@@ -165,7 +165,7 @@ jobs:
           python-platform: "Windows"
           annotate: false # only add comments for one platform (see above)
           warnings: true
-          extra-args: ${{join(matrix.session[2], ' ')}}
+          extra-args: ${{join(matrix.session.directories, ' ')}}
 
   misc:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -135,8 +135,11 @@ jobs:
         # because nox uses pdm internally to install, this means that the venv that is used is
         # the one that pdm would create in project: `.venv`
         # python is NOT forced here because the session name is explicit
+        env:
+          NOXSESSION: ${{ matrix.session.name }}
+          PIP_PYTHON: "./.venv/bin/python"
         run: |
-          nox -s '${{ matrix.session.name }}' --no-venv --install-only
+          nox --no-venv --install-only
 
       - name: Add .venv/bin to PATH
         run: dirname "$(pdm info --python)" >> $GITHUB_PATH

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -73,7 +73,7 @@ jobs:
           echo docs=$(nox -s docs --list --json | jq -rc '.[].python') | tee --append $GITHUB_OUTPUT
           echo libcst=$(nox -s codemod --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
           echo test-sessions=$(nox -s test --list --json | jq -c '[.[] | { python: .python, name: .session, extras: .call_spec.execution_group.extras, experimental: (.call_spec.execution_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
-          echo pyright-sessions=$(nox -s pyright --list --json | jq -c '[.[] | {python: .python, name: .session, paths: .call_spec.execution_group.paths, experimental: (.call_spec.execution_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
+          echo pyright-sessions=$(nox -s pyright --list --json | jq -c '[.[] | {python: .python, name: .session, paths: .call_spec.execution_group.pyright_paths, experimental: (.call_spec.execution_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -117,18 +117,21 @@ jobs:
         session: ${{ fromJson(needs.python-versions.outputs.pyright-sessions) }}
       fail-fast: false
     continue-on-error: ${{ matrix.session.experimental }}
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up environment
         id: setup-env
         uses: ./.github/actions/setup-env
-        env:
-          PDM_USE_VENV: true
-          PDM_VENV_IN_PROJECT: true
         with:
           python-version: ${{ matrix.session.python }}
+
+      - name: Add .venv/bin to PATH
+        id: venv-bin
+        run: |
+          pdm venv create
+          dirname "$(pdm info --python)" >> $GITHUB_PATH
+          echo python="$(pdm info --python)" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         # `--no-venv` to install in the main pdm venv instead of nox's pyright-specific one
@@ -137,17 +140,16 @@ jobs:
         # python is NOT forced here because the session name is explicit
         env:
           NOXSESSION: ${{ matrix.session.name }}
-          PIP_PYTHON: "./.venv/bin/python"
+          NOX_DEFAULT_VENV_BACKEND: "none"
+          ## needed to install specific dependencies
+          PIP_PYTHON: ${{ steps.venv-bin.outputs.python }}
         run: |
-          nox --no-venv --install-only
-
-      - name: Add .venv/bin to PATH
-        run: dirname "$(pdm info --python)" >> $GITHUB_PATH
+          nox --install-only
 
       - name: Set pyright version
         id: pyright-version
         run: |
-          echo "pyright-version=$(pdm run python -c 'import pyright; print(pyright.__pyright_version__)')" >> $GITHUB_OUTPUT
+          echo "pyright-version=$(${{steps.venv-bin.outputs.python}} -c 'import pyright; print(pyright.__pyright_version__)')" >> $GITHUB_OUTPUT
 
       - name: Run pyright (Linux)
         uses: jakebailey/pyright-action@v2.2.1

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -56,7 +56,7 @@ jobs:
       docs: ${{ steps.set-matrix.outputs.docs }}
       libcst: ${{ steps.set-matrix.outputs.libcst }}
       pyright-sessions: ${{ steps.set-matrix.outputs.pyright-sessions }}
-      tests: ${{ steps.set-matrix.outputs.tests }}
+      test-sessions: ${{ steps.set-matrix.outputs.test-sessions }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up environment
@@ -72,8 +72,9 @@ jobs:
           echo min-python=$(nox -s test --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
           echo docs=$(nox -s docs --list --json | jq -rc '.[].python') | tee --append $GITHUB_OUTPUT
           echo libcst=$(nox -s codemod --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
-          echo tests=$(nox -s test --list --json | jq -c '[.[].python]') | tee --append $GITHUB_OUTPUT
-          echo pyright-sessions=$(nox -s pyright --list --json | jq -c '[.[] | {python: .python, name: .session, paths: .call_spec.pyright_group.paths, experimental: (.call_spec.pyright_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
+          echo test-sessions=$(nox -s test --list --json | jq -c '[.[] | { python: .python, name: .session, extras: .call_spec.execution_group_dict.extras, experimental: (.call_spec.execution_group_dict.experimental == true) }]') | tee --append $GITHUB_OUTPUT
+          echo pyright-sessions=$(nox -s pyright --list --json | jq -c '[.[] | {python: .python, name: .session, paths: .call_spec.execution_group_dict.paths, experimental: (.call_spec.execution_group_dict.experimental == true) }]') | tee --append $GITHUB_OUTPUT
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -253,10 +254,11 @@ jobs:
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         # TODO: add 3.14 once we switch to uv
-        python-version: ${{ fromJson(needs.python-versions.outputs.tests) }}
-        experimental: [false]
-      fail-fast: true
-    continue-on-error: ${{ matrix.experimental }}
+        session: ${{ fromJson(needs.python-versions.outputs.test-sessions) }}
+      fail-fast: false
+    continue-on-error: ${{ matrix.session.experimental }}
+    env:
+      NOXSESSION: ${{ matrix.session.name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -264,11 +266,11 @@ jobs:
         id: setup-env
         uses: ./.github/actions/setup-env
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.session.python }}
 
       - name: Install nox environment
         run: |
-          nox -s test --no-venv --install-only --force-python ${{ steps.setup-env.outputs.python-version }}
+          nox --no-venv --install-only
 
       - name: Run pytest
         id: run_tests
@@ -277,7 +279,7 @@ jobs:
           TZ: "America/New_York"
         run: |
           echo "$GITHUB_STEP_SUMMARY_HEADER" | sed "s/#name#/Test Summary/" >> $GITHUB_STEP_SUMMARY
-          pdm run nox --no-venv -s test -- --color=no --cov-report= | tee -a $GITHUB_STEP_SUMMARY
+          pdm run nox --no-venv -- --color=no --cov-report= | tee -a $GITHUB_STEP_SUMMARY
           echo "$GITHUB_STEP_SUMMARY_FOOTER" >> $GITHUB_STEP_SUMMARY
 
       - name: Print Coverage Output

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -66,12 +66,14 @@ jobs:
 
       - name: Determine Python versions to test and lint against
         id: set-matrix
+        # raw values (without a list) need the raw flag in order to not print quotes
+        # lists do not need the raw flag, as we parse them with fromJSON() later on
         run: |
           echo min-python=$(nox -s test --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
           echo docs=$(nox -s docs --list --json | jq -rc '.[].python') | tee --append $GITHUB_OUTPUT
           echo libcst=$(nox -s codemod --list --json | jq -rc '[.[].python][0]') | tee --append $GITHUB_OUTPUT
           echo tests=$(nox -s test --list --json | jq -c '[.[].python]') | tee --append $GITHUB_OUTPUT
-          echo pyright-sessions=$(nox -s pyright -l --json | jq -c '[.[] | {python: .python, name: .session, directories: .call_spec.pyright_group.directories, experimental: (.call_spec.pyright_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
+          echo pyright-sessions=$(nox -s pyright --list --json | jq -c '[.[] | {python: .python, name: .session, paths: .call_spec.pyright_group.paths, experimental: (.call_spec.pyright_group.experimental == true) }]') | tee --append $GITHUB_OUTPUT
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -113,9 +115,8 @@ jobs:
       matrix:
         # TODO: add 3.14 once we switch to uv
         session: ${{ fromJson(needs.python-versions.outputs.pyright-sessions) }}
-        experimental: [false]
       fail-fast: false
-    continue-on-error: ${{ matrix.session.experimental || matrix.experimental }}
+    continue-on-error: ${{ matrix.session.experimental }}
 
     steps:
       - uses: actions/checkout@v4
@@ -154,7 +155,7 @@ jobs:
           python-platform: "Linux"
           annotate: ${{ matrix.session.python == needs.python-versions.outputs.min-python }} # only add comments for one version
           warnings: true
-          extra-args: ${{join(matrix.session.directories, ' ')}}
+          extra-args: ${{join(matrix.session.paths, ' ')}}
 
       - name: Run pyright (Windows)
         uses: jakebailey/pyright-action@v2.2.1
@@ -165,7 +166,7 @@ jobs:
           python-platform: "Windows"
           annotate: false # only add comments for one platform (see above)
           warnings: true
-          extra-args: ${{join(matrix.session.directories, ' ')}}
+          extra-args: ${{join(matrix.session.paths, ' ')}}
 
   misc:
     runs-on: ubuntu-latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,7 +78,7 @@ EXECUTION_GROUPS: List[ExecutionGroup] = [
             python=python,
             pyright_paths=("disnake", "tests", "examples", "noxfile.py", "setup.py"),
             project=True,
-            # orjson doesn't yet support python 3.14
+            # FIXME: orjson doesn't yet support python 3.14, remove once we migrate to uv and have version-specific locks
             extras=("speed", "voice") if python not in EXPERIMENTAL_PYTHON_VERSIONS else ("voice",),
             groups=("test", "nox"),
             dependencies=("setuptools", "pytz", "requests"),  # needed for type checking

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,7 +52,7 @@ else:
 @dataclasses.dataclass
 class ExecutionGroup(ExecutionGroupType):
     sessions: Tuple[str, ...] = ()
-    python: Optional[str] = MIN_PYTHON
+    python: str = MIN_PYTHON
     project: bool = True
     extras: Tuple[str, ...] = ()
     groups: Tuple[str, ...] = ()

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,8 +35,8 @@ nox.options.reuse_venv = "yes"
 PYPROJECT = nox.project.load_toml()
 
 SUPPORTED_PYTHONS = nox.project.python_versions(PYPROJECT)
-# todo(onerandomusername): add 3.14 once CI supports 3.14.
-EXPERIMENTAL_PYTHON_VERSIONS = ["3.14"]
+# TODO(onerandomusername): add 3.14 once CI supports 3.14.
+EXPERIMENTAL_PYTHON_VERSIONS = []
 CI = "CI" in os.environ
 
 # used to reset cached coverage data once for the first test run only
@@ -89,7 +89,7 @@ EXECUTION_GROUPS: List[ExecutionGroup] = [
         experimental=True,
         sessions=("codemod", "pyright", "autotyping"),
     ),
-    # the other sessions, they don't need pyright
+    # the other sessions, they don't need pyright, but they need to run
     ExecutionGroup(
         python="3.8",
         paths=("disnake",),
@@ -107,13 +107,6 @@ EXECUTION_GROUPS: List[ExecutionGroup] = [
             sessions=("test",),
         )
         for python in [*SUPPORTED_PYTHONS, *EXPERIMENTAL_PYTHON_VERSIONS]
-    ),
-    ExecutionGroup(
-        python="3.11",
-        paths=("disnake", "tests"),
-        extras=("speed", "voice"),
-        groups=("test",),
-        sessions=("test",),
     ),
 ]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,6 +39,7 @@ SUPPORTED_PYTHONS: Final[List[str]] = nox.project.python_versions(PYPROJECT)
 # TODO(onerandomusername): add 3.14 once CI supports 3.14.
 EXPERIMENTAL_PYTHON_VERSIONS: Final[List[str]] = []
 ALL_PYTHONS: Final[List[str]] = [*SUPPORTED_PYTHONS, *EXPERIMENTAL_PYTHON_VERSIONS]
+MIN_PYTHON: Final[str] = SUPPORTED_PYTHONS[0]
 CI: Final[bool] = "CI" in os.environ
 
 # used to reset cached coverage data once for the first test run only
@@ -64,6 +65,8 @@ class ExecutionGroup(ExecutionGroupType):
     def __post_init__(self) -> None:
         if self.pyright_paths and "pyright" not in self.sessions:
             self.sessions = (*self.sessions, "pyright")
+        if not self.python:
+            self.python = MIN_PYTHON
         if self.python in EXPERIMENTAL_PYTHON_VERSIONS:
             self.experimental = True
         for key in self.__dataclass_fields__.keys():
@@ -88,24 +91,19 @@ EXECUTION_GROUPS: List[ExecutionGroup] = [
     # docs and pyright
     ExecutionGroup(
         sessions=("docs",),
-        python="3.8",
         pyright_paths=("docs",),
-        project=True,
         extras=("docs",),
     ),
     # codemodding and pyright
     ExecutionGroup(
         sessions=("codemod", "autotyping"),
-        python="3.8",
         pyright_paths=("scripts",),
         groups=("codemod",),
     ),
     # the other sessions, they don't need pyright, but they need to run
     ExecutionGroup(
         sessions=("lint", "slotscheck", "check-manifest"),
-        python="3.8",
         groups=("tools",),
-        project=True,
     ),
     ## testing
     *(
@@ -119,7 +117,6 @@ EXECUTION_GROUPS: List[ExecutionGroup] = [
     # coverage
     ExecutionGroup(
         sessions=("coverage",),
-        python="3.8",
         project=False,
         groups=("test",),
     ),

--- a/noxfile.py
+++ b/noxfile.py
@@ -124,10 +124,10 @@ def get_groups_for_session(name: str) -> List[ExecutionGroup]:
 
 
 def get_version_for_session(name: str) -> str:
-    versions = dict.fromkeys(g.python for g in get_groups_for_session(name) if g.python)
+    versions = {g.python for g in get_groups_for_session(name) if g.python}
     if len(versions) != 1:
         raise TypeError(f"not the right number of groups for session {name}")
-    return next(iter(versions))
+    return versions.pop()
 
 
 def install_deps(session: nox.Session, *, execution_group: Optional[ExecutionGroup] = None) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,10 @@ codemod = [
 typing = [
     # this is not pyright itself, but the python wrapper
     "pyright==1.1.405",
+    # used in the disnake/webhook/sync.py module
+    "requests",
     # only used for type-checking, version does not matter
-    "pytz",
+    "pytz>=2022",
 ]
 test = [
     "pytest~=8.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: OS Independent",
+    # it is important that the python classifiers are sorted in the sequential order
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,10 +88,7 @@ codemod = [
 typing = [
     # this is not pyright itself, but the python wrapper
     "pyright==1.1.405",
-    # used in the disnake/webhook/sync.py module
-    "requests",
-    # only used for type-checking, version does not matter
-    "pytz>=2022",
+    # some type-check only dependencies are defined in noxfile.py.
 ]
 test = [
     "pytest~=8.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ codemod = [
 typing = [
     # this is not pyright itself, but the python wrapper
     "pyright==1.1.405",
-    # some type-check only dependencies are defined in noxfile.py.
+    # all type-check only dependencies are defined in noxfile.py.
 ]
 test = [
     "pytest~=8.3.2",


### PR DESCRIPTION
### Summary

solves an issue blocking us from upgrading to sphinx 8.4, which is that if docs can't be installed on all supported python versions, typechecking won't pass.

This moves every nox dependency definition into an ExecutionGroup list which stores the dependencies for a specific session and environment. These dependencies are subsequently installed in CI. 

This groups allow pyright and typechecking to be ran on specific segements of our repository, documentation for example will only be typechecked with pyright 3.8.

### Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [x] This PR fixes an issue