### PR TITLE
fix(dev): enable typechecking on scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,7 @@ include = [
     "disnake",
     "docs",
     "examples",
+    "scripts",
     "tests",
     "*.py",
 ]

--- a/scripts/codemods/typed_permissions.py
+++ b/scripts/codemods/typed_permissions.py
@@ -114,7 +114,7 @@ class PermissionTypings(BaseCodemodCommand):
         is_overload = False
         previously_generated = False
         for deco in node.decorators:
-            if isinstance(deco.decorator, cst.Call):
+            if not isinstance(deco.decorator, cst.Name):
                 continue
             name = deco.decorator.value
             if name == "_overload_with_permissions":


### PR DESCRIPTION
## Summary

At some point this was disabled/never enabled, but it should be. 

Required by #1341, if we want to run pyright on scripts.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
