### PR TITLE
feat(dev): support a pep 723 noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "nox==2025.5.1",
+# ]
+# ///
+
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
@@ -17,6 +24,7 @@ if TYPE_CHECKING:
 
     NoxSessionFunc = Callable[Concatenate[nox.Session, P], T]
 
+nox.needs_version = ">=2025.5.1"
 
 # see https://pdm-project.org/latest/usage/advanced/#use-nox-as-the-runner
 os.environ.update(
@@ -24,7 +32,6 @@ os.environ.update(
         "PDM_IGNORE_SAVED_PYTHON": "1",
     },
 )
-
 
 nox.options.error_on_external_run = True
 nox.options.reuse_existing_virtualenvs = True
@@ -35,7 +42,6 @@ nox.options.sessions = [
     "pyright",
     "test",
 ]
-nox.needs_version = ">=2022.1.7"
 
 
 # used to reset cached coverage data once for the first test run only
@@ -247,3 +253,7 @@ def coverage(session: nox.Session) -> None:
         )
     if "erase" in session.posargs:
         session.run("coverage", "erase")
+
+
+if __name__ == "__main__":
+    nox.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docs = [
 
 [dependency-groups]
 nox = [
-    "nox==2022.11.21",
+    "nox==2025.5.1",
 ]
 tools = [
     "pre-commit~=3.0",
@@ -104,6 +104,8 @@ build = [
     "twine~=5.1.1",
 ]
 
+[tool.nox]
+script-venv-backend = "uv|virtualenv"
 
 [tool.pdm]
 # Ignore `requires-python` warnings when locking, the latest versions of some


### PR DESCRIPTION
## Summary

Support PEP 723 with the noxfile.

This allows running the noxfile directly, which with using a pep 723 compliant frontend, will run nox without any pre-configuration.


`pdm run noxfile.py -h` will now run the noxfile without requiring the environment itself to be installed; pdm will do this for us.

As a bonus, `./noxfile.py` has been enabled, the file can be executed directly.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
