### PR TITLE
fix(gateway): fix missing `user_update` event for new attributes, missing attributes in `member_update` event

### DIFF
--- a/changelog/1350.bugfix.rst
+++ b/changelog/1350.bugfix.rst
@@ -1,0 +1,1 @@
+Fix missing :attr:`~Member.avatar_decoration` on the old :class:`Member` in :func:`on_member_update` events.

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -420,6 +420,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         self._banner = member._banner
         self._communication_disabled_until = member.current_timeout
         self._flags = member._flags
+        self._avatar_decoration_data = member._avatar_decoration_data
 
         # Reference will not be copied unless necessary by PRESENCE_UPDATE
         # See below

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -296,6 +296,7 @@ class Member(disnake.abc.Messageable, _UserTag):
         banner: Optional[Asset]
         accent_color: Optional[Colour]
         accent_colour: Optional[Colour]
+        avatar_decoration: Optional[Asset]
         collectibles: Collectibles
         primary_guild: Optional[PrimaryGuild]
 

--- a/disnake/member.py
+++ b/disnake/member.py
@@ -471,32 +471,35 @@ class Member(disnake.abc.Messageable, _UserTag):
         u = self._user
         original = (
             u.name,
-            u._avatar,
             u.discriminator,
             u.global_name,
-            u._public_flags,
+            u._avatar,
             u._avatar_decoration_data,
+            u._public_flags,
+            u._collectibles,
             u._primary_guild,
         )
         # These keys seem to always be available
         modified = (
             user["username"],
-            user["avatar"],
             user["discriminator"],
             user.get("global_name"),
+            user["avatar"],
+            user.get("avatar_decoration_data"),
             user.get("public_flags", 0),
-            user.get("avatar_decoration_data", None),
+            user.get("collectibles"),
             user.get("primary_guild"),
         )
         if original != modified:
             to_return = User._copy(self._user)
             (
                 u.name,
-                u._avatar,
                 u.discriminator,
                 u.global_name,
-                u._public_flags,
+                u._avatar,
                 u._avatar_decoration_data,
+                u._public_flags,
+                u._collectibles,
                 u._primary_guild,
             ) = modified
             # Signal to dispatch on_user_update

--- a/disnake/types/user.py
+++ b/disnake/types/user.py
@@ -53,6 +53,7 @@ class PartialUser(TypedDict):
     discriminator: str  # may be removed in future API versions
     global_name: NotRequired[Optional[str]]
     avatar: Optional[str]
+    avatar_decoration_data: Optional[AvatarDecorationData]
     collectibles: NotRequired[Optional[Collectibles]]
     primary_guild: NotRequired[Optional[UserPrimaryGuild]]
 
@@ -72,4 +73,3 @@ class User(PartialUser, total=False):
     flags: int
     premium_type: PremiumType
     public_flags: int
-    avatar_decoration_data: Optional[AvatarDecorationData]

--- a/disnake/types/user.py
+++ b/disnake/types/user.py
@@ -53,7 +53,7 @@ class PartialUser(TypedDict):
     discriminator: str  # may be removed in future API versions
     global_name: NotRequired[Optional[str]]
     avatar: Optional[str]
-    avatar_decoration_data: Optional[AvatarDecorationData]
+    avatar_decoration_data: NotRequired[Optional[AvatarDecorationData]]
     collectibles: NotRequired[Optional[Collectibles]]
     primary_guild: NotRequired[Optional[UserPrimaryGuild]]
 

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -65,26 +65,10 @@ class BaseUser(_UserTag):
         "_state",
     )
 
-    if TYPE_CHECKING:
-        name: str
-        id: int
-        discriminator: str
-        global_name: Optional[str]
-        bot: bool
-        system: bool
-        _state: ConnectionState
-        _avatar: Optional[str]
-        _banner: Optional[str]
-        _avatar_decoration_data: Optional[AvatarDecorationDataPayload]
-        _collectibles: Optional[CollectiblesPayload]
-        _accent_colour: Optional[int]
-        _public_flags: int
-        _primary_guild: Optional[UserPrimaryGuildPayload]
-
     def __init__(
         self, *, state: ConnectionState, data: Union[UserPayload, PartialUserPayload]
     ) -> None:
-        self._state = state
+        self._state: ConnectionState = state
         self._update(data)
 
     def __repr__(self) -> str:
@@ -110,19 +94,21 @@ class BaseUser(_UserTag):
         return self.id >> 22
 
     def _update(self, data: Union[UserPayload, PartialUserPayload]) -> None:
-        self.name = data["username"]
-        self.id = int(data["id"])
-        self.discriminator = data["discriminator"]
-        self.global_name = data.get("global_name")
-        self._avatar = data["avatar"]
-        self._banner = data.get("banner", None)
-        self._avatar_decoration_data = data.get("avatar_decoration_data", None)
-        self._collectibles = data.get("collectibles")
-        self._accent_colour = data.get("accent_color", None)
-        self._public_flags = data.get("public_flags", 0)
-        self._primary_guild = data.get("primary_guild")
-        self.bot = data.get("bot", False)
-        self.system = data.get("system", False)
+        self.name: str = data["username"]
+        self.id: int = int(data["id"])
+        self.discriminator: str = data["discriminator"]
+        self.global_name: Optional[str] = data.get("global_name")
+        self._avatar: Optional[str] = data["avatar"]
+        self._banner: Optional[str] = data.get("banner")
+        self._avatar_decoration_data: Optional[AvatarDecorationDataPayload] = data.get(
+            "avatar_decoration_data"
+        )
+        self._collectibles: Optional[CollectiblesPayload] = data.get("collectibles")
+        self._accent_colour: Optional[int] = data.get("accent_color")
+        self._public_flags: int = data.get("public_flags", 0)
+        self._primary_guild: Optional[UserPrimaryGuildPayload] = data.get("primary_guild")
+        self.bot: bool = data.get("bot", False)
+        self.system: bool = data.get("system", False)
 
     @classmethod
     def _copy(cls, user: BaseUser) -> Self:

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -61,8 +61,8 @@ class BaseUser(_UserTag):
         "_collectibles",
         "_accent_colour",
         "_public_flags",
-        "_state",
         "_primary_guild",
+        "_state",
     )
 
     if TYPE_CHECKING:
@@ -120,14 +120,15 @@ class BaseUser(_UserTag):
         self._collectibles = data.get("collectibles")
         self._accent_colour = data.get("accent_color", None)
         self._public_flags = data.get("public_flags", 0)
+        self._primary_guild = data.get("primary_guild")
         self.bot = data.get("bot", False)
         self.system = data.get("system", False)
-        self._primary_guild = data.get("primary_guild")
 
     @classmethod
     def _copy(cls, user: BaseUser) -> Self:
         self = cls.__new__(cls)  # bypass __init__
 
+        self._state = user._state
         self.name = user.name
         self.id = user.id
         self.discriminator = user.discriminator
@@ -135,10 +136,12 @@ class BaseUser(_UserTag):
         self._avatar = user._avatar
         self._banner = user._banner
         self._avatar_decoration_data = user._avatar_decoration_data
+        self._collectibles = user._collectibles
         self._accent_colour = user._accent_colour
-        self.bot = user.bot
-        self._state = user._state
         self._public_flags = user._public_flags
+        self._primary_guild = user._primary_guild
+        self.bot = user.bot
+        self.system = user.system
 
         return self
 

--- a/disnake/user.py
+++ b/disnake/user.py
@@ -58,9 +58,9 @@ class BaseUser(_UserTag):
         "_avatar",
         "_banner",
         "_avatar_decoration_data",
-        "_collectibles",
         "_accent_colour",
         "_public_flags",
+        "_collectibles",
         "_primary_guild",
         "_state",
     )
@@ -103,9 +103,9 @@ class BaseUser(_UserTag):
         self._avatar_decoration_data: Optional[AvatarDecorationDataPayload] = data.get(
             "avatar_decoration_data"
         )
-        self._collectibles: Optional[CollectiblesPayload] = data.get("collectibles")
         self._accent_colour: Optional[int] = data.get("accent_color")
         self._public_flags: int = data.get("public_flags", 0)
+        self._collectibles: Optional[CollectiblesPayload] = data.get("collectibles")
         self._primary_guild: Optional[UserPrimaryGuildPayload] = data.get("primary_guild")
         self.bot: bool = data.get("bot", False)
         self.system: bool = data.get("system", False)
@@ -122,9 +122,9 @@ class BaseUser(_UserTag):
         self._avatar = user._avatar
         self._banner = user._banner
         self._avatar_decoration_data = user._avatar_decoration_data
-        self._collectibles = user._collectibles
         self._accent_colour = user._accent_colour
         self._public_flags = user._public_flags
+        self._collectibles = user._collectibles
         self._primary_guild = user._primary_guild
         self.bot = user.bot
         self.system = user.system


### PR DESCRIPTION
## Summary

This fixes a couple minor issues with `user_update`/`member_update` events not triggering correctly for some field changes, namely:
- The old `Member` in `member_update` now has the correct `avatar_decoration` set.
- A `user_update` now triggers for updates to `collectibles`, and the old `User` now has `collectibles`, `primary_guild` and `system` set.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm lint`
    - [x] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
