### PR TITLE
fix(ci): require lint for all jobs

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -56,7 +56,9 @@ jobs:
     # unlike the other workflows, we explicitly use the same version as
     # readthedocs (see .readthedocs.yml) here for consistency
     runs-on: ubuntu-24.04
-    needs: lock-dependencies
+    needs:
+      - lock-dependencies
+      - lint
     steps:
       - uses: actions/checkout@v4
 
@@ -70,7 +72,9 @@ jobs:
 
   pyright:
     runs-on: ubuntu-latest
-    needs: lock-dependencies
+    needs:
+      - lock-dependencies
+      - lint
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -123,7 +127,9 @@ jobs:
 
   misc:
     runs-on: ubuntu-latest
-    needs: lock-dependencies
+    needs:
+      - lock-dependencies
+      - lint
     steps:
       - uses: actions/checkout@v4
 
@@ -157,6 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - lock-dependencies
+      - lint
     steps:
       - uses: actions/checkout@v4
 
@@ -181,7 +188,9 @@ jobs:
 
   pytest:
     runs-on: ${{ matrix.os }}
-    needs: lock-dependencies
+    needs:
+      - lock-dependencies
+      - lint
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
## Summary

In the event that lint fails the rest of ci does not need to run, as we are spending minutes on something that will be pushed away, and will need to re-run. the linting in also quickly completes, meaning this won't be delaying our other jobs more than a couple seconds (and not at all if pdm isn't cached).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
