### PR TITLE
feat(packaging): migrate packages out of setup.py

### DIFF
--- a/changelog/1356.misc.rst
+++ b/changelog/1356.misc.rst
@@ -1,0 +1,1 @@
+Migrate determining which packages to include in the built wheel and package from a static setup.py list to dynamic configured in pyproject.toml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,10 @@ build = [
     "twine~=5.1.1",
 ]
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["disnake*"]
+
 [tool.nox]
 script-venv-backend = "uv|virtualenv"
 

--- a/setup.py
+++ b/setup.py
@@ -31,21 +31,6 @@ if version.endswith(("a", "b", "rc")):
     except Exception:
         pass
 
-packages = [
-    "disnake",
-    "disnake.bin",
-    "disnake.types",
-    "disnake.ui",
-    "disnake.ui.select",
-    "disnake.webhook",
-    "disnake.interactions",
-    "disnake.ext.commands",
-    "disnake.ext.tasks",
-    "disnake.ext.mypy_plugin",
-]
-
 setup(
     version=version,
-    packages=packages,
-    include_package_data=True,
 )


### PR DESCRIPTION
## Summary

Previously, new modules or files would need to be explicitly added to setup.py

This moves the configuration to pyproject.toml and drops the requirement they must be explicit. At this point, this means the *only* reason for setup.py is our custom version indicators.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
