### PR TITLE
fix(ci): stop vscode from complaining about invalid syntax

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,7 +9,7 @@ on:
       - "v[0-9]+.[0-9]+.x"  # matches to backport branches, e.g. v3.6.x
       - "run-ci/**"
     tags:
-      - "**"
+      - "*"
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -5,10 +5,11 @@ name: Lint & Test
 on:
   push:
     branches:
-      - 'master'
-      - 'v[0-9]+.[0-9]+.x'  # matches to backport branches, e.g. v3.6.x
-      - 'run-ci/*'
+      - "master"
+      - "v[0-9]+.[0-9]+.x"  # matches to backport branches, e.g. v3.6.x
+      - "run-ci/**"
     tags:
+      - "**"
   pull_request:
   merge_group:
     types: [checks_requested]
@@ -145,7 +146,7 @@ jobs:
         if: (success() || failure()) && steps.setup.outcome == 'success'
         run: nox -s check-manifest
 
-    # This only runs if the previous steps were successful, no point in running it otherwise
+      # This only runs if the previous steps were successful, no point in running it otherwise
       - name: Try building package
         run: |
           pdm install -dG build
@@ -169,7 +170,7 @@ jobs:
         with:
           python-version: 3.8
 
-    # run the libcst parsers and check for changes
+      # run the libcst parsers and check for changes
       - name: libcst codemod
         run: |
           nox -s codemod -- run-all
@@ -217,7 +218,7 @@ jobs:
 
       - name: Run pytest
         id: run_tests
-      # use non-utc timezone, to test time/date-dependent features properly
+        # use non-utc timezone, to test time/date-dependent features properly
         env:
           TZ: "America/New_York"
         run: |


### PR DESCRIPTION
## Summary

I. am. going. insane.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
