### PR TITLE
fix: bump versions of hooks for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-case-conflict
       - id: check-toml
@@ -44,7 +44,7 @@ repos:
         exclude: 'changelog/|py.typed|disnake/bin/COPYING|.github/PULL_REQUEST_TEMPLATE.md|.github/CODEOWNERS|LICENSE|MANIFEST.in|.gitattributes'
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.12.12
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ tools = [
     "pre-commit~=3.0",
     "slotscheck~=0.16.4",
     "check-manifest==0.49",
-    "ruff==0.12.11",
+    "ruff==0.12.12",
 ]
 changelog = [
     "towncrier==23.6.0",
@@ -81,7 +81,7 @@ changelog = [
 codemod = [
     # run codemods on the respository (mostly automated typing)
     "libcst~=1.1.0",
-    "ruff==0.12.11",
+    "ruff==0.12.12",
     "autotyping==23.2.0",
 ]
 typing = [


### PR DESCRIPTION
## Summary

Working on the pre-commit part of CI and saw a deprecation warning from pre-commit. Bumping the hooks to solve that, and sneaking in a ruff bump.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
