### PR TITLE
feat: add custom versionchanged/versionadded logic for replacing |vnext|

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ We use [towncrier](https://github.com/twisted/towncrier) for managing our change
 We use Sphinx to build the project's documentation, which includes [automatically generating](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) the API Reference from docstrings using the [NumPy style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).  
 To build the documentation locally, use `pdm run docs` and visit http://127.0.0.1:8009/ once built.
 
-Changes should be marked with a [Sphinx directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions) which are documented on the Sphinx documentation.
+Changes should be marked with a [version directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions) as documented on the Sphinx documentation.
 
 For the `version` argument, provide ``|vnext|`` as the argument.
 We have a custom role which replaces ``|vnext|`` with the next version of the library upon building the documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ extensions = [
     "collapse",
     "enumattrs",
     "nitpick_file_ignorer",
-    "versionadded",
+    "versionchange",
 ]
 
 autodoc_member_order = "bysource"

--- a/docs/extensions/versionchange.py
+++ b/docs/extensions/versionchange.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import sphinx.domains.changeset
-from sphinx.application import Sphinx
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+    from ._types import SphinxExtensionMeta
 
 
 class VersionAddedNext(sphinx.domains.changeset.VersionChange):
@@ -16,11 +23,10 @@ class VersionAddedNext(sphinx.domains.changeset.VersionChange):
         return super().run()
 
 
-def setup(app: Sphinx) -> None:
+def setup(app: Sphinx) -> SphinxExtensionMeta:
     app.add_directive("versionadded", VersionAddedNext, override=True)
     app.add_directive("versionchanged", VersionAddedNext, override=True)
     app.add_directive("deprecated", VersionAddedNext, override=True)
-    app.add_directive("versionremoved", VersionAddedNext)
 
     return {
         "parallel_read_safe": True,


### PR DESCRIPTION
## Summary

feat: add custom versionchanged/versionadded logic for replacing |vnext| with our next version

Does not add to release workflow as I'm working on rewriting that in a separate pull.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `pdm lint`
    - [ ] I have type-checked the code by running `pdm pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
