### PR TITLE
ci: bump pyright action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ codemod = [
 ]
 typing = [
     # this is not pyright itself, but the python wrapper
-    "pyright==1.1.389",
+    "pyright==1.1.405",
     # only used for type-checking, version does not matter
     "pytz",
 ]


### PR DESCRIPTION
Bump the pyright action to be able to use $PATH rather than having to set the pyright dependency ourselves.

This will run the pyright dependency that *we* have installed to the environment, meaning the exact same version of python we've already downloaded will be used by the pyright action.