### PR TITLE
feat(components): add `FileUpload` component

### DIFF
--- a/changelog/1390.feature.rst
+++ b/changelog/1390.feature.rst
@@ -1,0 +1,1 @@
+Add a :class:`ui.FileUpload` component for modals. This allows you to receive up to 10 files from users in a modal.

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -142,6 +142,7 @@ ContainerChildComponent = Union[
 # valid `Label.component` types
 LabelChildComponent = Union[
     "TextInput",
+    "FileUpload",
     "AnySelectMenu",
 ]
 
@@ -1507,7 +1508,7 @@ class Label(Component):
         The label text.
     description: Optional[:class:`str`]
         The description text for the label.
-    component: Union[:class:`TextInput`, :class:`StringSelectMenu`]
+    component: Union[:class:`TextInput`, :class:`FileUpload`, :class:`StringSelectMenu`]
         The component within the label.
     id: :class:`int`
         The numeric identifier for the component.
@@ -1549,6 +1550,8 @@ class Label(Component):
 
 class FileUpload(Component):
     """Represents a file upload component from the Discord Bot UI Kit.
+
+    This allows you to receive files from users, and can only be used in modals.
 
     .. note::
         The user constructible and usable type to create a

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1562,8 +1562,7 @@ class FileUpload(Component):
         The ID of the file upload that gets received during an interaction.
     min_values: :class:`int`
         The minimum number of files that must be uploaded.
-        # TODO: match api default
-        Defaults to 0 and must be between 0 and 10.
+        Defaults to 1 and must be between 0 and 10.
     max_values: :class:`int`
         The maximum number of files that must be uploaded.
         Defaults to 1 and must be between 1 and 10.
@@ -1590,7 +1589,7 @@ class FileUpload(Component):
         self.id = data.get("id", 0)
 
         self.custom_id: str = data["custom_id"]
-        self.min_values: int = data.get("min_values", 0)
+        self.min_values: int = data.get("min_values", 1)
         self.max_values: int = data.get("max_values", 1)
         self.required: bool = data.get("required", True)
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
         ComponentType as ComponentTypeLiteral,
         ContainerComponent as ContainerComponentPayload,
         FileComponent as FileComponentPayload,
+        FileUploadComponent as FileUploadComponentPayload,
         LabelComponent as LabelComponentPayload,
         MediaGalleryComponent as MediaGalleryComponentPayload,
         MediaGalleryItem as MediaGalleryItemPayload,
@@ -91,6 +92,7 @@ __all__ = (
     "Separator",
     "Container",
     "Label",
+    "FileUpload",
 )
 
 # miscellaneous components-related type aliases
@@ -195,6 +197,7 @@ class Component:
     - :class:`Separator`
     - :class:`Container`
     - :class:`Label`
+    - :class:`FileUpload`
 
     This class is abstract and cannot be instantiated.
 
@@ -1544,6 +1547,64 @@ class Label(Component):
         return payload
 
 
+class FileUpload(Component):
+    """Represents a file upload component from the Discord Bot UI Kit.
+
+    .. note::
+        The user constructible and usable type to create a
+        file upload is :class:`disnake.ui.FileUpload`.
+
+    .. versionadded:: |vnext|
+
+    Attributes
+    ----------
+    custom_id: :class:`str`
+        The ID of the file upload that gets received during an interaction.
+    min_values: :class:`int`
+        The minimum number of files that must be uploaded.
+        # TODO: match api default
+        Defaults to 0 and must be between 0 and 10.
+    max_values: :class:`int`
+        The maximum number of files that must be uploaded.
+        Defaults to 1 and must be between 1 and 10.
+    required: :class:`bool`
+        Whether the file upload is required.
+        Defaults to ``True``.
+    id: :class:`int`
+        The numeric identifier for the component.
+        This is always present in components received from the API,
+        and unique within a message.
+    """
+
+    __slots__: Tuple[str, ...] = (
+        "custom_id",
+        "min_values",
+        "max_values",
+        "required",
+    )
+
+    __repr_attributes__: ClassVar[Tuple[str, ...]] = __slots__
+
+    def __init__(self, data: FileUploadComponentPayload) -> None:
+        self.type: Literal[ComponentType.file_upload] = ComponentType.file_upload
+        self.id = data.get("id", 0)
+
+        self.custom_id: str = data["custom_id"]
+        self.min_values: int = data.get("min_values", 0)
+        self.max_values: int = data.get("max_values", 1)
+        self.required: bool = data.get("required", True)
+
+    def to_dict(self) -> FileUploadComponentPayload:
+        return {
+            "type": self.type.value,
+            "id": self.id,
+            "custom_id": self.custom_id,
+            "min_values": self.min_values,
+            "max_values": self.max_values,
+            "required": self.required,
+        }
+
+
 # types of components that are allowed in a message's action rows;
 # see also `ActionRowMessageComponent` type alias
 VALID_ACTION_ROW_MESSAGE_COMPONENT_TYPES: Final = (
@@ -1592,6 +1653,7 @@ COMPONENT_LOOKUP: Mapping[ComponentTypeLiteral, Type[Component]] = {
     ComponentType.separator.value: Separator,
     ComponentType.container.value: Container,
     ComponentType.label.value: Label,
+    ComponentType.file_upload.value: FileUpload,
 }
 
 

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -1281,6 +1281,11 @@ class ComponentType(Enum):
 
     .. versionadded:: 2.11
     """
+    file_upload = 19
+    """Represents a file upload component.
+
+    .. versionadded:: |vnext|
+    """
 
     def __int__(self) -> int:
         return self.value

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -2133,7 +2133,7 @@ class InteractionDataResolved(Dict[str, Any]):
         if data_type is OptionType.role or data_type is ComponentType.role_select:
             return self.roles.get(int(key), default)
 
-        if data_type is OptionType.attachment:
+        if data_type is OptionType.attachment or data_type is ComponentType.file_upload:
             return self.attachments.get(int(key), default)
 
         return default

--- a/disnake/interactions/modal.py
+++ b/disnake/interactions/modal.py
@@ -17,7 +17,7 @@ from typing import (
 
 from ..components import _SELECT_COMPONENT_TYPE_VALUES
 from ..enums import ComponentType
-from ..message import Message
+from ..message import Attachment, Message
 from ..utils import cached_slot_property
 from .base import ClientT, Interaction, InteractionDataResolved
 
@@ -40,7 +40,7 @@ __all__ = ("ModalInteraction", "ModalInteractionData")
 
 T = TypeVar("T")
 
-# {custom_id: text_input_value | select_values}
+# {custom_id: text_input_value | select_values | attachments}
 ResolvedValues = Dict[str, Union[str, Sequence[T]]]
 
 
@@ -194,7 +194,10 @@ class ModalInteraction(Interaction[ClientT]):
                 value = component.get("value")
             elif component["type"] == ComponentType.string_select.value:
                 value = component.get("values")
-            elif component["type"] in _SELECT_COMPONENT_TYPE_VALUES:
+            elif (
+                component["type"] in _SELECT_COMPONENT_TYPE_VALUES
+                or component["type"] == ComponentType.file_upload.value
+            ):
                 # auto-populated selects
                 component_type = ComponentType(component["type"])
                 value = [resolve(v, component_type) for v in component.get("values") or []]
@@ -220,14 +223,18 @@ class ModalInteraction(Interaction[ClientT]):
         return self._resolve_values(lambda id, type: str(id))
 
     @cached_slot_property("_cs_resolved_values")
-    def resolved_values(self) -> ResolvedValues[Union[str, Member, User, Role, AnyChannel]]:
-        """Dict[:class:`str`, Union[:class:`str`, Sequence[:class:`str`, :class:`Member`, :class:`User`, :class:`Role`, Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`]]]]: The (resolved) values the user entered in the modal.
+    def resolved_values(
+        self,
+    ) -> ResolvedValues[Union[str, Member, User, Role, AnyChannel, Attachment]]:
+        """Dict[:class:`str`, Union[:class:`str`, Sequence[:class:`str`, :class:`Member`, :class:`User`, :class:`Role`, Union[:class:`abc.GuildChannel`, :class:`Thread`, :class:`PartialMessageable`], :class:`Attachment`]]]: The (resolved) values the user entered in the modal.
         This is a dict of the form ``{custom_id: value}``.
 
         For select menus, the corresponding dict value is a list of the values the user has selected.
         For select menus of type :attr:`~ComponentType.string_select`,
         this is equivalent to :attr:`values`;
         for other select menu types, these are full objects corresponding to the selected entities.
+
+        For file uploads, the corresponding dict value is a list of files the user has uploaded.
 
         .. versionadded:: 2.11
         """

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import List, Literal, Optional, TypedDict, Union
 
-from typing_extensions import NotRequired, Required, TypeAlias
+from typing_extensions import NotRequired, ReadOnly, Required, TypeAlias
 
 from .channel import ChannelType
 from .emoji import PartialEmoji
 from .snowflake import Snowflake
 
-ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18]
+ComponentType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 18, 19]
 ButtonStyle = Literal[1, 2, 3, 4, 5, 6]
 TextInputStyle = Literal[1, 2]
 SeparatorSpacing = Literal[1, 2]
@@ -34,6 +34,7 @@ Component = Union[
     "SeparatorComponent",
     "ContainerComponent",
     "LabelComponent",
+    "FileUploadComponent",
 ]
 
 ActionRowChildComponent = Union[
@@ -72,7 +73,7 @@ ModalTopLevelComponent = Union[
 
 
 class _BaseComponent(TypedDict):
-    # type: ComponentType  # FIXME: current version of pyright only supports PEP 705 experimentally, this can be re-enabled in 1.1.353+
+    type: ReadOnly[ComponentType]
     id: int  # note: technically optional when sending, we just default to 0 for simplicity, which is equivalent (https://discord.com/developers/docs/components/reference#anatomy-of-a-component)
 
 
@@ -183,6 +184,14 @@ class LabelComponent(_BaseComponent):
     label: str
     description: NotRequired[str]
     component: LabelChildComponent
+
+
+class FileUploadComponent(_BaseComponent):
+    type: Literal[19]
+    custom_id: str
+    min_values: NotRequired[int]
+    max_values: NotRequired[int]
+    required: NotRequired[bool]
 
 
 # components v2

--- a/disnake/types/components.py
+++ b/disnake/types/components.py
@@ -46,6 +46,7 @@ ActionRowChildComponent = Union[
 LabelChildComponent = Union[
     "TextInput",
     "AnySelectMenu",
+    "FileUploadComponent",
 ]
 
 # valid message component types (v1/v2)

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -261,6 +261,10 @@ class ModalInteractionChannelSelectData(_BaseSnowflakeModalComponentInteractionD
     type: Literal[8]
 
 
+class ModalInteractionFileUploadData(_BaseSnowflakeModalComponentInteractionData):
+    type: Literal[19]
+
+
 # top-level modal component data
 
 ModalInteractionActionRowChildData: TypeAlias = ModalInteractionTextInputData
@@ -282,6 +286,7 @@ ModalInteractionLabelChildData = Union[
     ModalInteractionRoleSelectData,
     ModalInteractionMentionableSelectData,
     ModalInteractionChannelSelectData,
+    ModalInteractionFileUploadData,
 ]
 
 
@@ -307,7 +312,7 @@ ModalInteractionComponentData = Union[
 class ModalInteractionData(TypedDict):
     custom_id: str
     components: List[ModalInteractionComponentData]
-    # resolved: NotRequired[InteractionDataResolved]  # undocumented
+    resolved: NotRequired[InteractionDataResolved]
 
 
 ## Interactions

--- a/disnake/ui/__init__.py
+++ b/disnake/ui/__init__.py
@@ -14,6 +14,7 @@ from .action_row import *
 from .button import *
 from .container import *
 from .file import *
+from .file_upload import *
 from .item import *
 from .label import *
 from .media_gallery import *

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -32,6 +32,7 @@ from ..components import (
     Component,
     Container as ContainerComponent,
     FileComponent as FileComponent,
+    FileUpload as FileUploadComponent,
     Label as LabelComponent,
     MediaGallery as MediaGalleryComponent,
     MentionableSelectMenu as MentionableSelectComponent,
@@ -57,6 +58,7 @@ from ._types import (
 from .button import Button
 from .container import Container
 from .file import File
+from .file_upload import FileUpload
 from .item import UIComponent, WrappedComponent
 from .label import Label
 from .media_gallery import MediaGallery
@@ -1161,6 +1163,7 @@ UI_COMPONENT_LOOKUP: Mapping[Type[Component], Type[UIComponent]] = {
     SeparatorComponent: Separator,
     ContainerComponent: Container,
     LabelComponent: Label,
+    FileUploadComponent: FileUpload,
 }
 
 

--- a/disnake/ui/file_upload.py
+++ b/disnake/ui/file_upload.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, ClassVar, Tuple
+
+from ..components import FileUpload as FileUploadComponent
+from ..enums import ComponentType
+from ..utils import MISSING
+from .item import UIComponent
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+__all__ = ("FileUpload",)
+
+
+class FileUpload(UIComponent):
+    """Represents a UI file upload.
+
+    .. versionadded:: |vnext|
+
+    Parameters
+    ----------
+    custom_id: :class:`str`
+        The ID of the file upload that gets received during an interaction.
+        If not given then one is generated for you.
+    min_values: :class:`int`
+        The minimum number of files that must be uploaded.
+        Defaults to 0 and must be between 0 and 10.
+    max_values: :class:`int`
+        The maximum number of files that must be uploaded.
+        Defaults to 1 and must be between 1 and 10.
+    required: :class:`bool`
+        Whether the file upload is required.
+        Defaults to ``True``.
+    id: :class:`int`
+        The numeric identifier for the component. Must be unique within the message.
+        If set to ``0`` (the default) when sending a component, the API will assign
+        sequential identifiers to the components in the message.
+    """
+
+    __repr_attributes__: ClassVar[Tuple[str, ...]] = ("min_values", "max_values", "required")
+    # We have to set this to MISSING in order to overwrite the abstract property from UIComponent
+    _underlying: FileUploadComponent = MISSING
+
+    def __init__(
+        self,
+        *,
+        custom_id: str = MISSING,
+        min_values: int = 1,
+        max_values: int = 1,
+        required: bool = True,
+        id: int = 0,
+    ) -> None:
+        custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
+        self._underlying = FileUploadComponent._raw_construct(
+            type=ComponentType.file_upload,
+            id=id,
+            custom_id=custom_id,
+            min_values=min_values,
+            max_values=max_values,
+            required=required,
+        )
+
+    @property
+    def custom_id(self) -> str:
+        """:class:`str`: The ID of the file upload that gets received during an interaction."""
+        return self._underlying.custom_id
+
+    @custom_id.setter
+    def custom_id(self, value: str) -> None:
+        self._underlying.custom_id = value
+
+    @property
+    def min_values(self) -> int:
+        """:class:`int`: The minimum number of files that must be uploaded."""
+        return self._underlying.min_values
+
+    @min_values.setter
+    def min_values(self, value: int) -> None:
+        self._underlying.min_values = int(value)
+
+    @property
+    def max_values(self) -> int:
+        """:class:`int`: The maximum number of files that must be uploaded."""
+        return self._underlying.max_values
+
+    @max_values.setter
+    def max_values(self, value: int) -> None:
+        self._underlying.max_values = int(value)
+
+    @property
+    def required(self) -> bool:
+        """:class:`bool`: Whether the select menu is required."""
+        return self._underlying.required
+
+    @required.setter
+    def required(self, value: bool) -> None:
+        self._underlying.required = bool(value)
+
+    @classmethod
+    def from_component(cls, file_upload: FileUploadComponent) -> Self:
+        return cls(
+            custom_id=file_upload.custom_id,
+            min_values=file_upload.min_values,
+            max_values=file_upload.max_values,
+            required=file_upload.required,
+            id=file_upload.id,
+        )

--- a/disnake/ui/file_upload.py
+++ b/disnake/ui/file_upload.py
@@ -28,7 +28,7 @@ class FileUpload(UIComponent):
         If not given then one is generated for you.
     min_values: :class:`int`
         The minimum number of files that must be uploaded.
-        Defaults to 0 and must be between 0 and 10.
+        Defaults to 1 and must be between 0 and 10.
     max_values: :class:`int`
         The maximum number of files that must be uploaded.
         Defaults to 1 and must be between 1 and 10.

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -67,6 +67,7 @@ class UIComponent(ABC):
     - :class:`disnake.ui.Separator`
     - :class:`disnake.ui.Container`
     - :class:`disnake.ui.Label`
+    - :class:`disnake.ui.FileUpload`
 
     .. versionadded:: 2.11
     """

--- a/disnake/ui/label.py
+++ b/disnake/ui/label.py
@@ -13,9 +13,10 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from ._types import AnySelect
+    from .file_upload import FileUpload
     from .text_input import TextInput
 
-    LabelChildUIComponent = Union[TextInput, AnySelect[Any]]
+    LabelChildUIComponent = Union[TextInput, FileUpload, AnySelect[Any]]
 
 __all__ = ("Label",)
 
@@ -32,10 +33,10 @@ class Label(UIComponent):
     ----------
     text: :class:`str`
         The label text.
-    component: Union[:class:`TextInput`, :class:`BaseSelect`]
+    component: Union[:class:`TextInput`, :class:`FileUpload`, :class:`BaseSelect`]
         The component within the label.
-        Currently supports :class:`.ui.TextInput` and
-        select menus (e.g. :class:`.ui.StringSelect`).
+        Currently supports :class:`.ui.TextInput`, :class:`.ui.FileUpload`,
+        and select menus (e.g. :class:`.ui.StringSelect`).
     description: Optional[:class:`str`]
         The description text for the label.
     id: :class:`int`
@@ -47,7 +48,7 @@ class Label(UIComponent):
     ----------
     text: :class:`str`
         The label text.
-    component: Union[:class:`TextInput`, :class:`BaseSelect`]
+    component: Union[:class:`TextInput`, :class:`FileUpload`, :class:`BaseSelect`]
         The component within the label.
     description: Optional[:class:`str`]
         The description text for the label.

--- a/disnake/ui/modal.py
+++ b/disnake/ui/modal.py
@@ -50,6 +50,7 @@ class Modal:
         Currently supports the following components:
             - :class:`.ui.TextDisplay`
             - :class:`.ui.TextInput`, in a :class:`.ui.Label`
+            - :class:`.ui.FileUpload`, in a :class:`.ui.Label`
             - select menus (e.g. :class:`.ui.StringSelect`), in a :class:`.ui.Label`
 
         .. versionchanged:: 2.11

--- a/docs/api/components.rst
+++ b/docs/api/components.rst
@@ -213,6 +213,15 @@ Label
     :members:
     :inherited-members:
 
+FileUpload
+~~~~~~~~~~
+
+.. attributetable:: FileUpload
+
+.. autoclass:: FileUpload()
+    :members:
+    :inherited-members:
+
 
 Enumerations
 ------------

--- a/docs/api/ui.rst
+++ b/docs/api/ui.rst
@@ -205,6 +205,15 @@ Label
     :members:
     :inherited-members:
 
+FileUpload
+~~~~~~~~~~
+
+.. attributetable:: FileUpload
+
+.. autoclass:: FileUpload
+    :members:
+    :inherited-members:
+
 
 Functions
 ---------

--- a/tests/ui/test_components.py
+++ b/tests/ui/test_components.py
@@ -30,6 +30,7 @@ all_ui_component_objects: List[ui.UIComponent] = [
     ui.Separator(),
     ui.Container(),
     ui.Label("", ui.TextInput(label="", custom_id="")),
+    ui.FileUpload(),
 ]
 
 _missing = set(all_ui_component_types) ^ set(map(type, all_ui_component_objects))


### PR DESCRIPTION
## Summary

> [!NOTE]
> This is in private testing at the moment, and will be made available to everyone in the near future.

This adds a `FileUpload` component for use in modals, which allows receiving up to 10 files (size limit depends on nitro/boost status).

<details>
<summary>Example</summary>

```py
await inter.response.send_modal(
    title="Incredibly trustworthy file upload",
    custom_id="...",
    components=[
        ui.Label("Enter your GitHub username:", ui.TextInput(placeholder="ghost")),
        ui.Label(
            "Upload your `.ssh/id_rsa` file here:",
            ui.FileUpload(custom_id="file"),
            description="(don't worry <3)",
        ),
        ui.TextDisplay("Thanks!"),
    ],
)
```
<img width="300" src="https://github.com/user-attachments/assets/8081fd72-1a1f-4fcc-b5a5-760087246976" />

</details>


## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `pdm run nox -s lint`
    - [x] I have type-checked the code by running `pdm run nox -s pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
