### PR TITLE
ci: add dependabot to update github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,8 +6,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 1
+    labels:
+      - "t: dependencies"
+      - "t: meta"
+      - "skip news"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
in correlation with #1402, adds dependabot configuration to bump actions automatically
