### PR TITLE
fix: re-enable other TC rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,9 @@ ignore = [
     ## flake8-todos
     "TD", # similar to flake8-fixme, though they may conflict
     ## flake8-typechecking
-    "TC", # TODO: enable in typing PR
+    "TC001", # typing-only first party import # to be enabled
+    "TC002", # typing only standard library import # to be enabled
+    "TC003", # typing only third party import # to be enabled
     ## flake8-unused-arguments
     "ARG", # most unused arguments are intentional
     ## flake8-use-pathlib


### PR DESCRIPTION
these rules got disabled accidently in 5b43b21f6bbf4751489f39489fdffaaf11e4c762
and shouldn't have been
