### PR TITLE
feat: improve error messages for annotation issues in command parameters

### DIFF
--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -391,7 +391,14 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         except AttributeError:
             globalns = {}
 
-        params = get_signature_parameters(function, globalns, skip_standard_params=True)
+        try:
+            params = get_signature_parameters(function, globalns, skip_standard_params=True)
+        except NameError as e:
+            raise NameError(
+                "Stringified params annotations must have their reference imported outside of a TYPE_CHECKING block: "
+                + e.args[0]
+            ) from None
+
         for param in params.values():
             if param.annotation is Greedy:
                 msg = "Unparameterized Greedy[...] is disallowed in signature."

--- a/disnake/ext/commands/slash_core.py
+++ b/disnake/ext/commands/slash_core.py
@@ -306,7 +306,13 @@ class SubCommand(InvokableApplicationCommand):
         )
 
         if options is None:
-            options = expand_params(self)
+            try:
+                options = expand_params(self)
+            except NameError as e:
+                raise NameError(
+                    "Could not expand parameters. Please check all annotations are imported outside of TYPE_CHECKING blocks. "
+                    + e.args[0]
+                ) from e
 
         self.docstring = utils.parse_docstring(func)
         desc_loc = Localized._cast(description, False)
@@ -473,7 +479,13 @@ class InvokableSlashCommand(InvokableApplicationCommand):
         )
 
         if options is None:
-            options = expand_params(self)
+            try:
+                options = expand_params(self)
+            except NameError as e:
+                raise NameError(
+                    "Could not expand parameter options. Please check all annotations are imported outside of TYPE_CHECKING blocks. "
+                    + e.args[0]
+                ) from e
 
         self.docstring = utils.parse_docstring(func)
         desc_loc = Localized._cast(description, False)


### PR DESCRIPTION
Reduce the length of the traceback and provide a helpful error message
when a user forgets to import a type used in a command parameter annotation
outside of a TYPE_CHECKING block.
