### PR TITLE
feat: add support for message call objects

### DIFF
--- a/changelog/1414.feature.rst
+++ b/changelog/1414.feature.rst
@@ -1,0 +1,1 @@
+Add new :class:`MessageCall` object and associated :attr:`Message.call` attribute for viewing information about a call in private channels

--- a/changelog/1414.feature.rst
+++ b/changelog/1414.feature.rst
@@ -1,1 +1,1 @@
-Add new :class:`MessageCall` object and associated :attr:`Message.call` attribute for viewing information about a call in private channels
+Add new :class:`MessageCall` object and associated :attr:`Message.call` attribute for viewing information about a call in private channels.

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
         Message as MessagePayload,
         MessageActivity as MessageActivityPayload,
         MessageApplication as MessageApplicationPayload,
+        MessageCall as MessageCallPayload,
         MessageReference as MessageReferencePayload,
         Reaction as ReactionPayload,
         RoleSubscriptionData as RoleSubscriptionDataPayload,
@@ -974,6 +975,33 @@ def flatten_handlers(cls: Type[Message]) -> Type[Message]:
     return cls
 
 
+class MessageCall:
+    """
+    Represents a call in a message.
+
+    .. versionadded:: |vnext|
+
+    Attributes
+    ----------
+    ended_timestamp: Optional[:class:`datetime.datetime`]
+        The timestamp when the call ended, or ``None`` if the call is still ongoing.
+    participant_ids: List[:class:`int`]
+        A list of user IDs of the participants in the call.
+
+        Due to API limitations, this list is simply the snowflakes of users that were in the call.
+        It is not resolved to the user objects themselves.
+    """
+
+    def __init__(self, *, data: MessageCallPayload, state: ConnectionState) -> None:
+        self.ended_timestamp: Optional[datetime.datetime] = (
+            utils.parse_time(timestamp) if (timestamp := data.get("ended_timestamp")) else None
+        )
+        self.participant_ids: List[int] = [
+            int(participant) for participant in data.get("participants", [])
+        ]
+        self._state = state
+
+
 @flatten_handlers
 class Message(Hashable):
     """Represents a message from Discord.
@@ -1116,6 +1144,11 @@ class Message(Hashable):
         The poll contained in this message.
 
         .. versionadded:: 2.10
+
+    call: Optional[:class:`MessageCall`]
+        The call contained in this message.
+
+        .. versionadded:: |vnext|
     """
 
     __slots__ = (
@@ -1154,6 +1187,7 @@ class Message(Hashable):
         "components",
         "guild",
         "poll",
+        "call",
         "_edited_timestamp",
         "_role_subscription_data",
         "_pinned_at",
@@ -1213,7 +1247,9 @@ class Message(Hashable):
         self.poll: Optional[Poll] = None
         if poll_data := data.get("poll"):
             self.poll = Poll.from_dict(message=self, data=poll_data)
-
+        self.call = (
+            MessageCall(data=call_data, state=state) if (call_data := data.get("call")) else None
+        )
         try:
             # if the channel doesn't have a guild attribute, we handle that
             self.guild = channel.guild  # type: ignore

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -102,6 +102,7 @@ __all__ = (
     "AuthorizingIntegrationOwners",
     "RoleSubscriptionData",
     "ForwardedMessage",
+    "MessageCall",
 )
 
 
@@ -988,18 +989,17 @@ class MessageCall:
     participant_ids: List[:class:`int`]
         A list of user IDs of the participants in the call.
 
-        Due to API limitations, this list is simply the snowflakes of users that were in the call.
+        Due to API limitations, this list is simply the user IDs that were in the call.
         It is not resolved to the user objects themselves.
     """
 
-    def __init__(self, *, data: MessageCallPayload, state: ConnectionState) -> None:
-        self.ended_timestamp: Optional[datetime.datetime] = (
-            utils.parse_time(timestamp) if (timestamp := data.get("ended_timestamp")) else None
+    def __init__(self, *, data: MessageCallPayload) -> None:
+        self.ended_timestamp: Optional[datetime.datetime] = utils.parse_time(
+            data.get("ended_timestamp")
         )
         self.participant_ids: List[int] = [
             int(participant) for participant in data.get("participants", [])
         ]
-        self._state = state
 
 
 @flatten_handlers
@@ -1147,6 +1147,7 @@ class Message(Hashable):
 
     call: Optional[:class:`MessageCall`]
         The call contained in this message.
+        Only present when :attr:`type` is :attr:`MessageType.call`.
 
         .. versionadded:: |vnext|
     """
@@ -1247,9 +1248,7 @@ class Message(Hashable):
         self.poll: Optional[Poll] = None
         if poll_data := data.get("poll"):
             self.poll = Poll.from_dict(message=self, data=poll_data)
-        self.call = (
-            MessageCall(data=call_data, state=state) if (call_data := data.get("call")) else None
-        )
+        self.call = MessageCall(data=call_data) if (call_data := data.get("call")) else None
         try:
             # if the channel doesn't have a guild attribute, we handle that
             self.guild = channel.guild  # type: ignore

--- a/disnake/types/message.py
+++ b/disnake/types/message.py
@@ -164,3 +164,8 @@ class AllowedMentions(TypedDict):
 class MessagePin(TypedDict):
     pinned_at: str
     message: Message
+
+
+class MessageCall(TypedDict):
+    participants: SnowflakeList
+    ended_timestamp: NotRequired[Optional[str]]

--- a/docs/api/messages.rst
+++ b/docs/api/messages.rst
@@ -70,6 +70,14 @@ RoleSubscriptionData
 .. autoclass:: RoleSubscriptionData()
     :members:
 
+MessageCall
+~~~~~~~~~~~
+
+.. attributetable:: MessageCall
+
+.. autoclass:: MessageCall()
+    :members:
+
 RawTypingEvent
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
https://discord.com/developers/docs/resources/message#message-call-object

Didn't add an edit handler but also doesn't even look like that matters? To my knowledge, these messages shouldn't be received over the gateway for bots anyways.