### PR TITLE
fix: run dependabot on reusuable workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1


### PR DESCRIPTION
Noticed in #1415 that Dependabot doesn't seem to run on.github/actions without this specific piece of code. The `*` is important to the directory. 

Tested locally with the dependabot's cli