### PR TITLE
docs: update role of typing.Union to class to align with type of Union

### DIFF
--- a/disnake/ext/commands/errors.py
+++ b/disnake/ext/commands/errors.py
@@ -805,7 +805,7 @@ class BotMissingPermissions(CheckFailure):
 
 
 class BadUnionArgument(UserInputError):
-    """Exception raised when a :data:`typing.Union` converter fails for all
+    """Exception raised when a :class:`typing.Union` converter fails for all
     its associated types.
 
     This inherits from :exc:`UserInputError`

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -485,7 +485,7 @@ commands in an easy to use manner.
 typing.Union
 ^^^^^^^^^^^^
 
-A :data:`typing.Union` is a special type hint that allows for the command to take in any of the specific types instead of
+A :class:`typing.Union` is a special type hint that allows for the command to take in any of the specific types instead of
 a singular type. For example, given the following:
 
 .. code-block:: python3
@@ -502,7 +502,7 @@ The way this works is through a left-to-right order. It first attempts to conver
 :class:`disnake.TextChannel`, and if it fails it tries to convert it to a :class:`disnake.Member`. If all converters fail,
 then a special error is raised, :exc:`~ext.commands.BadUnionArgument`.
 
-Note that any valid converter discussed above can be passed in to the argument list of a :data:`typing.Union`.
+Note that any valid converter discussed above can be passed in to the argument list of a :class:`typing.Union`.
 
 typing.Optional
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
python 3.14 changed documentation regarding the level of typing.Union
and it is no longer represented with the data role. This causes CI to 
fail until we reference typing.Union under a class how it actually is 
defined.
