### PR TITLE
build: bump uv to 0.9 for python 3.14 final

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -43,7 +43,7 @@ runs:
       id: setup-python
       uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       with:
-        version: '0.8.14'
+        version: '0.9.2'
         enable-cache: true
         # this doesn't install python but pins the uv version; its the same as providing UV_PYTHON
         python-version: ${{ inputs.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ where = ["."]
 include = ["disnake*"]
 
 [tool.uv]
-required-version = ">=0.8.4"
+required-version = ">=0.9.2"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
to use python3.14 final, the internal uv must support it with the proper listing
so we must update uv to 0.9 to have the latest python 3.14

this is a temporary shortcoming that should be resolved eventually
