### PR TITLE
build: bump nox to 2025.10.16

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#     "nox==2025.10.14",
+#     "nox==2025.10.16",
 # ]
 # ///
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
As CI still relies on nox in ci using the same version to run it that's also the nox running the script.... this bumps nox again to make ci work again.