### PR TITLE
chore: add maintainers to CODEOWNERS for noxfile.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 /.github @DisnakeDev/maintainers
 /scripts/ci @DisnakeDev/maintainers
+/noxfile.py @DisnakeDev/maintainers


### PR DESCRIPTION
`noxfile.py` is now used extensively in CI and should go through the same required review process that is required by all changes to ci configuration.