### PR TITLE
refactor: `type(x).__name__` => `x.__class__.__name__`

### DIFF
--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -650,7 +650,7 @@ class ApplicationCommand(ABC):  # noqa: B024  # this will get refactored eventua
 
     def __repr__(self) -> str:
         attrs = " ".join(f"{key}={getattr(self, key)!r}" for key in self.__repr_attributes__)
-        return f"<{type(self).__name__} {attrs}>"
+        return f"<{self.__class__.__name__} {attrs}>"
 
     def __str__(self) -> str:
         return self.name

--- a/disnake/automod.py
+++ b/disnake/automod.py
@@ -90,7 +90,7 @@ class AutoModAction:
         self._metadata: AutoModActionMetadata = {}
 
     def __repr__(self) -> str:
-        return f"<{type(self).__name__} type={self.type!r}>"
+        return f"<{self.__class__.__name__} type={self.type!r}>"
 
     @classmethod
     def _from_dict(cls, data: AutoModActionPayload) -> Self:
@@ -150,7 +150,7 @@ class AutoModBlockMessageAction(AutoModAction):
         return self._metadata.get("custom_message")
 
     def __repr__(self) -> str:
-        return f"<{type(self).__name__} custom_message={self.custom_message!r}>"
+        return f"<{self.__class__.__name__} custom_message={self.custom_message!r}>"
 
 
 class AutoModSendAlertAction(AutoModAction):
@@ -188,7 +188,7 @@ class AutoModSendAlertAction(AutoModAction):
         return int(self._metadata["channel_id"])
 
     def __repr__(self) -> str:
-        return f"<{type(self).__name__} channel_id={self.channel_id!r}>"
+        return f"<{self.__class__.__name__} channel_id={self.channel_id!r}>"
 
 
 class AutoModTimeoutAction(AutoModAction):
@@ -230,7 +230,7 @@ class AutoModTimeoutAction(AutoModAction):
         return self._metadata["duration_seconds"]
 
     def __repr__(self) -> str:
-        return f"<{type(self).__name__} duration={self.duration!r}>"
+        return f"<{self.__class__.__name__} duration={self.duration!r}>"
 
 
 class AutoModBlockInteractionAction(AutoModAction):
@@ -439,7 +439,7 @@ class AutoModTriggerMetadata:
         return data
 
     def __repr__(self) -> str:
-        s = f"<{type(self).__name__}"
+        s = f"<{self.__class__.__name__}"
         if self.keyword_filter is not None:
             s += f" keyword_filter={self.keyword_filter!r}"
         if self.regex_patterns is not None:
@@ -791,7 +791,7 @@ class AutoModActionExecution:
 
     def __repr__(self) -> str:
         return (
-            f"<{type(self).__name__} guild={self.guild!r} action={self.action!r}"
+            f"<{self.__class__.__name__} guild={self.guild!r} action={self.action!r}"
             f" rule_id={self.rule_id!r} rule_trigger_type={self.rule_trigger_type!r}"
             f" channel={self.channel!r} user_id={self.user_id!r} message_id={self.message_id!r}"
             f" alert_message_id={self.alert_message_id!r} content={self.content!r}"

--- a/disnake/channel.py
+++ b/disnake/channel.py
@@ -3402,7 +3402,7 @@ class ThreadOnlyGuildChannel(disnake.abc.GuildChannel, Hashable):
             ("flags", self.flags),
         )
         joined = " ".join(f"{k!s}={v!r}" for k, v in attrs)
-        return f"<{type(self).__name__} {joined}>"
+        return f"<{self.__class__.__name__} {joined}>"
 
     def _update(self, guild: Guild, data: ForumChannelPayload | MediaChannelPayload) -> None:
         self.guild: Guild = guild

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -1038,7 +1038,7 @@ class Client:
         """
         _log.info("logging in using static token")
         if not isinstance(token, str):
-            msg = f"token must be of type str, got {type(token).__name__} instead"
+            msg = f"token must be of type str, got {token.__class__.__name__} instead"
             raise TypeError(msg)
 
         data = await self.http.static_login(token.strip())

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1917,7 +1917,7 @@ def handle_media_item_input(value: MediaItemInput) -> UnfurledMediaItem:
         return UnfurledMediaItem(value.url)
 
     assert_never(value)
-    msg = f"{type(value).__name__} cannot be converted to UnfurledMediaItem"
+    msg = f"{value.__class__.__name__} cannot be converted to UnfurledMediaItem"
     raise TypeError(msg)
 
 

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -336,7 +336,7 @@ class Embed:
         elif value is MISSING or value is None or isinstance(value, Colour):
             self._colour = value
         else:
-            msg = f"Expected disnake.Colour, int, or None but received {type(value).__name__} instead."
+            msg = f"Expected disnake.Colour, int or None, received {value.__class__.__name__} instead."
             raise TypeError(msg)
 
     @colour.deleter
@@ -358,7 +358,7 @@ class Embed:
         elif value is None:
             self._timestamp = value
         else:
-            msg = f"Expected datetime.datetime or None received {type(value).__name__} instead"
+            msg = f"Expected datetime.datetime or None, received {value.__class__.__name__} instead."
             raise TypeError(msg)
 
     @property
@@ -845,7 +845,7 @@ class Embed:
         elif isinstance(value, int):
             cls._default_colour = Colour(value=value)
         else:
-            msg = f"Expected disnake.Colour, int, or None but received {type(value).__name__} instead."
+            msg = f"Expected disnake.Colour, int or None, received {value.__class__.__name__} instead."
             raise TypeError(msg)
         return cls._default_colour
 

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -336,7 +336,7 @@ class Embed:
         elif value is MISSING or value is None or isinstance(value, Colour):
             self._colour = value
         else:
-            msg = f"Expected disnake.Colour, int or None, received {value.__class__.__name__} instead."
+            msg = f"Expected disnake.Colour, int, or None, received {value.__class__.__name__} instead."
             raise TypeError(msg)
 
     @colour.deleter
@@ -847,7 +847,7 @@ class Embed:
         elif isinstance(value, int):
             cls._default_colour = Colour(value=value)
         else:
-            msg = f"Expected disnake.Colour, int or None, received {value.__class__.__name__} instead."
+            msg = f"Expected disnake.Colour, int, or None, received {value.__class__.__name__} instead."
             raise TypeError(msg)
         return cls._default_colour
 

--- a/disnake/embeds.py
+++ b/disnake/embeds.py
@@ -358,7 +358,9 @@ class Embed:
         elif value is None:
             self._timestamp = value
         else:
-            msg = f"Expected datetime.datetime or None, received {value.__class__.__name__} instead."
+            msg = (
+                f"Expected datetime.datetime or None, received {value.__class__.__name__} instead."
+            )
             raise TypeError(msg)
 
     @property

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -127,7 +127,7 @@ def _format_diff(diff: _Diff) -> str:
             continue
         lines.append(label)
         if changes := diff[key]:
-            lines.extend(f"    <{type(cmd).__name__} name={cmd.name!r}>" for cmd in changes)
+            lines.extend(f"    <{cmd.__class__.__name__} name={cmd.name!r}>" for cmd in changes)
         else:
             lines.append("    -")
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -329,7 +329,7 @@ class _BaseRange(ABC):
     def __repr__(self) -> str:
         a = "..." if self.min_value is None else self.min_value
         b = "..." if self.max_value is None else self.max_value
-        return f"{type(self).__name__}[{self.underlying_type.__name__}, {a}, {b}]"
+        return f"{self.__class__.__name__}[{self.underlying_type.__name__}, {a}, {b}]"
 
     @classmethod
     @abstractmethod
@@ -610,7 +610,7 @@ class ParamInfo:
 
     def __repr__(self) -> str:
         args = ", ".join(f"{k}={'...' if v is ... else repr(v)}" for k, v in vars(self).items())
-        return f"{type(self).__name__}({args})"
+        return f"{self.__class__.__name__}({args})"
 
     async def get_default(self, inter: ApplicationCommandInteraction) -> Any:
         """Gets the default for an interaction"""

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -87,6 +87,10 @@ class Loop(Generic[LF]):
         """.. note:
         If you overwrite ``__init__`` arguments, make sure to redefine .clone too.
         """
+        if not inspect.iscoroutinefunction(coro):
+            msg = f"Expected a coroutine function, got {coro.__class__.__name__!r} instead."
+            raise TypeError(msg)
+
         self.coro: LF = coro
         self.reconnect: bool = reconnect
         self.loop: asyncio.AbstractEventLoop = loop
@@ -117,10 +121,6 @@ class Loop(Generic[LF]):
         self._last_iteration_failed = False
         self._last_iteration: datetime.datetime = MISSING
         self._next_iteration = None
-
-        if not inspect.iscoroutinefunction(self.coro):
-            msg = f"Expected coroutine function, not {type(self.coro).__name__!r}."
-            raise TypeError(msg)
 
     async def _call_loop_function(self, name: str, *args: Any, **kwargs: Any) -> None:
         coro = getattr(self, "_" + name)
@@ -623,7 +623,7 @@ class Loop(Generic[LF]):
         ret: list[datetime.time] = []
         for index, t in enumerate(time):
             if not isinstance(t, dt):
-                msg = f"Expected a sequence of {dt!r} for ``time``, received {type(t).__name__!r} at index {index} instead."
+                msg = f"Expected a sequence of {dt!r} for ``time``, received {t.__class__.__name__!r} at index {index} instead."
                 raise TypeError(msg)
             ret.append(t if t.tzinfo is not None else t.replace(tzinfo=utc))
 

--- a/disnake/flags.py
+++ b/disnake/flags.py
@@ -1091,7 +1091,7 @@ class Intents(BaseFlags):
     def __init__(self, value: int | None = None, **kwargs: bool) -> None:
         if value is not None:
             if not isinstance(value, int):
-                msg = f"Expected int, received {type(value).__name__} for argument 'value'."
+                msg = f"Expected int, received {value.__class__.__name__} for parameter 'value'."
                 raise TypeError(msg)
             if value < 0:
                 msg = "Expected a non-negative value."

--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -4228,7 +4228,7 @@ class Guild(Hashable):
         else:
             msg = (
                 "`clean_history_duration` should be int or timedelta, "
-                f"not {type(clean_history_duration).__name__}"
+                f"not {clean_history_duration.__class__.__name__}"
             )
             raise TypeError(msg)
 
@@ -4317,7 +4317,7 @@ class Guild(Hashable):
         else:
             msg = (
                 "`clean_history_duration` should be int or timedelta, "
-                f"not {type(clean_history_duration).__name__}"
+                f"not {clean_history_duration.__class__.__name__}"
             )
             raise TypeError(msg)
 

--- a/disnake/i18n.py
+++ b/disnake/i18n.py
@@ -179,7 +179,7 @@ class LocalizationValue:
             self._key = None
             self._data = {str(k): v for k, v in localizations.items()}
         else:
-            msg = f"Invalid localizations type: {type(localizations).__name__}"
+            msg = f"Invalid localizations type: {localizations.__class__.__name__}"
             raise TypeError(msg)
 
     def _upgrade(self, key: str | None) -> None:

--- a/disnake/player.py
+++ b/disnake/player.py
@@ -663,9 +663,7 @@ class PCMVolumeTransformer(AudioSource, Generic[AT]):
 
     def __init__(self, original: AT, volume: float = 1.0) -> None:
         if not has_audioop:
-            msg = (
-                f"audioop-lts library needed in Python >=3.13 in order to use {type(self).__name__}"
-            )
+            msg = f"audioop-lts library needed in Python >=3.13 in order to use {self.__class__.__name__}"
             raise RuntimeError(msg)
 
         if not isinstance(original, AudioSource):

--- a/disnake/raw_models.py
+++ b/disnake/raw_models.py
@@ -59,7 +59,7 @@ class _RawReprMixin:
 
     def __repr__(self) -> str:
         value = " ".join(f"{attr}={getattr(self, attr)!r}" for attr in get_slots(type(self)))
-        return f"<{type(self).__name__} {value}>"
+        return f"<{self.__class__.__name__} {value}>"
 
 
 class RawMessageDeleteEvent(_RawReprMixin):

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -181,7 +181,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildDefaultT]):
 
         for component in components:
             if not isinstance(component, WrappedComponent):
-                msg = f"components should be of type WrappedComponent, got {type(component).__name__}."
+                msg = f"components should be of type WrappedComponent, got {component.__class__.__name__}."
                 raise TypeError(msg)
             self.append_item(component)
 

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -108,7 +108,7 @@ class Container(UIComponent):
         elif value is None or isinstance(value, Colour):
             self._accent_colour = value
         else:
-            msg = f"Expected Colour, int, or None but received {type(value).__name__} instead."
+            msg = f"Expected Colour, int or None, received {value.__class__.__name__} instead."
             raise TypeError(msg)
 
     accent_color = accent_colour

--- a/disnake/ui/container.py
+++ b/disnake/ui/container.py
@@ -108,7 +108,7 @@ class Container(UIComponent):
         elif value is None or isinstance(value, Colour):
             self._accent_colour = value
         else:
-            msg = f"Expected Colour, int or None, received {value.__class__.__name__} instead."
+            msg = f"Expected Colour, int, or None, received {value.__class__.__name__} instead."
             raise TypeError(msg)
 
     accent_color = accent_colour

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -41,7 +41,7 @@ ItemCallbackType = Callable[[V_deco, I, "MessageInteraction"], Coroutine[Any, An
 
 def ensure_ui_component(obj: UIComponentT, name: str = "component") -> UIComponentT:
     if not isinstance(obj, UIComponent):
-        msg = f"{name} should be a valid UI component, got {type(obj).__name__}."
+        msg = f"{name} should be a valid UI component, got {obj.__class__.__name__}."
         raise TypeError(msg)
     return obj
 
@@ -81,7 +81,7 @@ class UIComponent(ABC):
         attrs = " ".join(
             f"{key.lstrip('_')}={getattr(self, key)!r}" for key in self.__repr_attributes__
         )
-        return f"<{type(self).__name__} {attrs}>"
+        return f"<{self.__class__.__name__} {attrs}>"
 
     @property
     def is_v2(self) -> bool:

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -228,7 +228,7 @@ class View:
                 continue
             if not isinstance(component, VALID_ACTION_ROW_MESSAGE_COMPONENT_TYPES):
                 # can happen if message uses components v2
-                msg = f"Cannot construct view from message - unexpected {type(component).__name__}"
+                msg = f"Cannot construct view from message - unexpected {component.__class__.__name__}"
                 raise TypeError(msg)
             view.add_item(_component_to_item(component))
         return view
@@ -570,7 +570,7 @@ class ViewStore:
                 _log.warning(
                     "cannot update view for message %d, unexpected %s",
                     message_id,
-                    type(row).__name__,
+                    row.__class__.__name__,
                 )
                 return
 

--- a/tests/ui/test_components.py
+++ b/tests/ui/test_components.py
@@ -42,7 +42,7 @@ assert not _missing, f"missing component objects: {_missing}"
 @pytest.mark.parametrize(
     "obj",
     all_ui_component_objects,
-    ids=[type(o).__name__ for o in all_ui_component_objects],
+    ids=[o.__class__.__name__ for o in all_ui_component_objects],
 )
 def test_id_property(obj: ui.UIComponent) -> None:
     assert obj.id == 0


### PR DESCRIPTION
## Summary

This PR unifies the style of access to a value's type's name, replacing `type(x).__name__` with `x.__class__.__name__` (since the latter has been used more often)
Also moves a type guard at [disnake/ext/tasks/__init__.py#L125-L127](https://github.com/DisnakeDev/disnake/blob/79a8027a14e8ef99789490fd94f9b7d52b6a1422/disnake/ext/tasks/__init__.py#L125-L127) higher up, so it can fail quicker.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
