### PR TITLE
fix: type annotation for `View.add_item` method

### DIFF
--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -239,7 +239,7 @@ class View:
             return time.monotonic() + self.timeout
         return None
 
-    def add_item(self, item: Item) -> Self:
+    def add_item(self, item: Item[Self]) -> Self:
         """Adds an item to the view.
 
         This function returns the class instance to allow for fluent-style


### PR DESCRIPTION
## Summary

Fixes type annotation issue in `View.add_item` method where type checkers (Pylance/mypy) reported "Type of 'add_item' is partially unknown" due to missing generic parameter in `Item` annotation.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
