### PR TITLE
fix: warn_deprecated now respect warnings.filter ignores

### DIFF
--- a/changelog/1476.bugfix.rst
+++ b/changelog/1476.bugfix.rst
@@ -1,0 +1,1 @@
+warn_deprecated now respected warning.filter ignores if at least "disnake" is passed to module argument.

--- a/changelog/1476.bugfix.rst
+++ b/changelog/1476.bugfix.rst
@@ -1,1 +1,1 @@
-warn_deprecated now respected warning.filter ignores if at least "disnake" is passed to module argument.
+Fix ``utils.warn_deprecated`` to respect :mod:`warnings` filters defined by user.

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -312,15 +312,16 @@ def warn_deprecated(
                 send_warning = False
                 break  # break out after first disnake rule, it's good enough.
 
-    if send_warning:
-        # this still allows force bypassing of filters if the default DeprecationWarning ignore is set.
-        try:
-            warnings.simplefilter(action="always", category=DeprecationWarning)
-            warnings.warn(*args, stacklevel=stacklevel + 1, category=DeprecationWarning, **kwargs)
-        finally:
-            # NOTE: Is this assertion even necessary? warnings.filters is always at minimum an empty list?
-            assert isinstance(warnings.filters, list)
-            warnings.filters[:] = old_filters
+    # allow force bypassing of filters if the default DeprecationWarning ignore is set.
+    if not send_warning:
+        return
+
+    try:
+        warnings.simplefilter(action="always", category=DeprecationWarning)
+        warnings.warn(*args, stacklevel=stacklevel + 1, category=DeprecationWarning, **kwargs)
+    finally:
+        assert isinstance(warnings.filters, list)
+        warnings.filters[:] = old_filters
 
 
 def oauth_url(

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -301,21 +301,15 @@ def warn_deprecated(
         stacklevel = 1  # reset stacklevel, assume we just want the first frame outside library code
 
     old_filters = warnings.filters[:]
-    send_warning = True
-    if len(old_filters) > 0:
+    if len(old_filters) >= 0:
         for action, _, category, module, _ in old_filters:
             if (
                 (category is DeprecationWarning)
                 and ("disnake" in str(module))
                 and (action == "ignore")
             ):
-                send_warning = False
-                break  # break out after first disnake rule, it's good enough.
-
-    # allow force bypassing of filters if the default DeprecationWarning ignore is set.
-    if not send_warning:
-        return
-
+                return  # if a disnake ignore rule is found, we skip warning
+    # we allow force bypassing of filters if the default/global DeprecationWarning ignore is set.
     try:
         warnings.simplefilter(action="always", category=DeprecationWarning)
         warnings.warn(*args, stacklevel=stacklevel + 1, category=DeprecationWarning, **kwargs)

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -301,7 +301,6 @@ def warn_deprecated(
         stacklevel = 1  # reset stacklevel, assume we just want the first frame outside library code
 
     old_filters = warnings.filters[:]
-    warnings.filterwarnings(action="default", category=DeprecationWarning, module="cumbum")
     send_warning = True
     if len(old_filters) > 0:
         for action, _, category, module, _ in old_filters:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -301,6 +301,7 @@ def warn_deprecated(
         stacklevel = 1  # reset stacklevel, assume we just want the first frame outside library code
 
     old_filters = warnings.filters[:]
+    warnings.filterwarnings(action="default", category=DeprecationWarning, module="cumbum")
     send_warning = True
     if len(old_filters) > 0:
         for action, _, category, module, _ in old_filters:
@@ -319,8 +320,9 @@ def warn_deprecated(
             warnings.warn(*args, stacklevel=stacklevel + 1, category=DeprecationWarning, **kwargs)
         finally:
             # NOTE: Is this assertion even necessary? warnings.filters is always at minimum an empty list?
-            assert isinstance(warnings.filters, list)  
+            assert isinstance(warnings.filters, list)
             warnings.filters[:] = old_filters
+
 
 def oauth_url(
     client_id: Union[int, str],

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -301,15 +301,15 @@ def warn_deprecated(
         stacklevel = 1  # reset stacklevel, assume we just want the first frame outside library code
 
     old_filters = warnings.filters[:]
-    if len(old_filters) >= 0:
+    if len(old_filters) > 0:
         for action, _, category, module, _ in old_filters:
             if (
                 (category is DeprecationWarning)
                 and ("disnake" in str(module))
                 and (action == "ignore")
             ):
-                return  # if a disnake ignore rule is found, we skip warning
-    # we allow force bypassing of filters if the default/global DeprecationWarning ignore is set.
+                return  # If a disnake ignore rule is found, we skip warning.
+    # We allow force bypassing of filters if the default/global DeprecationWarning ignore is set.
     try:
         warnings.simplefilter(action="always", category=DeprecationWarning)
         warnings.warn(*args, stacklevel=stacklevel + 1, category=DeprecationWarning, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,41 +132,43 @@ def test_deprecated_skip() -> None:
     ["This is a deprecated function"],
 )
 def test_deprecated_warn(msg: str) -> None:
-    # Just test if works 
+    # Just test if works
     # first clear existing filters - these will be restored at the end as this is probably messing with the global warning filters
     filters = warnings.filters[:]
-    
+
     warnings.resetwarnings()
     with warnings.catch_warnings(record=True) as result:
-        warnings.filterwarnings("always", category=DeprecationWarning, module=r"disnake\..*")  # this also works with just a plain str
+        warnings.filterwarnings(
+            "always", category=DeprecationWarning, module=r"disnake\..*"
+        )  # this also works with just a plain str
         utils.warn_deprecated(msg)
 
     assert len(result) == 1
     assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
     assert result[0].category is DeprecationWarning
-    
+
     # Reset With empty filters - expected behaviour is that a warning is forced because it's empty
     warnings.resetwarnings()
-    assert len(warnings.filters) == 0  # should be empty 
+    assert len(warnings.filters) == 0  # should be empty
     with warnings.catch_warnings(record=True) as result:
         utils.warn_deprecated(msg)
 
     assert len(result) == 1
     assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
     assert result[0].category is DeprecationWarning
-    
+
     # Reset With empty filters - expected behaviour is that there is no warning because it's ignored
     warnings.resetwarnings()
-    assert len(warnings.filters) == 0  # should be empty 
+    assert len(warnings.filters) == 0  # should be empty
     with warnings.catch_warnings(record=True) as result:
         warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"disnake\..*")
         utils.warn_deprecated(msg)
 
     assert len(result) == 0
 
+    warnings.filters[:] = filters  # pyright: ignore[reportIndexIssue]
 
-    warnings.filters[:] = filters # pyright: ignore[reportIndexIssue]
-    
+
 @pytest.mark.parametrize(
     ("params", "expected"),
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,6 +128,46 @@ def test_deprecated_skip() -> None:
 
 
 @pytest.mark.parametrize(
+    "msg",
+    ["This is a deprecated function"],
+)
+def test_deprecated_warn(msg: str) -> None:
+    # Just test if works 
+    # first clear existing filters - these will be restored at the end as this is probably messing with the global warning filters
+    filters = warnings.filters[:]
+    
+    warnings.resetwarnings()
+    with warnings.catch_warnings(record=True) as result:
+        warnings.filterwarnings("always", category=DeprecationWarning, module=r"disnake\..*")  # this also works with just a plain str
+        utils.warn_deprecated(msg)
+
+    assert len(result) == 1
+    assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
+    assert result[0].category is DeprecationWarning
+    
+    # Reset With empty filters - expected behaviour is that a warning is forced because it's empty
+    warnings.resetwarnings()
+    assert len(warnings.filters) == 0  # should be empty 
+    with warnings.catch_warnings(record=True) as result:
+        utils.warn_deprecated(msg)
+
+    assert len(result) == 1
+    assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
+    assert result[0].category is DeprecationWarning
+    
+    # Reset With empty filters - expected behaviour is that there is no warning because it's ignored
+    warnings.resetwarnings()
+    assert len(warnings.filters) == 0  # should be empty 
+    with warnings.catch_warnings(record=True) as result:
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"disnake\..*")
+        utils.warn_deprecated(msg)
+
+    assert len(result) == 0
+
+
+    warnings.filters[:] = filters # pyright: ignore[reportIndexIssue]
+    
+@pytest.mark.parametrize(
     ("params", "expected"),
     [
         (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,16 +138,15 @@ def test_deprecated_warn(msg: str) -> None:
 
     warnings.resetwarnings()
     with warnings.catch_warnings(record=True) as result:
-        warnings.filterwarnings(
-            "always", category=DeprecationWarning, module=r"disnake\..*"
-        )  # this also works with just a plain str
+        warnings.filterwarnings("always", category=DeprecationWarning, module=r"disnake\..*")
         utils.warn_deprecated(msg)
 
     assert len(result) == 1, "Expected one warning to be raised."
     assert result[0].category is DeprecationWarning
     assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
 
-    # Reset With empty filters - expected behaviour is that a warning is forced because it's empty
+    # Reset With empty filters.
+    # Expected behaviour is that a warning is forced because it's empty.
     warnings.resetwarnings()
     with warnings.catch_warnings(record=True) as result:
         utils.warn_deprecated(msg)
@@ -156,7 +155,8 @@ def test_deprecated_warn(msg: str) -> None:
     assert result[0].category is DeprecationWarning
     assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
 
-    # Reset With empty filters - expected behaviour is that there is no warning because it's ignored
+    # Reset With empty filters and add disnake ignore rule.
+    # Expected behaviour is that there is no warning because it's ignored.
     warnings.resetwarnings()
     with warnings.catch_warnings(record=True) as result:
         warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"disnake\..*")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,28 +143,28 @@ def test_deprecated_warn(msg: str) -> None:
         )  # this also works with just a plain str
         utils.warn_deprecated(msg)
 
-    assert len(result) == 1
-    assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
+    assert len(result) == 1, "Expected one warning to be raised."
     assert result[0].category is DeprecationWarning
+    assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
 
     # Reset With empty filters - expected behaviour is that a warning is forced because it's empty
     warnings.resetwarnings()
-    assert len(warnings.filters) == 0  # should be empty
     with warnings.catch_warnings(record=True) as result:
         utils.warn_deprecated(msg)
 
-    assert len(result) == 1
-    assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
+    assert len(result) == 1, "Expected one warning to be raised."
     assert result[0].category is DeprecationWarning
+    assert result[0].message.args[0] == msg  # pyright: ignore[reportAttributeAccessIssue]
 
     # Reset With empty filters - expected behaviour is that there is no warning because it's ignored
     warnings.resetwarnings()
-    assert len(warnings.filters) == 0  # should be empty
     with warnings.catch_warnings(record=True) as result:
         warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"disnake\..*")
         utils.warn_deprecated(msg)
 
-    assert len(result) == 0
+    assert len(result) == 0, (
+        "Expected no warnings to be raised when declaring disnake to be ignored."
+    )
 
     warnings.filters[:] = filters  # pyright: ignore[reportIndexIssue]
 


### PR DESCRIPTION
## Summary

Closes #1475 

warn_deprecated now respect if a user wants to ignore deprecation warnings by checking if the module name has `disnake` in it. 

`test_deprecated_warn` tests have been added.

Expected use will be:

```python
import warnings
warnings.filterwarnings("ignore", category=DeprecationWarning, module = "disnake")
 ```

Using simplefilter or not passing a module value will result in the existing behaviour now which forces through the warning, as such this change will not impact current users unless they use the above example, or similar.

warning filters are generally not that large, so there is expected to be a very negligible impact to performance. 

### Known potential issues with this approach
- This only currently respects `ignore` action value for the warnings. 
- literally any module string which has `disnake` in it will be picked up to be ignored if the action is `ignore`

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
