### PR TITLE
fix(converter): prevent ColourConverter from returning non-Color types like tuples

### DIFF
--- a/changelog/1488.bugfix.rst
+++ b/changelog/1488.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ColourConverter.convert to reject non-Color returns.

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -741,7 +741,6 @@ class ColourConverter(Converter[disnake.Colour]):
 
         if argument[0:2] == "0x":
             rest = argument[2:]
-            # Legacy backwards compatible syntax
             if rest.startswith("#"):
                 return self.parse_hex_number(rest[1:])
             return self.parse_hex_number(rest)
@@ -752,9 +751,17 @@ class ColourConverter(Converter[disnake.Colour]):
 
         arg = arg.replace(" ", "_")
         method = getattr(disnake.Colour, arg, None)
-        if arg.startswith("from_") or method is None or not inspect.ismethod(method):
+
+        if arg.startswith("from_") or method is None or not callable(method):
             raise BadColourArgument(arg)
-        return method()
+
+        result = method()
+
+        if not isinstance(result, disnake.Color):
+            error_msg = f"The colour method '{argument}' returned an invalid type: {type(result).__name__}"
+            raise BadColourArgument(error_msg)
+
+        return result
 
 
 ColorConverter = ColourConverter

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -758,7 +758,9 @@ class ColourConverter(Converter[disnake.Colour]):
         result = method()
 
         if not isinstance(result, disnake.Color):
-            error_msg = f"The colour method '{argument}' returned an invalid type: {type(result).__name__}"
+            error_msg = (
+                f"The colour method '{argument}' returned an invalid type: {type(result).__name__}"
+            )
             raise BadColourArgument(error_msg)
 
         return result


### PR DESCRIPTION
## Summary
Fix #1488 => in `ColourConverter.convert` where certain classmethods (like `holographic_style`) return a tuple of colors instead of a single `disnake.Color` instance. Previously, this caused the converter to return a tuple instead of raising an error. 

This PR adds a type check after invoking the color method and raises `BadColourArgument` if the returned value is not a single `disnake.Color`. 

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)