### PR TITLE
Fix tasks.loop running twice when a specific time is given

### DIFF
--- a/changelog/585.bugfix.rst
+++ b/changelog/585.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``tasks.loop`` running twice when a specific ``time`` is given, caused by a scheduling comparison that did not account for the task waking up at exactly the target time.

--- a/disnake/ext/tasks/__init__.py
+++ b/disnake/ext/tasks/__init__.py
@@ -584,7 +584,7 @@ class Loop(Generic[LF]):
                 )
 
         next_date = self._last_iteration
-        if next_time < next_date.timetz():
+        if next_time <= next_date.timetz():
             next_date += datetime.timedelta(days=1)
 
         self._time_index += 1

--- a/tests/ext/tasks/test_loops.py
+++ b/tests/ext/tasks/test_loops.py
@@ -71,3 +71,24 @@ class TestLoops:
 
         @loop(lambda lf: Loop(lf))
         async def task() -> None: ...
+
+    def test_get_next_sleep_time_advances_day(self) -> None:
+        """When _last_iteration has the same time as the scheduled time,
+        _get_next_sleep_time should schedule for the next day, not the same day.
+        Regression test for https://github.com/DisnakeDev/disnake/issues/585
+        """
+        target = datetime.time(0, 0, tzinfo=datetime.timezone.utc)
+
+        async def callback() -> None:
+            pass
+
+        lp = Loop(callback, time=target)
+        lp._current_loop = 1
+        lp._time_index = 0
+        lp._last_iteration = datetime.datetime(
+            2026, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        result = lp._get_next_sleep_time()
+        expected = datetime.datetime(2026, 1, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        assert result == expected, f"Expected {expected}, got {result}"


### PR DESCRIPTION
## Summary

Fixes #585

`tasks.loop(time=...)` can fire twice because `_get_next_sleep_time` doesn't advance to the next day when `_last_iteration` has the exact same time as the scheduled target. This happens because `asyncio.sleep` doesn't guarantee waking up *after* the requested duration — it can return slightly early, which means `_last_iteration` ends up set to the exact target time. The `<` comparison then fails to add a day, scheduling the next run for a time that's already in the past.

The fix changes `<` to `<=` on [this line](https://github.com/DisnakeDev/disnake/blob/d76c09fca5d50d3fbf1522890f668a6ed8812c21/disnake/ext/tasks/__init__.py#L587) so that when `next_time == next_date.timetz()`, a day is still added. This is safe for multi-time schedules since the time index has already advanced past the current time slot.

Also added a regression test and a changelog fragment.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)