### PR TITLE
feat(errors): add voice close event code `4017`

### DIFF
--- a/disnake/errors.py
+++ b/disnake/errors.py
@@ -251,6 +251,7 @@ class ConnectionClosed(ClientException):
         4014: "Disconnected (you were kicked, the main gateway session was dropped, etc.)",
         4015: "Voice server crashed",
         4016: "Unknown encryption mode",
+        4017: "E2EE/DAVE protocol required",
         4020: "Bad request - you sent a malformed request",
         4021: "Disconnected: Rate Limited",
         4022: "Disconnected: Call Terminated (channel deleted, voice server changed, etc.)",


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Added close code `4017` (E2EE/DAVE protocol required)

References:
- https://github.com/discord/discord-api-docs/commit/eebfe6dc09bf1c0228bc0206310cf212a7cff71f
- https://github.com/discord/discord-api-docs/pull/8167
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
