### PR TITLE
fix(voice): handle additional ws close codes, raise early if dependency missing

### DIFF
--- a/changelog/1513.bugfix.0.rst
+++ b/changelog/1513.bugfix.0.rst
@@ -1,0 +1,1 @@
+Handle voice websocket close codes 4017, 4021, and 4022 properly.

--- a/changelog/1513.bugfix.1.rst
+++ b/changelog/1513.bugfix.1.rst
@@ -1,0 +1,1 @@
+Raise early error if required dependencies for voice connections are not installed.

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -446,9 +446,20 @@ class Client:
         self._connection._get_websocket = self._get_websocket
         self._connection._get_client = lambda: self
 
-        if VoiceClient.warn_nacl:
-            VoiceClient.warn_nacl = False
-            _log.warning("PyNaCl is not installed, voice will NOT be supported")
+        if VoiceClient.warn_nacl or VoiceClient.warn_dave:
+            missing: list[str] = []
+            if VoiceClient.warn_nacl:
+                missing.append("PyNaCl")
+            if VoiceClient.warn_dave:
+                missing.append("dave.py")
+
+            _log.warning(
+                "%s %s not installed, voice will NOT be supported",
+                " and ".join(missing),
+                "are" if len(missing) > 1 else "is",
+            )
+
+            VoiceClient.warn_nacl = VoiceClient.warn_dave = False
 
         if strict_localization and localization_provider is not None:
             msg = (

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -217,6 +217,9 @@ class VoiceClient(VoiceProtocol):
         if not has_nacl:
             msg = "PyNaCl library needed in order to use voice"
             raise RuntimeError(msg)
+        if not has_dave:
+            msg = "dave.py library needed in order to use voice"
+            raise RuntimeError(msg)
 
         super().__init__(client, channel)
         state = client._connection

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -444,13 +444,23 @@ class VoiceClient(VoiceProtocol):
 
                 if isinstance(exc, ConnectionClosed):
                     # 1000 - normal closure (obviously)
-                    # 4014 - voice channel has been deleted.
+                    # 4014 - potentially kicked or moved from voice channel
                     # 4015 - voice server has crashed
+                    # 4017 - E2EE required (should be caught earlier and usually not happen in the first place)
+                    # 4021 - rate limited
+                    # 4022 - similar to 4014 (only happens when bot is the only remaining user in voice channel)
                     if exc.code == 1000:
                         _log.info("Disconnecting from voice normally, close code %d.", exc.code)
                         await self.disconnect()
                         break
-                    if exc.code == 4014:
+
+                    if exc.code in (4017, 4021):
+                        _log.info(
+                            "Disconnected from voice with close code %d, not reconnecting", exc.code
+                        )
+                        break
+
+                    if exc.code in (4014, 4022):
                         _log.info("Disconnected from voice by force... potentially reconnecting.")
                         successful = await self.potential_reconnect()
                         if not successful:
@@ -460,6 +470,7 @@ class VoiceClient(VoiceProtocol):
                             await self.disconnect()
                             break
                         continue
+
                     # only attempt to resume if the session is valid/established
                     if exc.code == 4015 and self.ws._ready.is_set():
                         _log.info("Disconnected from voice, trying to resume session...")

--- a/disnake/voice_client.py
+++ b/disnake/voice_client.py
@@ -23,7 +23,7 @@ import socket
 import struct
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from . import opus, utils
 from .backoff import ExponentialBackoff
@@ -55,6 +55,8 @@ except ImportError:
 
 if TYPE_CHECKING:
     import dave
+
+    has_dave = cast("bool", ...)  # prevent pyright from trying to be smart
 else:
     try:
         import dave
@@ -243,6 +245,7 @@ class VoiceClient(VoiceProtocol):
         self.dave: DaveState | None = DaveState(self) if has_dave else None
 
     warn_nacl = not has_nacl
+    warn_dave = not has_dave
     supported_modes: tuple[SupportedModes, ...] = ("aead_xchacha20_poly1305_rtpsize",)
 
     @property


### PR DESCRIPTION
## Summary

This adds handling for some additional voice close codes:
- 4017 - e2ee required, not reconnecting
- 4021 - rate limited, not reconnecting
- 4022 - basically the same as 4014, where we wait for a potential reconnect from being moved between channels

Additionally, adds some extra warnings/errors related to E2EE/DAVE now being *required* and no longer just optional. Realistically this should also mean that 4017 will never happen, since we won't attempt to connect without DAVE support in the first place.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
