### PR TITLE
feat(types): add missing guild features to `GuildFeature` literal type

### DIFF
--- a/changelog/1515.feature.rst
+++ b/changelog/1515.feature.rst
@@ -1,0 +1,1 @@
+Add missing guild features to ``GuildFeature`` literal type

--- a/changelog/1515.feature.rst
+++ b/changelog/1515.feature.rst
@@ -1,1 +1,1 @@
-Add missing guild features to ``GuildFeature`` literal type
+Add missing guild features to ``GuildFeature`` literal type.

--- a/disnake/types/guild.py
+++ b/disnake/types/guild.py
@@ -43,6 +43,7 @@ PremiumTier = Literal[0, 1, 2, 3]
 GuildFeature = Literal[
     "ANIMATED_BANNER",
     "ANIMATED_ICON",
+    "APPLICATION_COMMAND_PERMISSIONS_V2",
     "AUTO_MODERATION",
     "BANNER",
     "COMMUNITY",
@@ -84,6 +85,9 @@ GuildFeature = Literal[
     "VERIFIED",
     "VIP_REGIONS",
     "WELCOME_SCREEN_ENABLED",
+    "GUESTS_ENABLED",
+    "GUILD_TAGS",
+    "ENHANCED_ROLE_COLORS",
 ]
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Adds four missing guild features to the `GuildFeature` literal type.
- `APPLICATION_COMMAND_PERMISSIONS_V2`
- `GUESTS_ENABLED` 
- `GUILD_TAGS`
- `ENHANCED_ROLE_COLORS`

Reference: https://docs.discord.com/developers/resources/guild#guild-object-guild-features
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
