### PR TITLE
fix(converter): restrict ColourConverter to valid factory methods

### DIFF
--- a/changelog/1488.bugfix.rst
+++ b/changelog/1488.bugfix.rst
@@ -1,1 +1,1 @@
-Fix ``ColourConverter`` accepting non-factory classmethods like ``holographic_style``, which returns a tuple instead of a single :class:`Colour`.
+Fix :class:`~disnake.ext.commands.ColourConverter` accepting ``classmethod`` names that do not return :class:`Colour`, for example ``holographic_style``.

--- a/changelog/1488.bugfix.rst
+++ b/changelog/1488.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``ColourConverter`` accepting non-factory classmethods like ``holographic_style``, which returns a tuple instead of a single :class:`Colour`.

--- a/disnake/colour.py
+++ b/disnake/colour.py
@@ -328,6 +328,9 @@ class Colour:
         """
         return cls(0x2B2D31)
 
+    # NOTE: when adding new factory methods, also update _COLOUR_FACTORY_NAMES
+    # in disnake/ext/commands/converter.py
+
     @classmethod
     def holographic_style(cls) -> tuple[Self, Self, Self]:
         """A factory method that returns a tuple of :class:`Colour` with values of

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -669,6 +669,51 @@ class ThreadConverter(IDConverter[disnake.Thread]):
         return GuildChannelConverter._resolve_thread(ctx, argument, "threads", disnake.Thread)
 
 
+# valid colour factory method names accepted by ColourConverter, used to
+# prevent non-factory classmethods (like holographic_style) from being invoked
+_COLOUR_FACTORY_NAMES: frozenset[str] = frozenset(
+    {
+        "default",
+        "random",
+        "teal",
+        "dark_teal",
+        "brand_green",
+        "green",
+        "dark_green",
+        "blue",
+        "dark_blue",
+        "purple",
+        "dark_purple",
+        "magenta",
+        "dark_magenta",
+        "gold",
+        "dark_gold",
+        "orange",
+        "dark_orange",
+        "brand_red",
+        "red",
+        "dark_red",
+        "lighter_grey",
+        "lighter_gray",
+        "dark_grey",
+        "dark_gray",
+        "light_grey",
+        "light_gray",
+        "darker_grey",
+        "darker_gray",
+        "og_blurple",
+        "old_blurple",
+        "blurple",
+        "greyple",
+        "dark_theme",
+        "fuchsia",
+        "yellow",
+        "light_embed",
+        "dark_embed",
+    }
+)
+
+
 class ColourConverter(Converter[disnake.Colour]):
     """Converts to a :class:`~disnake.Colour`.
 
@@ -748,10 +793,9 @@ class ColourConverter(Converter[disnake.Colour]):
             return self.parse_rgb(arg)
 
         arg = arg.replace(" ", "_")
-        method = getattr(disnake.Colour, arg, None)
-        if arg.startswith("from_") or method is None or not inspect.ismethod(method):
+        if arg not in _COLOUR_FACTORY_NAMES:
             raise BadColourArgument(arg)
-        return method()
+        return getattr(disnake.Colour, arg)()
 
 
 ColorConverter = ColourConverter

--- a/disnake/ext/commands/converter.py
+++ b/disnake/ext/commands/converter.py
@@ -669,8 +669,7 @@ class ThreadConverter(IDConverter[disnake.Thread]):
         return GuildChannelConverter._resolve_thread(ctx, argument, "threads", disnake.Thread)
 
 
-# valid colour factory method names accepted by ColourConverter, used to
-# prevent non-factory classmethods (like holographic_style) from being invoked
+# set of Colour.xyz() method names supported by ColourConverter
 _COLOUR_FACTORY_NAMES: frozenset[str] = frozenset(
     {
         "default",

--- a/tests/ext/commands/test_converter.py
+++ b/tests/ext/commands/test_converter.py
@@ -9,12 +9,12 @@ from disnake.ext.commands import BadColourArgument
 from disnake.ext.commands.converter import ColourConverter
 
 
-@pytest.fixture()
+@pytest.fixture
 def converter() -> ColourConverter:
     return ColourConverter()
 
 
-@pytest.fixture()
+@pytest.fixture
 def ctx() -> mock.Mock:
     return mock.Mock()
 

--- a/tests/ext/commands/test_converter.py
+++ b/tests/ext/commands/test_converter.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+
+from unittest import mock
+
+import pytest
+
+import disnake
+from disnake.ext.commands import BadColourArgument
+from disnake.ext.commands.converter import ColourConverter
+
+
+@pytest.fixture()
+def converter() -> ColourConverter:
+    return ColourConverter()
+
+
+@pytest.fixture()
+def ctx() -> mock.Mock:
+    return mock.Mock()
+
+
+class TestColourConverter:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("arg", "expected_value"),
+        [
+            ("red", 0xE74C3C),
+            ("dark_green", 0x1F8B4C),
+            ("blurple", 0x5865F2),
+            ("dark theme", 0x313338),
+            ("og blurple", 0x7289DA),
+        ],
+    )
+    async def test_valid_colour_names(
+        self, converter: ColourConverter, ctx: mock.Mock, arg: str, expected_value: int
+    ) -> None:
+        result = await converter.convert(ctx, arg)
+        assert isinstance(result, disnake.Colour)
+        assert result.value == expected_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "arg",
+        [
+            "holographic_style",
+            "holographic style",
+            "from_rgb",
+            "from_hsv",
+            "from_hex",
+            "to_rgb",
+            "value",
+            "__init__",
+            "nonexistent",
+        ],
+    )
+    async def test_invalid_colour_names(
+        self, converter: ColourConverter, ctx: mock.Mock, arg: str
+    ) -> None:
+        with pytest.raises(BadColourArgument):
+            await converter.convert(ctx, arg)
+
+    @pytest.mark.asyncio
+    async def test_hex_format(self, converter: ColourConverter, ctx: mock.Mock) -> None:
+        result = await converter.convert(ctx, "#ff0000")
+        assert result.value == 0xFF0000
+
+    @pytest.mark.asyncio
+    async def test_rgb_format(self, converter: ColourConverter, ctx: mock.Mock) -> None:
+        result = await converter.convert(ctx, "rgb(255, 0, 0)")
+        assert result.value == 0xFF0000


### PR DESCRIPTION
## Summary

Fixes #1488
Supersedes #1491

`ColourConverter` currently uses `getattr` + `inspect.ismethod` to resolve colour names, which means any classmethod on `Colour` can be invoked - including `holographic_style`, which returns a tuple of three colours instead of a single `Colour`. This causes the converter to silently return the wrong type.

This replaces the dynamic lookup with an explicit frozenset of valid colour factory names. As @Enegg suggested in #1491, this is the proper approach since it prevents the converter from ever invoking methods it shouldn't (non-factory classmethods, or future methods with side effects), rather than checking the return type after the fact.

Also added tests for the converter covering valid names, invalid/dangerous names (including `holographic_style`, `from_rgb`, `__init__` etc.), and the hex/rgb input formats.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)