### PR TITLE
feat(application): use `flags_new` field

### DIFF
--- a/changelog/1519.misc.rst
+++ b/changelog/1519.misc.rst
@@ -1,0 +1,1 @@
+Support :class:`ApplicationFlags` beyond bit 30 by using ``flags_new``.

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -352,7 +352,7 @@ class AppInfo:
         self.terms_of_service_url: str | None = data.get("terms_of_service_url")
         self.privacy_policy_url: str | None = data.get("privacy_policy_url")
 
-        flags: int | None = data.get("flags")
+        flags: int | None = utils._get_as_snowflake(data, "flags_new")
         self.flags: ApplicationFlags | None = (
             ApplicationFlags._from_value(flags) if flags is not None else None
         )

--- a/disnake/state.py
+++ b/disnake/state.py
@@ -768,7 +768,7 @@ class ConnectionState:
         else:
             if self.application_id is None:
                 self.application_id = utils._get_as_snowflake(application, "id")
-            self.application_flags = ApplicationFlags._from_value(application["flags"])
+            self.application_flags = ApplicationFlags._from_value(int(application["flags_new"]))
 
         for guild_data in data["guilds"]:
             self._add_guild_from_data(guild_data)
@@ -2580,7 +2580,7 @@ class AutoShardedConnectionState(ConnectionState):
         else:
             if self.application_id is None:
                 self.application_id = utils._get_as_snowflake(application, "id")
-            self.application_flags = ApplicationFlags._from_value(application["flags"])
+            self.application_flags = ApplicationFlags._from_value(int(application["flags_new"]))
 
         for guild_data in data["guilds"]:
             self._add_guild_from_data(guild_data)

--- a/disnake/types/appinfo.py
+++ b/disnake/types/appinfo.py
@@ -45,6 +45,7 @@ class AppInfo(BaseAppInfo):
     owner: User
     team: NotRequired[Team]
     flags: NotRequired[int]
+    flags_new: NotRequired[str]  # like `flags`, but also contains flags beyond bit 30
     guild_id: NotRequired[Snowflake]
     primary_sku_id: NotRequired[Snowflake]
     slug: NotRequired[str]
@@ -68,12 +69,14 @@ class PartialAppInfo(BaseAppInfo, total=False):
     rpc_origins: list[str]
     cover_image: str
     flags: int
+    flags_new: str  # like `flags`, but also contains flags beyond bit 30
 
 
 # see https://docs.discord.com/developers/events/gateway-events#ready-ready-event-fields
 class PartialGatewayAppInfo(TypedDict):
     id: Snowflake
     flags: int
+    flags_new: str  # like `flags`, but also contains flags beyond bit 30
 
 
 class EditAppInfo(TypedDict, total=False):


### PR DESCRIPTION
## Summary

https://github.com/discord/discord-api-docs/commit/8f416b65918d83ff8d00adcedd8cc353bed7def5, https://github.com/discord/discord-api-docs/commit/2b56a64ffb5cd103bcf280fe67de1033f2691780

We haven't implemented any flags above bit 30, so this doesn't really have an immediate effect, but might as well do it for future-proofing.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
