### PR TITLE
build(deps): update pytest dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ typing = [
     # all type-check only dependencies are defined in noxfile.py.
 ]
 test = [
-    "pytest~=8.4.2",
+    "pytest~=9.0.3",
     "pytest-cov~=7.0",
     "pytest-asyncio~=0.24.0",
     "looptime~=0.2.0",
@@ -425,11 +425,11 @@ reportUnknownVariableType = false
 reportMissingTypeArgument = false
 
 
-[tool.pytest.ini_options]
-minversion = "8.2"
-pythonpath = "." # legacy configuration, new pytest versions don't add the rootdir to path
-testpaths = "tests"
-addopts = "--strict-markers -Werror -s"
+[tool.pytest]
+minversion = "9.0"
+pythonpath = ["."]  # legacy configuration, new pytest versions don't add the rootdir to path
+testpaths = ["tests"]
+addopts = ["--strict-markers", "-Werror", "-s"]
 xfail_strict = true
 asyncio_mode = "strict"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -430,7 +430,8 @@ minversion = "9.0"
 pythonpath = ["."]  # legacy configuration, new pytest versions don't add the rootdir to path
 testpaths = ["tests"]
 addopts = ["--strict-markers", "-Werror", "-s"]
-xfail_strict = true
+strict = true
+strict_parametrization_ids = false
 asyncio_mode = "strict"
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,9 @@ typing = [
 test = [
     "pytest~=9.0.3",
     "pytest-cov~=7.0",
-    "pytest-asyncio~=0.24.0",
-    "looptime~=0.2.0",
-    "coverage[toml]~=7.10.0",
+    "pytest-asyncio~=1.3.0",
+    "looptime~=0.7.0",
+    "coverage[toml]~=7.14",
 ]
 build = [
     "build>=1.2.2.post1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -429,7 +429,12 @@ reportMissingTypeArgument = false
 minversion = "9.0"
 pythonpath = ["."]  # legacy configuration, new pytest versions don't add the rootdir to path
 testpaths = ["tests"]
-addopts = ["--strict-markers", "-Werror", "-s"]
+addopts = [
+    "--strict-markers",
+    "-s",
+    "-Werror",
+    "-Wignore:There is no current event loop:DeprecationWarning:looptime._internal.plugin",
+]
 strict = true
 strict_parametrization_ids = false
 asyncio_mode = "strict"


### PR DESCRIPTION
## Summary

Updates all pytest-related dependencies to their current latest versions, which also fixes a couple deprecation warnings that started appearing in 3.14 (which are currently being silenced in CI).

looptime still struggles a bit with pytest-asyncio's `event_loop_policy` fixture; it's at least at a point now where it no longer raises an error on 3.14. The deprecation warnings on earlier versions are silenced, there isn't really a way to avoid them until looptime handles this correctly.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
