### PR TITLE
refactor(bot)!: remove deprecated `sync_commands*` parameters

### DIFF
--- a/changelog/1528.breaking.rst
+++ b/changelog/1528.breaking.rst
@@ -1,0 +1,1 @@
+|commands| Remove deprecated ``sync_commands``, ``sync_commands_debug``, and ``sync_commands_on_cog_unload`` parameters from :class:`~ext.commands.Bot`. Use :attr:`Bot.command_sync_flags <ext.commands.Bot.command_sync_flags>` instead.

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -74,39 +74,6 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
 
         .. versionadded:: 2.7
 
-    sync_commands: :class:`bool`
-        Whether to enable automatic synchronization of application commands in your code.
-        Defaults to ``True``, which means that commands in API are automatically synced
-        with the commands in your code.
-
-        .. versionadded:: 2.1
-
-        .. deprecated:: 2.7
-            Replaced with ``command_sync_flags``.
-
-    sync_commands_on_cog_unload: :class:`bool`
-        Whether to sync the application commands on cog unload / reload. Defaults to ``True``.
-
-        .. versionadded:: 2.1
-
-        .. deprecated:: 2.7
-            Replaced with ``command_sync_flags``.
-
-    sync_commands_debug: :class:`bool`
-        Whether to always show sync debug logs (uses ``INFO`` log level if it's enabled, prints otherwise).
-        If disabled, uses the default ``DEBUG`` log level which isn't shown unless the log level is changed manually.
-        Useful for tracking the commands being registered in the API.
-        Defaults to ``False``.
-
-        .. versionadded:: 2.1
-
-        .. versionchanged:: 2.4
-            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO`` or ``print``\s them,
-            instead of controlling whether they are enabled at all.
-
-        .. deprecated:: 2.7
-            Replaced with ``command_sync_flags``.
-
     localization_provider: :class:`.LocalizationProtocol`
         An implementation of :class:`.LocalizationProtocol` to use for localization of
         application commands.
@@ -261,9 +228,6 @@ class Bot(BotBase, InteractionBotBase, disnake.Client):
             reload: bool = False,
             case_insensitive: bool = False,
             command_sync_flags: CommandSyncFlags = ...,
-            sync_commands: bool = ...,
-            sync_commands_debug: bool = ...,
-            sync_commands_on_cog_unload: bool = ...,
             test_guilds: Sequence[int] | None = None,
             default_install_types: ApplicationInstallTypes | None = None,
             default_contexts: InteractionContextTypes | None = None,
@@ -314,9 +278,6 @@ class AutoShardedBot(BotBase, InteractionBotBase, disnake.AutoShardedClient):
             reload: bool = False,
             case_insensitive: bool = False,
             command_sync_flags: CommandSyncFlags = ...,
-            sync_commands: bool = ...,
-            sync_commands_debug: bool = ...,
-            sync_commands_on_cog_unload: bool = ...,
             test_guilds: Sequence[int] | None = None,
             default_install_types: ApplicationInstallTypes | None = None,
             default_contexts: InteractionContextTypes | None = None,
@@ -371,39 +332,6 @@ class InteractionBot(InteractionBotBase, disnake.Client):
         If not given, defaults to :func:`CommandSyncFlags.default`.
 
         .. versionadded:: 2.7
-
-    sync_commands: :class:`bool`
-        Whether to enable automatic synchronization of application commands in your code.
-        Defaults to ``True``, which means that commands in API are automatically synced
-        with the commands in your code.
-
-        .. versionadded:: 2.1
-
-        .. deprecated:: 2.7
-            Replaced with ``command_sync_flags``.
-
-    sync_commands_on_cog_unload: :class:`bool`
-        Whether to sync the application commands on cog unload / reload. Defaults to ``True``.
-
-        .. versionadded:: 2.1
-
-        .. deprecated:: 2.7
-            Replaced with ``command_sync_flags``.
-
-    sync_commands_debug: :class:`bool`
-        Whether to always show sync debug logs (uses ``INFO`` log level if it's enabled, prints otherwise).
-        If disabled, uses the default ``DEBUG`` log level which isn't shown unless the log level is changed manually.
-        Useful for tracking the commands being registered in the API.
-        Defaults to ``False``.
-
-        .. versionadded:: 2.1
-
-        .. versionchanged:: 2.4
-            Changes the log level of corresponding messages from ``DEBUG`` to ``INFO`` or ``print``\s them,
-            instead of controlling whether they are enabled at all.
-
-        .. deprecated:: 2.7
-            Replaced with ``command_sync_flags``.
 
     localization_provider: :class:`.LocalizationProtocol`
         An implementation of :class:`.LocalizationProtocol` to use for localization of
@@ -486,9 +414,6 @@ class InteractionBot(InteractionBotBase, disnake.Client):
             owner_ids: set[int] | None = None,
             reload: bool = False,
             command_sync_flags: CommandSyncFlags = ...,
-            sync_commands: bool = ...,
-            sync_commands_debug: bool = ...,
-            sync_commands_on_cog_unload: bool = ...,
             test_guilds: Sequence[int] | None = None,
             default_install_types: ApplicationInstallTypes | None = None,
             default_contexts: InteractionContextTypes | None = None,
@@ -532,9 +457,6 @@ class AutoShardedInteractionBot(InteractionBotBase, disnake.AutoShardedClient):
             owner_ids: set[int] | None = None,
             reload: bool = False,
             command_sync_flags: CommandSyncFlags = ...,
-            sync_commands: bool = ...,
-            sync_commands_debug: bool = ...,
-            sync_commands_on_cog_unload: bool = ...,
             test_guilds: Sequence[int] | None = None,
             default_install_types: ApplicationInstallTypes | None = None,
             default_contexts: InteractionContextTypes | None = None,

--- a/disnake/ext/commands/interaction_bot_base.py
+++ b/disnake/ext/commands/interaction_bot_base.py
@@ -21,7 +21,7 @@ from disnake.app_commands import ApplicationCommand, Option
 from disnake.custom_warnings import SyncWarning
 from disnake.enums import ApplicationCommandType
 from disnake.flags import ApplicationInstallTypes, InteractionContextTypes
-from disnake.utils import iscoroutinefunction, warn_deprecated
+from disnake.utils import iscoroutinefunction
 
 from . import errors
 from .base_core import InvokableApplicationCommand
@@ -137,9 +137,6 @@ class InteractionBotBase(CommonBotBase):
         self,
         *,
         command_sync_flags: CommandSyncFlags | None = None,
-        sync_commands: bool = MISSING,
-        sync_commands_debug: bool = MISSING,
-        sync_commands_on_cog_unload: bool = MISSING,
         test_guilds: Sequence[int] | None = None,
         default_install_types: ApplicationInstallTypes | None = None,
         default_contexts: InteractionContextTypes | None = None,
@@ -154,42 +151,11 @@ class InteractionBotBase(CommonBotBase):
         test_guilds = None if test_guilds is None else tuple(test_guilds)
         self._test_guilds: tuple[int, ...] | None = test_guilds
 
-        if command_sync_flags is not None and (
-            sync_commands is not MISSING
-            or sync_commands_debug is not MISSING
-            or sync_commands_on_cog_unload is not MISSING
-        ):
-            msg = "cannot set 'command_sync_flags' and any of 'sync_commands', 'sync_commands_debug', 'sync_commands_on_cog_unload' at the same time."
-            raise TypeError(msg)
-
         if command_sync_flags is not None:
             # this makes a copy so it cannot be changed after setting
             command_sync_flags = CommandSyncFlags._from_value(command_sync_flags.value)
-        if command_sync_flags is None:
+        else:
             command_sync_flags = CommandSyncFlags.default()
-
-            if sync_commands is not MISSING:
-                warn_deprecated(
-                    "sync_commands is deprecated and will be removed in a future version. "
-                    "Use `command_sync_flags` with an `CommandSyncFlags` instance as a replacement.",
-                    stacklevel=3,
-                )
-                command_sync_flags.sync_commands = sync_commands
-            if sync_commands_debug is not MISSING:
-                warn_deprecated(
-                    "sync_commands_debug is deprecated and will be removed in a future version. "
-                    "Use `command_sync_flags` with an `CommandSyncFlags` instance as a replacement.",
-                    stacklevel=3,
-                )
-                command_sync_flags.sync_commands_debug = sync_commands_debug
-
-            if sync_commands_on_cog_unload is not MISSING:
-                warn_deprecated(
-                    "sync_commands_on_cog_unload is deprecated and will be removed in a future version. "
-                    "Use `command_sync_flags` with an `CommandSyncFlags` instance as a replacement.",
-                    stacklevel=3,
-                )
-                command_sync_flags.sync_on_cog_actions = sync_commands_on_cog_unload
 
         self._command_sync_flags = command_sync_flags
         self._sync_queued: asyncio.Lock = asyncio.Lock()


### PR DESCRIPTION
## Summary

These were deprecated back in v2.7, around 3.5 years ago. It's about time~~

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
