### PR TITLE
ci: avoid syncing venv in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -15,6 +15,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # https://docs.astral.sh/uv/reference/environment/
+  UV_LOCKED: 1
+  UV_NO_SYNC: 1
+  UV_PYTHON_DOWNLOADS: never
+
 jobs:
   check-changelog-entry:
     name: Check for changelog entry


### PR DESCRIPTION
## Summary

`uv run` syncs by default, which installs all dependencies, including the `docs` group which requires 3.11, even though it's not required to run towncrier.
Since CI (correctly) defaults to 3.10 (well, kind of. it's complicated), the changelog workflow breaks. `UV_NO_SYNC` fixes this, matching other workflows.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
