### PR TITLE
refactor(appinfo)!: remove deprecated `summary` fields

### DIFF
--- a/changelog/1531.breaking.rst
+++ b/changelog/1531.breaking.rst
@@ -1,0 +1,1 @@
+Remove deprecated ``AppInfo.summary``, ``PartialAppInfo.summary`` and ``IntegrationApplication.summary`` fields. Use ``.description`` instead.

--- a/disnake/appinfo.py
+++ b/disnake/appinfo.py
@@ -300,7 +300,6 @@ class AppInfo:
         "bot_require_code_grant",
         "owner",
         "_icon",
-        "_summary",
         "verify_key",
         "team",
         "guild_id",
@@ -341,7 +340,6 @@ class AppInfo:
         team: TeamPayload | None = data.get("team")
         self.team: Team | None = Team(state, team) if team else None
 
-        self._summary: str = data.get("summary", "")
         self.verify_key: str = data["verify_key"]
 
         self.guild_id: int | None = utils._get_as_snowflake(data, "guild_id")
@@ -419,23 +417,6 @@ class AppInfo:
         .. versionadded:: 1.3
         """
         return self._state._get_guild(self.guild_id)
-
-    @property
-    def summary(self) -> str:
-        """:class:`str`: If this application is a game sold on Discord,
-        this field will be the summary field for the store page of its primary SKU.
-
-        .. versionadded:: 1.3
-
-        .. deprecated:: 2.5
-
-            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
-        """
-        utils.warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Consider using description instead.",
-            stacklevel=2,
-        )
-        return self._summary
 
     @property
     def guild_install_type_config(self) -> InstallTypeConfiguration | None:
@@ -673,7 +654,6 @@ class PartialAppInfo:
         "name",
         "description",
         "rpc_origins",
-        "_summary",
         "verify_key",
         "terms_of_service_url",
         "privacy_policy_url",
@@ -687,7 +667,6 @@ class PartialAppInfo:
         self._icon: str | None = data.get("icon")
         self.description: str = data["description"]
         self.rpc_origins: list[str] | None = data.get("rpc_origins")
-        self._summary: str = data.get("summary", "")
         self.verify_key: str = data["verify_key"]
         self.terms_of_service_url: str | None = data.get("terms_of_service_url")
         self.privacy_policy_url: str | None = data.get("privacy_policy_url")
@@ -701,18 +680,3 @@ class PartialAppInfo:
         if self._icon is None:
             return None
         return Asset._from_icon(self._state, self.id, self._icon, path="app")
-
-    @property
-    def summary(self) -> str:
-        """:class:`str`: If this application is a game sold on Discord,
-        this field will be the summary field for the store page of its primary SKU.
-
-        .. deprecated:: 2.5
-
-            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
-        """
-        utils.warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Consider using description instead.",
-            stacklevel=2,
-        )
-        return self._summary

--- a/disnake/integrations.py
+++ b/disnake/integrations.py
@@ -13,7 +13,6 @@ from .utils import (
     deprecated,
     parse_time,
     snowflake_time,
-    warn_deprecated,
 )
 
 __all__ = (
@@ -352,7 +351,6 @@ class IntegrationApplication:
         "name",
         "icon",
         "description",
-        "_summary",
         "user",
     )
 
@@ -361,23 +359,8 @@ class IntegrationApplication:
         self.name: str = data["name"]
         self.icon: str | None = data["icon"]
         self.description: str = data["description"]
-        self._summary: str = data.get("summary", "")
         user = data.get("bot")
         self.user: User | None = User(state=state, data=user) if user else None
-
-    @property
-    def summary(self) -> str:
-        """:class:`str`: The application's summary. Can be an empty string.
-
-        .. deprecated:: 2.5
-
-            This field is deprecated by discord and is now always blank. Consider using :attr:`.description` instead.
-        """
-        warn_deprecated(
-            "summary is deprecated and will be removed in a future version. Consider using description instead.",
-            stacklevel=2,
-        )
-        return self._summary
 
 
 class BotIntegration(Integration):

--- a/disnake/types/appinfo.py
+++ b/disnake/types/appinfo.py
@@ -22,7 +22,6 @@ class BaseAppInfo(TypedDict):
     description: str
     terms_of_service_url: NotRequired[str]
     privacy_policy_url: NotRequired[str]
-    summary: str
     verify_key: str
     hook: NotRequired[bool]
     max_participants: NotRequired[int]

--- a/disnake/types/integration.py
+++ b/disnake/types/integration.py
@@ -15,7 +15,6 @@ class IntegrationApplication(TypedDict):
     name: str
     icon: str | None
     description: str
-    summary: str
     bot: NotRequired[User]
 
 


### PR DESCRIPTION
## Summary

These fields were deprecated a few versions ago, the Discord API has always been returning empty strings since.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
