### PR TITLE
feat(components): add `send_v2`, `edit_v2` convenience methods

### DIFF
--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1820,6 +1820,112 @@ class Messageable:
             await ret.delete(delay=delete_after)
         return ret
 
+    async def send_v2(
+        self,
+        components: MessageComponents,
+        *,
+        files: File | Sequence[File] = (),
+        nonce: str | int | None = None,
+        flags: MessageFlags = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+        reference: Message | MessageReference | PartialMessage = MISSING,
+    ) -> Message:
+        R"""|coro|
+
+        Sends a message to the destination with the given components v2.
+
+        .. note::
+            This method unconditionally sets the :attr:`~MessageFlags.is_components_v2` flag.
+            If you want to use components v1, use :meth:`send` instead.
+
+        Parameters
+        ----------
+        components: |components_type|
+            A list of components to include in the message.
+        files: :class:`File` | :class:`list`\[:class:`File`]
+            A file or a list of files to upload. Must be a maximum of 10.
+        nonce: :class:`str` | :class:`int`
+            The nonce to use for sending this message. If the message was successfully sent,
+            then the message will have a nonce with this value.
+        flags: :class:`.MessageFlags`
+            The flags to set for this message.
+            Only :attr:`~.MessageFlags.suppress_embeds`, :attr:`~.MessageFlags.suppress_notifications`,
+            and :attr:`~.MessageFlags.is_components_v2` are supported.
+        allowed_mentions: :class:`.AllowedMentions`
+            Controls the mentions being processed in this message. If this is
+            passed, then the object is merged with :attr:`.Client.allowed_mentions`.
+            The merging behaviour only overrides attributes that have been explicitly passed
+            to the object, otherwise it uses the attributes set in :attr:`.Client.allowed_mentions`.
+            If no object is passed at all then the defaults given by :attr:`.Client.allowed_mentions`
+            are used instead.
+        reference: :class:`.Message` | :class:`.MessageReference` | :class:`.PartialMessage`
+            A reference to the :class:`.Message` to which you are replying, this can be created using
+            :meth:`.Message.to_reference` or passed directly as a :class:`.Message`. You can control
+            whether this mentions the author of the referenced message using the :attr:`.AllowedMentions.replied_user`
+            attribute of ``allowed_mentions``.
+
+        Returns
+        -------
+        :class:`.Message`
+            The message that was sent.
+        """
+        channel = await self._get_channel()
+        state = self._state
+
+        from .ui.action_row import normalize_components_to_dict
+
+        components_payload, _ = normalize_components_to_dict(components)
+
+        if isinstance(files, File):
+            files_ = [files]
+        elif len(files) > 10:
+            msg = "files cannot exceed maximum of 10 elements"
+            raise ValueError(msg)
+        else:
+            files_ = list(files) if files else None
+
+        if allowed_mentions is MISSING:
+            if state.allowed_mentions is not None:
+                allowed_mentions_payload = state.allowed_mentions.to_dict()
+            else:
+                allowed_mentions_payload = None
+        elif state.allowed_mentions is not None:
+            allowed_mentions_payload = state.allowed_mentions.merge(allowed_mentions).to_dict()
+        else:
+            allowed_mentions_payload = allowed_mentions.to_dict()
+
+        reference_payload = None if reference is MISSING else reference.to_message_reference_dict()
+
+        flags = MessageFlags._from_value(0 if flags is MISSING else flags.value)
+        flags.is_components_v2 = True
+
+        if files_ is not None:
+            try:
+                data = await state.http.send_files(
+                    channel_id=channel.id,
+                    files=files_,
+                    nonce=None if nonce is MISSING else nonce,
+                    allowed_mentions=allowed_mentions_payload,
+                    message_reference=reference_payload,
+                    components=components_payload,
+                    flags=flags.value,
+                )
+            finally:
+                for f in files_:
+                    f.close()
+        else:
+            data = await state.http.send_message(
+                channel_id=channel.id,
+                content=None,
+                nonce=None if nonce is MISSING else nonce,
+                allowed_mentions=allowed_mentions_payload,
+                message_reference=reference_payload,
+                components=components_payload,
+                flags=flags.value,
+            )
+
+        return state.create_message(channel=channel, data=data)
+
     async def trigger_typing(self) -> None:
         """|coro|
 

--- a/disnake/abc.py
+++ b/disnake/abc.py
@@ -1830,7 +1830,7 @@ class Messageable:
         allowed_mentions: AllowedMentions = MISSING,
         reference: Message | MessageReference | PartialMessage = MISSING,
     ) -> Message:
-        R"""|coro|
+        r"""|coro|
 
         Sends a message to the destination with the given components v2.
 
@@ -1842,8 +1842,8 @@ class Messageable:
         ----------
         components: |components_type|
             A list of components to include in the message.
-        files: :class:`File` | :class:`list`\[:class:`File`]
-            A file or a list of files to upload. Must be a maximum of 10.
+        files: :class:`File` | :class:`~collections.abc.Sequence`\[:class:`File`]
+            A file or a sequence of files to upload. Must be a maximum of 10.
         nonce: :class:`str` | :class:`int`
             The nonce to use for sending this message. If the message was successfully sent,
             then the message will have a nonce with this value.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1198,7 +1198,7 @@ class InteractionResponse:
         ephemeral: bool = MISSING,
         flags: MessageFlags = MISSING,
     ) -> None:
-        R"""|coro|
+        r"""|coro|
 
         Responds to this interaction by sending a message with components v2.
 
@@ -1210,8 +1210,8 @@ class InteractionResponse:
         ----------
         components: |components_type|
             A list of components to send with the message.
-        files: :class:`File` | :class:`list`\[:class:`File`]
-            A file or a list of files to upload. Must be a maximum of 10.
+        files: :class:`File` | :class:`~collections.abc.Sequence`\[:class:`File`]
+            A file or a sequence of files to upload. Must be a maximum of 10.
         allowed_mentions: :class:`AllowedMentions`
             Controls the mentions being processed in this message.
         ephemeral: :class:`bool`
@@ -1240,9 +1240,7 @@ class InteractionResponse:
         else:
             files_ = list(files) if files else None
 
-        previous_mentions: AllowedMentions | None = getattr(
-            self._parent._state, "allowed_mentions", None
-        )
+        previous_mentions = self._parent._state.allowed_mentions
         if allowed_mentions is MISSING:
             if previous_mentions is not None:
                 payload["allowed_mentions"] = previous_mentions.to_dict()
@@ -1504,6 +1502,101 @@ class InteractionResponse:
 
         if delete_after is not None:
             await self._parent.delete_original_response(delay=delete_after)
+
+    async def edit_message_v2(
+        self,
+        components: MessageComponents = MISSING,
+        *,
+        files: File | Sequence[File] = MISSING,
+        attachments: Sequence[Attachment] | None = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+    ) -> None:
+        r"""|coro|
+
+        Responds to this interaction by editing the original message of
+        a component interaction or modal interaction (if the modal was sent in
+        response to a component interaction).
+
+        Parameters
+        ----------
+        components: |components_type| | :data:`None`
+            A list of components to update this message with.
+        files: :class:`File` | :class:`~collections.abc.Sequence`\[:class:`File`]
+            A file or a sequence of files to upload. Files will be appended to the message.
+        attachments: :class:`~collections.abc.Sequence`\[:class:`Attachment`] | :data:`None`
+            A list of attachments to keep in the message.
+            If an empty sequence or :data:`None` is passed
+            then all existing attachments are removed.
+            Keeps existing attachments if not provided.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+        """
+        if self._response_type is not None:
+            raise InteractionResponded(self._parent)
+
+        parent = self._parent
+
+        if parent.type not in (InteractionType.component, InteractionType.modal_submit):
+            raise InteractionNotEditable(parent)
+
+        parent = cast("MessageInteraction | ModalInteraction", parent)
+        message = parent.message
+        # message in modal interactions only exists if modal was sent from component interaction
+        if message is None:
+            raise InteractionNotEditable(parent)
+
+        payload: dict[str, Any] = {}
+
+        if components is not MISSING:
+            if components:
+                payload["components"], _ = normalize_components_to_dict(components)
+            else:
+                payload["components"] = []
+
+        if files is MISSING:
+            files_ = MISSING
+        elif isinstance(files, File):
+            files_ = [files]
+        elif len(files) > 10:
+            msg = "files cannot exceed maximum of 10 elements"
+            raise ValueError(msg)
+        else:
+            files_ = list(files)
+
+        if allowed_mentions is not MISSING:
+            previous_mentions = self._parent._state.allowed_mentions
+
+            if previous_mentions is None:
+                payload["allowed_mentions"] = allowed_mentions.to_dict()
+            else:
+                payload["allowed_mentions"] = previous_mentions.merge(allowed_mentions).to_dict()
+
+        if attachments is None:
+            payload["attachments"] = []
+        elif attachments is not MISSING:
+            payload["attachments"] = [a.to_dict() for a in attachments]
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        elif files_:
+            payload["attachments"] = [a.to_dict() for a in message.attachments]
+
+        adapter = async_context.get()
+        response_type = InteractionResponseType.message_update
+        try:
+            await adapter.create_interaction_response(
+                parent.id,
+                parent.token,
+                session=parent._session,
+                type=response_type.value,
+                data=payload,
+                files=files_,
+            )
+        finally:
+            if files_:
+                for f in files_:
+                    f.close()
+
+        self._response_type = response_type
 
     async def autocomplete(self, *, choices: Choices) -> None:
         r"""|coro|

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -37,6 +37,7 @@ from ..errors import (
     ModalChainNotSupported,
     NotFound,
 )
+from ..file import File
 from ..flags import InteractionContextTypes, MessageFlags
 from ..guild import Guild
 from ..http import HTTPClient
@@ -67,7 +68,6 @@ if TYPE_CHECKING:
     from ..client import Client
     from ..embeds import Embed
     from ..ext.commands import AutoShardedBot, Bot
-    from ..file import File
     from ..mentions import AllowedMentions
     from ..poll import Poll
     from ..state import ConnectionState
@@ -1188,6 +1188,99 @@ class InteractionResponse:
 
         if delete_after is not MISSING:
             await self._parent.delete_original_response(delay=delete_after)
+
+    async def send_message_v2(
+        self,
+        components: MessageComponents,
+        *,
+        files: File | Sequence[File] = (),
+        allowed_mentions: AllowedMentions = MISSING,
+        ephemeral: bool = MISSING,
+        flags: MessageFlags = MISSING,
+    ) -> None:
+        R"""|coro|
+
+        Responds to this interaction by sending a message with components v2.
+
+        .. note::
+            This method unconditionally sets the :attr:`~MessageFlags.is_components_v2` flag.
+            If you want to use components v1, use :meth:`send_message` instead.
+
+        Parameters
+        ----------
+        components: |components_type|
+            A list of components to send with the message.
+        files: :class:`File` | :class:`list`\[:class:`File`]
+            A file or a list of files to upload. Must be a maximum of 10.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+        ephemeral: :class:`bool`
+            Whether the message should only be visible to the user who started the interaction.
+        flags: :class:`MessageFlags`
+            The flags to set for this message.
+            Only :attr:`~MessageFlags.suppress_embeds`, :attr:`~MessageFlags.ephemeral`,
+            :attr:`~MessageFlags.suppress_notifications`, and :attr:`~MessageFlags.is_components_v2`
+            are supported.
+
+            If parameter ``ephemeral`` is provided,
+            it will override the corresponding setting of this ``flags`` parameter.
+        """
+        if self._response_type is not None:
+            raise InteractionResponded(self._parent)
+
+        payload: dict[str, Any] = {
+            "components": normalize_components_to_dict(components)[0],
+        }
+
+        if isinstance(files, File):
+            files_ = [files]
+        elif len(files) > 10:
+            msg = "files cannot exceed maximum of 10 elements"
+            raise ValueError(msg)
+        else:
+            files_ = list(files) if files else None
+
+        previous_mentions: AllowedMentions | None = getattr(
+            self._parent._state, "allowed_mentions", None
+        )
+        if allowed_mentions is MISSING:
+            if previous_mentions is not None:
+                payload["allowed_mentions"] = previous_mentions.to_dict()
+        elif previous_mentions is not None:
+            payload["allowed_mentions"] = previous_mentions.merge(allowed_mentions).to_dict()
+        else:
+            payload["allowed_mentions"] = allowed_mentions.to_dict()
+
+        flags = MessageFlags._from_value(0 if flags is MISSING else flags.value)
+        flags.is_components_v2 = True
+
+        if ephemeral is not MISSING:
+            flags.ephemeral = ephemeral
+
+        payload["flags"] = flags.value
+
+        parent = self._parent
+        adapter = async_context.get()
+        response_type = InteractionResponseType.channel_message
+        try:
+            await adapter.create_interaction_response(
+                parent.id,
+                parent.token,
+                session=parent._session,
+                type=response_type.value,
+                data=payload,
+                files=files_,
+            )
+        except NotFound as e:
+            if e.code == 10062:
+                raise InteractionTimedOut(self._parent) from e
+            raise
+        finally:
+            if files_:
+                for f in files_:
+                    f.close()
+
+        self._response_type = response_type
 
     async def edit_message(
         self,

--- a/disnake/message.py
+++ b/disnake/message.py
@@ -7,7 +7,7 @@ import datetime
 import io
 import re
 from base64 import b64decode, b64encode
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from os import PathLike
 from typing import (
     TYPE_CHECKING,
@@ -2151,6 +2151,89 @@ class Message(Hashable):
             view=view,
             components=components,
             delete_after=delete_after,
+        )
+
+    async def edit_v2(
+        self,
+        components: MessageComponents = MISSING,
+        *,
+        files: File | Sequence[File] = MISSING,
+        attachments: Sequence[Attachment] | None = MISSING,
+        allowed_mentions: AllowedMentions = MISSING,
+    ) -> Message:
+        r"""|coro|
+
+        Edits the message.
+
+        .. note::
+
+            This method cannot be used on messages authored by others.
+
+        Parameters
+        ----------
+        components: |components_type|
+            The components to update this message with.
+        files: :class:`File` | :class:`~collections.abc.Sequence`\[:class:`File`]
+            A file or a sequence of files to upload. Files will be appended to the message.
+        attachments: :class:`~collections.abc.Sequence`\[:class:`Attachment`] | :data:`None`
+            A list of attachments to keep in the message.
+            If an empty sequence or :data:`None` is passed
+            then all existing attachments are removed.
+            Keeps existing attachments if not provided.
+        allowed_mentions: :class:`AllowedMentions`
+            Controls the mentions being processed in this message.
+
+        Returns
+        -------
+        :class:`Message`
+            The message that was edited.
+        """
+        # allowed_mentions can only be changed on the bot's own messages
+        if self._state.allowed_mentions is not None and self.author.id == self._state.self_id:
+            previous_allowed_mentions = self._state.allowed_mentions
+        else:
+            previous_allowed_mentions = None
+
+        if files is MISSING:
+            files_ = MISSING
+        elif isinstance(files, File):
+            files_ = [files]
+        elif len(files) > 10:
+            msg = "files cannot exceed maximum of 10 elements"
+            raise ValueError(msg)
+        else:
+            files_ = list(files)
+
+        # if no attachment list was provided but we're uploading new files,
+        # use current attachments as the base
+        attachments_: list[Attachment] | None
+
+        if attachments is None:
+            attachments_ = []
+        elif attachments is not MISSING:
+            attachments_ = list(attachments)
+        elif files_:
+            attachments_ = self.attachments
+        else:
+            attachments_ = MISSING
+
+        return await _edit_handler(
+            self,
+            default_flags=self.flags.value,
+            previous_allowed_mentions=previous_allowed_mentions,
+            content=MISSING,
+            embed=MISSING,
+            embeds=MISSING,
+            file=MISSING,
+            files=files_,
+            attachments=attachments_,
+            suppress=MISSING,
+            suppress_embeds=MISSING,
+            flags=MISSING,
+            allowed_mentions=allowed_mentions,
+            view=MISSING,
+            components=components,
+            delete_after=None,
         )
 
     async def publish(self) -> None:


### PR DESCRIPTION
## Summary

*This is a feeler whether this feature is useful or not*

This PR adds new convenience methods:
- `Messageable.send_v2`
- `Message.edit_v2`
- `InteractionResponse.{send,edit}_message_v2`
- [TODO] `async_.Webhook.send_v2`
- [TODO] `async_.WebhookMessage.edit_v2`
  - `sync.Webhook.send` and `sync.WebhookMessage.edit` don't support components?

which provide a simplified interface to sending components v2.

For example, `InteractionResponse.send_message`:
```py
async def send_message(
    self,
    content: str | None = None,
    *,
    embed: Embed = MISSING,
    embeds: list[Embed] = MISSING,
    file: File = MISSING,
    files: list[File] = MISSING,
    allowed_mentions: AllowedMentions = MISSING,
    view: View = MISSING,
    components: MessageComponents = MISSING,
    tts: bool = False,
    ephemeral: bool = MISSING,
    suppress_embeds: bool = MISSING,
    flags: MessageFlags = MISSING,
    delete_after: float = MISSING,
    poll: Poll = MISSING,
) -> None:

```
Becomes: [^1]
```py
async def send_message_v2(
    self,
    components: MessageComponents,
    *,
    files: File | Sequence[File] = (),
    allowed_mentions: AllowedMentions = MISSING,
    ephemeral: bool = MISSING,
    flags: MessageFlags = MISSING,
) -> None:
```

[^1]: I'm not sure if `tts` and `suppress_embeds` work with components, hence omitted; I'm not a fan of the `delete_after` functionality

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
