### PR TITLE
fix(docs): display enum defaults in signatures correctly

### DIFF
--- a/docs/extensions/enumattrs.py
+++ b/docs/extensions/enumattrs.py
@@ -35,13 +35,29 @@ class EnumMemberDocumenter(AttributeDocumenter):
         return True
 
 
+# show `Enum.name` instead of `(name, value)` in signatures
+# (object_description has a special case for enum.Enum, but obviously not
+# for our custom enum types, which ultimately get displayed as plain tuples)
+def _patch_object_description() -> None:
+    from sphinx.util import inspect
+
+    orig_description = inspect.object_description
+
+    def patched_description(obj: Any, **kwargs: Any) -> Any:
+        if isinstance(obj, disnake.enums._EnumValueBase):
+            # bypass `__str__` defined on some enums
+            return disnake.enums._EnumValueBase.__str__(obj)
+        return orig_description(obj, **kwargs)
+
+    inspect.object_description = patched_description
+
+
 def setup(app: Sphinx) -> SphinxExtensionMeta:
     app.setup_extension("sphinx.ext.autodoc")
 
     app.add_autodocumenter(EnumMemberDocumenter)
 
-    # show `Enum.name` instead of `<Enum.name: 123>` in signatures
-    disnake.enums._EnumValueBase.__repr__ = disnake.enums._EnumValueBase.__str__
+    _patch_object_description()
 
     return {
         "parallel_read_safe": True,


### PR DESCRIPTION
## Summary

The recent sphinx update in #1325 resulted in enum parameter defaults being displayed as tuples, courtesy of https://github.com/sphinx-doc/sphinx/commit/467e94dc62acca1f517f60f35479aefb775f9f17. There isn't much we can do besides monkey-patching it and bypassing its logic for our enum values.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
