### PR TITLE
docs: update to sphinx 9, drop hoverxref

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ formats:
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     create_environment:
       - asdf plugin add uv

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -627,11 +627,17 @@ class StatusDisplayType(Enum):
     """
 
     name = 0  # pyright: ignore[reportAssignmentType]
-    """The name of the activity is displayed, e.g: ``Listening to Spotify``."""
+    """The name of the activity is displayed,
+    e.g: ``Listening to Spotify``.
+    """
     state = 1
-    """The state of the activity is displayed, e.g: ``Listening to Rick Astley``."""
+    """The state of the activity is displayed,
+    e.g: ``Listening to Rick Astley``.
+    """
     details = 2
-    """The details of the activity are displayed, e.g: ``Listening to Never Gonna Give You Up``."""
+    """The details of the activity are displayed,
+    e.g: ``Listening to Never Gonna Give You Up``.
+    """
 
     def __int__(self) -> int:
         return self.value

--- a/docs/.ruff.toml
+++ b/docs/.ruff.toml
@@ -3,4 +3,4 @@
 extend = "../pyproject.toml"
 src = ["../"]
 
-target-version = "py311"
+target-version = "py312"

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1457,108 +1457,19 @@ div.code-block-caption {
 }
 
 
-/* TODO */
-/* hoverxref stuff */
-/* (this is mostly just a merge of the 'shadow' and 'borderless' themes) */
+/* link preview stuff */
 
-.tooltipster-sidetip.tooltipster-custom .tooltipster-content {
-  color: inherit;
-}
-
-.tooltipster-sidetip.tooltipster-custom .tooltipster-box {
+div.tooltip {
 	border: none;
 	background: var(--tooltip-background);
 }
 
-:root[data-theme="light"] .tooltipster-sidetip.tooltipster-custom .tooltipster-box {
-  box-shadow: 0px 0px 10px 6px rgba(0,0,0,0.1);
+div.tooltip .tooltip-content {
+  color: inherit;
 }
 
-.tooltipster-sidetip.tooltipster-custom.tooltipster-bottom .tooltipster-box {
-	margin-top: 8px;
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-left .tooltipster-box {
-	margin-right: 8px;
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-box {
-	margin-left: 8px;
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-top .tooltipster-box {
-	margin-bottom: 8px;
-}
-
-.tooltipster-sidetip.tooltipster-custom .tooltipster-arrow {
-	height: 8px;
-	margin-left: -8px;
-	width: 16px;
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-left .tooltipster-arrow,
-.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-arrow {
-	height: 16px;
-	margin-left: 0;
-	margin-top: -8px;
-	width: 8px;
-}
-
-.tooltipster-sidetip.tooltipster-custom .tooltipster-arrow-background {
-	display: none;
-}
-
-.tooltipster-sidetip.tooltipster-custom .tooltipster-arrow-border {
-	border: 8px solid transparent;
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-bottom .tooltipster-arrow-border {
-	border-bottom-color: var(--tooltip-background);
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-left .tooltipster-arrow-border {
-	border-left-color: var(--tooltip-background);
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-arrow-border {
-	border-right-color: var(--tooltip-background);
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-top .tooltipster-arrow-border {
-	border-top-color: var(--tooltip-background);
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-bottom .tooltipster-arrow-uncropped {
-	top: -8px;
-}
-
-.tooltipster-sidetip.tooltipster-custom.tooltipster-right .tooltipster-arrow-uncropped {
-	left: -8px;
-}
-
-
-/* hoverxref stuff (hoverxref custom additions) */
-
-.hxr-hoverxref {
-  border-bottom: 1px dotted;
-  border-color: gray;
-}
-
-.tooltipster-box {
-  max-height: 600px;
-}
-
-.tooltipster-sidetip.tooltipster-custom .tooltipster-content {
-  font-size: 80%;
-  padding: 18px;
-}
-
-.tooltipster-sidetip.tooltipster-custom .tooltipster-content p {
-  font-size: 100% !important;
-}
-
-.tooltipster-sidetip.tooltipster-custom .tooltipster-content .headerlink {
-  visibility: hidden;
+div.tooltip .arrow {
+	background: var(--tooltip-background);
 }
 
 

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1457,6 +1457,7 @@ div.code-block-caption {
 }
 
 
+/* TODO */
 /* hoverxref stuff */
 /* (this is mostly just a merge of the 'shadow' and 'borderless' themes) */
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -60,6 +60,10 @@
   <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
   {%- endif %}
   {%- endblock %}
+  <!-- Readthedocs Addons does some doctool detection magic based on a couple different selectors,
+    and custom themes are (unfortunately) not detected. We therefore have to trick it into detecting
+    a sphinx theme like this. No `rel=` means this should generally be a noop. -->
+  <link href="_static/alabaster.css" />
 </head>
 <body{% if not display_toc %} class="small-toc"{% endif %}>
 {%- block header %}{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,10 +20,8 @@ import os
 import re
 import subprocess  # noqa: TID251
 import sys
-import warnings
 from typing import Any
 
-import sphinx.deprecation
 import versioningit
 from sphinx.application import Sphinx
 
@@ -50,7 +48,6 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinxcontrib_trio",
     "sphinxcontrib.towncrier.ext",
-    "hoverxref.extension",
     "notfound.extension",
     "sphinxext.opengraph",
     "redirects",
@@ -245,30 +242,12 @@ def linkcode_resolve(domain: str, info: dict[str, Any]) -> str | None:
 
 
 # Links used for cross-referencing stuff in other documentation
-# when this is updated hoverxref_intersphinx also needs to be updated IF THE docs are hosted on readthedocs.
 intersphinx_mapping = {
     "py": ("https://docs.python.org/3", None),
     "aio": ("https://docs.aiohttp.org/en/stable/", None),
     "req": ("https://requests.readthedocs.io/en/latest/", None),
 }
 
-
-hoverx_default_type = "tooltip"
-hoverxref_domains = ["py"]
-hoverxref_role_types = dict.fromkeys(
-    ["ref", "class", "func", "meth", "attr", "exc", "data"],
-    "tooltip",
-)
-hoverxref_tooltip_theme = ["tooltipster-custom"]
-hoverxref_tooltip_lazy = True
-
-# these have to match the keys on intersphinx_mapping, and those projects must be hosted on readthedocs.
-hoverxref_intersphinx = list(intersphinx_mapping.keys())
-
-
-# use proxied API endpoint on readthedocs to avoid CORS issues
-if _IS_READTHEDOCS:
-    hoverxref_api_host = "/_"
 
 # when not on readthedocs, assume no prefix for the 404 page.
 # this means that /404.html should properly render on local builds
@@ -520,12 +499,6 @@ def setup(app: Sphinx) -> None:
     import disnake
 
     del disnake.Embed.Empty  # pyright: ignore[reportAttributeAccessIssue]
-
-    warnings.filterwarnings(
-        "ignore",
-        category=sphinx.deprecation.RemovedInSphinx90Warning,
-        module="hoverxref.extension",
-    )
 
     # silence somewhat verbose `Writing evaluated template result to ...` log
     logging.getLogger("sphinx.sphinx.util.fileutil").addFilter(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,10 @@ extensions = [
 
 autodoc_member_order = "bysource"
 autodoc_typehints = "none"
+# for now, go back to pre-9.0 class-based autodoc.
+# patching the new one for enum fixes is a little more tricky
+autodoc_use_legacy_class_based = True
+
 # maybe consider this?
 # napoleon_attr_annotations = False
 

--- a/docs/extensions/builder.py
+++ b/docs/extensions/builder.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 from typing import TYPE_CHECKING, Any
 
 from docutils import nodes
@@ -11,7 +10,6 @@ from sphinxext.opengraph._description_parser import DescriptionParser
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
-    from sphinx.config import Config
     from sphinx.writers.html5 import HTML5Translator
 
     from ._types import SphinxExtensionMeta
@@ -75,23 +73,9 @@ def patch_opengraph(*args: Any) -> None:
     DescriptionParser.dispatch_visit = patched_dispatch_visit
 
 
-def disable_mathjax(app: Sphinx, config: Config) -> None:
-    # prevent installation of mathjax script, which gets installed due to
-    # https://github.com/readthedocs/sphinx-hoverxref/commit/7c4655092c482bd414b1816bdb4f393da117062a
-    #
-    # inspired by https://github.com/readthedocs/sphinx-hoverxref/blob/003b84fee48262f1a969c8143e63c177bd98aa26/hoverxref/extension.py#L151
-
-    for listener in app.events.listeners.get("html-page-context", []):
-        module = inspect.getmodule(listener.handler)
-        module_name = module.__name__ if module else ""
-        if module_name == "sphinx.ext.mathjax":
-            app.disconnect(listener.id)
-
-
 def setup(app: Sphinx) -> SphinxExtensionMeta:
     app.connect("config-inited", patch_genindex)
     app.connect("config-inited", patch_opengraph)
-    app.connect("config-inited", disable_mathjax)
     app.connect("builder-inited", set_translator)
 
     return {

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,7 +84,7 @@ EXECUTION_GROUPS: Sequence[ExecutionGroup] = [
     # docs and pyright
     ExecutionGroup(
         sessions=("docs", "pyright"),
-        python="3.11",
+        python="3.12",
         pyright_paths=("docs",),
         groups=("docs",),
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,12 +82,12 @@ changelog = [
     "towncrier==25.8.0",
 ]
 docs = [
-    "sphinx==8.2.3",
+    "sphinx==9.1.0",
     "sphinx-autobuild~=2025.8.25",
     "sphinx-hoverxref==1.4.2",
     "sphinx-notfound-page==1.1.0",
     "sphinxcontrib-towncrier==0.5.0a0",
-    "sphinxcontrib-trio~=1.1.2",
+    "sphinxcontrib-trio~=1.2.0",
     "sphinxext-opengraph==0.13.0",
     "versioningit>=3.3.0,<4",
     { include-group = "changelog" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ changelog = [
 docs = [
     "sphinx==9.1.0",
     "sphinx-autobuild~=2025.8.25",
-    "sphinx-hoverxref==1.4.2",
     "sphinx-notfound-page==1.1.0",
     "sphinxcontrib-towncrier==0.5.0a0",
     "sphinxcontrib-trio~=1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ build = [
 required-version = ">=0.9.2"
 
 [tool.uv.dependency-groups]
-docs = { requires-python = ">=3.11" }
+docs = { requires-python = ">=3.12" }
 
 
 [tool.hatch.build]


### PR DESCRIPTION
## Summary

Followup to #1325, I suppose.
This updates the documentation from Sphinx 8 to 9, and increases the minimum Python version for building the docs to 3.12, which is what Sphinx 9.1 requires.

For now, this uses `autodoc_use_legacy_class_based` to go back to the pre-Sphinx-9 class-based autodoc system. The new one is significantly less extensible, which would make a few of our custom extensions rely on monkey-patching. Definitely [possible](https://gist.github.com/shiftinv/8e7c868c602e9d93526d65b773c9f5ec), but for now we're taking the easy way out.

Updating to v9 also forces us to get rid of the (already deprecated) hoverxref extension, which is now provided through [Readthedocs Addons](https://docs.readthedocs.com/platform/stable/link-previews.html) (once I enable it after this PR is merged). There's a bit of an annoyance in getting the addons script to recognize Sphinx, since they currently just hardcode a couple selectors matching popular themes, and it not detecting Sphinx results in the preview tooltip being largely broken. Anyhow, simply adding a defunct `<link>` with a particular href tricks it into recognizing Sphinx.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
