### PR TITLE
docs: add script to disable link previews on older documentation versions

### DIFF
--- a/docs/_static/_readthedocs_injected.js
+++ b/docs/_static/_readthedocs_injected.js
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+/*
+====================
+This script is meant to be injected into all documentation versions using
+https://docs.readthedocs.com/platform/stable/custom-script.html to apply
+various fixes to old documentation versions.
+(It could be hosted basically anywhere, but adding it to the repo is easiest.)
+====================
+*/
+
+// intercept the internal Readthedocs Addons event, and disable
+// link previews in (older) versions where hoverxref is still being used.
+document.addEventListener(
+    "readthedocs-addons-internal-data-ready",
+    (event) => {
+        const data = event.detail.data(true);
+
+        if (document.querySelector('script[src*="/hoverxref.js"]')) {
+            data.addons.linkpreviews.enabled = false;
+        }
+    }
+)


### PR DESCRIPTION
## Summary

#1534 removed hoverxref, with the idea being that we use the new link previews provided by Readthedocs Addons instead. Enabling those for the documentation enables them for *all* versions, though, including those that would then use both hoverxref and the new link previews simultaneously.
Since the settings for addons are still not configurable per-version, we can use https://docs.readthedocs.com/platform/stable/custom-script.html to roll our own per-version config, in a way. Patching old documentation versions is actually an intended use case for these, but intercepting the internal event... maybe not so much. oh well.

The script can be hosted basically anywhere (provided CORS is set up correctly), but keeping it in this repo and using `https://cdn.jsdelivr.net/gh/<owner>/<repo>@<sha>/` seemed reasonable to me.

<sup>and like, yeah, we could just get rid of link previews. but this is more fun c:</sup>

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
