### PR TITLE
chore(examples): remove pytz dependency from injections example

### DIFF
--- a/examples/interactions/injections.py
+++ b/examples/interactions/injections.py
@@ -5,9 +5,6 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import disnake
-
-# this file uses pytz in one of its examples but it is completely optional
-import pytz
 from disnake.ext import commands
 
 bot = commands.Bot(command_prefix=commands.when_mentioned)
@@ -15,19 +12,21 @@ bot = commands.Bot(command_prefix=commands.when_mentioned)
 # Instead of repeating boiler-plate code you may use injections.
 # Here we give each command a config with a few default options.
 
+Theme = Literal["light", "dark", "amoled"]
+
 
 @dataclass
 class Config:
     locale: str
-    timezone: pytz.BaseTzInfo
-    theme: str
+    theme: Theme
+    notifications: bool
 
 
 async def get_config(
     inter: disnake.CommandInteraction,
     locale: str | None = None,
-    timezone: str = "UTC",
-    theme: Literal["light", "dark", "amoled"] = "dark",
+    theme: Theme = "dark",
+    notifications: bool = True,
 ) -> Config:
     """Let the user enter a config
 
@@ -37,18 +36,15 @@ async def get_config(
 
     Parameters
     ----------
-    locale: The preferred locale, defaults to the server's locale
-    timezone: Your current timezone, must be in the format of "US/Eastern" or "Europe/London"
+    locale: Your preferred locale, defaults to the server's locale
     theme: Your preferred theme, defaults to the dark theme
+    notifications: Whether you'd like to receive notifications
     """
     # if a locale is not provided use the guild's locale
     if locale is None:
         locale = str(inter.guild_locale or "en-US")
 
-    # parse a timezone from a string using pytz (maybe even use the locale if you feel like it)
-    tzinfo = pytz.timezone(timezone)
-
-    return Config(locale, tzinfo, theme)
+    return Config(locale, theme, notifications)
 
 
 # Note that the following command will have 4 options:

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,7 +77,7 @@ EXECUTION_GROUPS: Sequence[ExecutionGroup] = [
             project=True,
             extras=("speed", "voice"),
             groups=("test", "nox"),
-            dependencies=("pytz", "requests"),  # needed for type checking
+            dependencies=("requests",),  # needed for type checking
         )
         for python in ALL_PYTHONS
     ),


### PR DESCRIPTION
## Summary

`pytz` was used for display purposes only, and would show a mildly annoying warning when running pyright, since pytz is only installed in CI:
```py
.../disnake/examples/interactions/injections.py
  .../disnake/examples/interactions/injections.py:10:8 - warning: Import "pytz" could not be resolved from source (reportMissingModuleSource)
0 errors, 1 warning, 0 informations
```

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
