### PR TITLE
fix(enums): swap `SubscriptionStatus.ending/.inactive` values

### DIFF
--- a/changelog/1544.bugfix.rst
+++ b/changelog/1544.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :class:`SubscriptionStatus`'s :attr:`~SubscriptionStatus.ending` and :attr:`~SubscriptionStatus.inactive` members to map to the correct value. These were previously swapped due to a mistake in the API documentation.

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -2416,10 +2416,10 @@ class SubscriptionStatus(Enum):
 
     active = 0
     """Represents an active Subscription which is scheduled to renew."""
-    ending = 1
-    """Represents an active Subscription which will not renew."""
-    inactive = 2
+    inactive = 1
     """Represents an inactive Subscription which is not being charged."""
+    ending = 2
+    """Represents an active Subscription which will not renew."""
 
 
 class PollLayoutType(Enum):


### PR DESCRIPTION
## Summary

These were incorrectly documented in the API docs as `ending = 1` and `inactive = 2`, but are meant to be the other way around. Somehow no-one had noticed this (including me while testing back then) up until now c:

https://github.com/discord/discord-api-docs/pull/8388/changes?w=1

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
