### PR TITLE
fix(commands): improve support for `FlagConverter` in Python 3.14+

### DIFF
--- a/changelog/1545.bugfix.rst
+++ b/changelog/1545.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Improve :class:`~ext.commands.FlagConverter` support in Python 3.14+ when ``from __future__ import annotations`` was not used.

--- a/disnake/ext/commands/flag_converter.py
+++ b/disnake/ext/commands/flag_converter.py
@@ -18,7 +18,12 @@ from typing import (
     get_origin,
 )
 
-from disnake.utils import MISSING, maybe_coroutine, resolve_annotation
+from disnake.utils import (
+    MISSING,
+    get_annotations_from_namespace,
+    maybe_coroutine,
+    resolve_annotation,
+)
 
 from .converter import run_converters
 from .errors import (
@@ -142,7 +147,7 @@ def validate_flag_name(name: str, forbidden: set[str]) -> None:
 def get_flags(
     namespace: dict[str, Any], globals: dict[str, Any], locals: dict[str, Any]
 ) -> dict[str, Flag]:
-    annotations = namespace.get("__annotations__", {})
+    annotations = get_annotations_from_namespace(namespace)
     case_insensitive = namespace["__commands_flag_case_insensitive__"]
     flags: dict[str, Flag] = {}
     cache: dict[str, Any] = {}

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1384,6 +1384,26 @@ def signature_has_self_param(function: Callable[..., Any]) -> bool:
     return not parent.endswith(".<locals>")
 
 
+if sys.version_info >= (3, 14):
+    import annotationlib
+
+    def get_annotations_from_namespace(namespace: dict[str, Any]) -> dict[str, Any]:
+        # classes in 3.14+ don't necessarily have an `__annotations__` dict,
+        # as annotations are lazily evaluated (provided the pre-3.14 future import isn't used)
+        # https://docs.python.org/3.14/library/annotationlib.html#annotationlib-metaclass
+        if annotate := annotationlib.get_annotate_from_class_namespace(namespace):
+            # we usually run these through `resolve_annotation` right after anyway,
+            # so `FORWARDREF` doesn't really provide an advantage over simply using `VALUE`,
+            # but it also doesn't hurt to use it.
+            return annotationlib.call_annotate_function(annotate, annotationlib.Format.FORWARDREF)
+        return namespace.get("__annotations__", {})
+
+else:
+
+    def get_annotations_from_namespace(namespace: dict[str, Any]) -> dict[str, Any]:
+        return namespace.get("__annotations__", {})
+
+
 TimestampStyle = Literal["t", "T", "d", "D", "f", "F", "s", "S", "R"]
 
 

--- a/tests/ext/commands/test_flags.py
+++ b/tests/ext/commands/test_flags.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from disnake.ext.commands import FlagConverter
+
+flag_def = """
+class SomeFlags(FlagConverter):
+    thing: str
+    stuff_with_default: int = 1
+"""
+
+
+@pytest.mark.parametrize("with_future", [False, True])
+def test_flags_annotations(with_future: bool) -> None:
+    import __future__
+
+    code_flags = __future__.annotations.compiler_flag if with_future else 0
+    code = compile(flag_def, "", "exec", code_flags)
+    exec(code, ns := {"FlagConverter": FlagConverter})  # noqa: S102
+
+    SomeFlags: type[FlagConverter] = ns["SomeFlags"]
+    flags = SomeFlags.get_flags()
+
+    assert flags.keys() == {"thing", "stuff_with_default"}
+    assert flags["thing"].annotation is str
+    assert flags["stuff_with_default"].annotation is int

--- a/tests/ext/commands/test_flags.py
+++ b/tests/ext/commands/test_flags.py
@@ -15,8 +15,9 @@ class SomeFlags(FlagConverter):
 def test_flags_annotations(with_future: bool) -> None:
     import __future__
 
+    # this is equivalent to `from __future__ import annotations`
     code_flags = __future__.annotations.compiler_flag if with_future else 0
-    code = compile(flag_def, "", "exec", code_flags)
+    code = compile(flag_def, "<>", "exec", code_flags, dont_inherit=True)
     exec(code, ns := {"FlagConverter": FlagConverter})  # noqa: S102
 
     SomeFlags: type[FlagConverter] = ns["SomeFlags"]


### PR DESCRIPTION
## Summary

long story short, `__annotations__` doesn't necessarily exist anymore in Python 3.14 and beyond, unless the (now legacy) future annotations import[^1] was used.
This PR uses `annotationlib.get_annotate_from_class_namespace` to support the new lazily evaluated annotations.

short story long(?), see [PEP 649](https://peps.python.org/pep-0649/)/[PEP 749](https://peps.python.org/pep-0749/), as well as the [example in the documentation](https://docs.python.org/3.14/library/annotationlib.html#annotationlib-metaclass) for this use case in particular.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

[^1]: if you think about it, it should really be ``from __past__ import annotations`` now. smfh.