### PR TITLE
ci: add 7-day dependabot update delay

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,8 @@ updates:
       - "/.github/actions/*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 1
     labels:
       - "t: dependencies"


### PR DESCRIPTION
## Summary

Just a precautionary measure, given the number of supply chain compromises over the last few months. While I always try to manually review CI actions updates, an extra delay won't hurt c:
7 days seemed like a reasonable cooldown to me, I've seen anything from 3 to 14 days in various repos. <sup>*shrug*</sup>

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
