### PR TITLE
fix(auditlog): rename `voice_channel_status_update` action to `*_create`

### DIFF
--- a/changelog/1520.feature.rst
+++ b/changelog/1520.feature.rst
@@ -1,4 +1,4 @@
 Support voice channel statuses.
 - New field: :attr:`VoiceChannel.status`, changeable using :meth:`VoiceChannel.set_status`.
 - New events: :func:`on_voice_channel_status_update` + :func:`on_voice_channel_start_time_update`.
-- New audit log types: :attr:`AuditLogAction.voice_channel_status_update`, :attr:`~AuditLogAction.voice_channel_status_delete`.
+- New audit log types: :attr:`AuditLogAction.voice_channel_status_create`, :attr:`~AuditLogAction.voice_channel_status_delete`.

--- a/changelog/1551.feature.rst
+++ b/changelog/1551.feature.rst
@@ -1,0 +1,4 @@
+Support voice channel statuses.
+- New field: :attr:`VoiceChannel.status`, changeable using :meth:`VoiceChannel.set_status`.
+- New events: :func:`on_voice_channel_status_update` + :func:`on_voice_channel_start_time_update`.
+- New audit log types: :attr:`AuditLogAction.voice_channel_status_create`, :attr:`~AuditLogAction.voice_channel_status_delete`.

--- a/disnake/audit_logs.py
+++ b/disnake/audit_logs.py
@@ -718,7 +718,7 @@ class AuditLogEntry(Hashable):
                     "integration_type": extra.get("integration_type"),
                 }
                 self.extra = type("_AuditLogProxy", (), elems)()
-            elif self.action is enums.AuditLogAction.voice_channel_status_update:
+            elif self.action is enums.AuditLogAction.voice_channel_status_create:
                 elems = {
                     "status": extra.get("status"),
                 }

--- a/disnake/enums.py
+++ b/disnake/enums.py
@@ -731,7 +731,7 @@ class AuditLogAction(Enum):
     onboarding_prompt_create              = 163
     onboarding_prompt_update              = 164
     onboarding_update                     = 167
-    voice_channel_status_update           = 192
+    voice_channel_status_create           = 192
     voice_channel_status_delete           = 193
     # fmt: on
 
@@ -802,7 +802,7 @@ class AuditLogAction(Enum):
             AuditLogAction.onboarding_prompt_create:              AuditLogActionCategory.create,
             AuditLogAction.onboarding_prompt_update:              AuditLogActionCategory.update,
             AuditLogAction.onboarding_update:                     AuditLogActionCategory.update,
-            AuditLogAction.voice_channel_status_update:           AuditLogActionCategory.update,
+            AuditLogAction.voice_channel_status_create:           AuditLogActionCategory.create,
             AuditLogAction.voice_channel_status_delete:           AuditLogActionCategory.delete,
         }
         # fmt: on

--- a/docs/api/audit_logs.rst
+++ b/docs/api/audit_logs.rst
@@ -1858,9 +1858,9 @@ AuditLogAction
 
         .. versionadded:: |vnext|
 
-    .. attribute:: voice_channel_status_update
+    .. attribute:: voice_channel_status_create
 
-        A voice channel status was updated.
+        A voice channel status was set by a user.
 
         When this is the action, the type of :attr:`~AuditLogEntry.extra` is
         set to an unspecified proxy object with one attribute:


### PR DESCRIPTION
## Summary

Followup to #1520, see https://github.com/discord/discord-api-docs/commit/65170436bd8a27692f341b9b060eb5930bb0e905.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
