### PR TITLE
fix(exceptions): correct typings of `CheckAnyFailure`

### DIFF
--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -1787,7 +1787,7 @@ def check_any(*checks: Check) -> Callable[[T], T]:
         async def only_for_owners(ctx):
             await ctx.send('Hello mister owner!')
     """
-    unwrapped = []
+    unwrapped: list[Callable[[AnyContext], Coro[bool]]] = []
     for wrapped in checks:
         try:
             pred = wrapped.predicate
@@ -1798,7 +1798,7 @@ def check_any(*checks: Check) -> Callable[[T], T]:
             unwrapped.append(pred)
 
     async def predicate(ctx: AnyContext) -> bool:
-        errors = []
+        errors: list[CheckFailure] = []
         for func in unwrapped:
             try:
                 value = await func(ctx)

--- a/disnake/ext/commands/errors.py
+++ b/disnake/ext/commands/errors.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from disnake.threads import Thread
     from disnake.types.snowflake import Snowflake, SnowflakeList
 
+    from ._types import Coro
     from .context import AnyContext
     from .cooldowns import BucketType, Cooldown
     from .flag_converter import Flag
@@ -208,10 +209,10 @@ class CheckAnyFailure(CheckFailure):
     """
 
     def __init__(
-        self, checks: list[CheckFailure], errors: list[Callable[[AnyContext], bool]]
+        self, checks: list[Callable[[AnyContext], Coro[bool]]], errors: list[CheckFailure]
     ) -> None:
-        self.checks: list[CheckFailure] = checks
-        self.errors: list[Callable[[AnyContext], bool]] = errors
+        self.checks: list[Callable[[AnyContext], Coro[bool]]] = checks
+        self.errors: list[CheckFailure] = errors
         super().__init__("You do not have permission to run this command.")
 
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Fixes annotations of `CheckAnyFailure`'s `.checks` and `.errors`, which have been flipped around.
Also annotates the insides of `commands.check_any`, which instantiates the exception.

Related issue: #1181

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
