### PR TITLE
build: remove `docs` dependency group from default `dev` group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     { include-group = "typing" },
     { include-group = "test" },
     { include-group = "build" },
+    # `docs` not included as it requires 3.12+
 ]
 nox = [
     # note: nox should be synced with nox.needs_version in noxfile.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,13 @@ voice = [
 ]
 
 [dependency-groups]
-dev   = [
+dev = [
     { include-group = "tools" },
     { include-group = "nox" },
     { include-group = "codemod" },
     { include-group = "typing" },
     { include-group = "test" },
     { include-group = "build" },
-    { include-group = "docs" },
 ]
 nox = [
     # note: nox should be synced with nox.needs_version in noxfile.py


### PR DESCRIPTION
## Summary

Since the `docs` group requires Python 3.12, including it in the `dev` group (which uv installs by default with `uv run`) would limit all development environments to 3.12+, which isn't the intention.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
