### PR TITLE
fix(utils,params): add filename/line_no context for eval'ed annotations

### DIFF
--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -271,9 +271,6 @@ class _BaseRange(ABC):
 
         if len(params) == 2:
             # backwards compatibility for `Range[1, 2]`
-
-            # FIXME: the warning context is incorrect when used with stringified annotations,
-            # and points to the eval frame instead of user code
             disnake.utils.warn_deprecated(
                 f"Using `{name}` without an explicit type argument is deprecated, "
                 "as this form does not work well with modern type-checkers. "

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1156,7 +1156,7 @@ def evaluate_annotation(
     cache: dict[str, Any],
     *,
     implicit_str: bool = True,
-    code: types.CodeType | None = None,
+    source_info: types.CodeType | None = None,
 ) -> Any:
     if isinstance(tp, ForwardRef):
         tp = tp.__forward_arg__
@@ -1167,24 +1167,26 @@ def evaluate_annotation(
         if tp in cache:
             return cache[tp]
 
-        if code is not None:
+        if source_info is not None:
             # compile the annotation to add filename/line no. data for warnings & tracebacks
-            source = compile(tp, code.co_filename, "eval", dont_inherit=True)
-            source = source.replace(co_firstlineno=code.co_firstlineno)
+            source = compile(tp, source_info.co_filename, "eval", dont_inherit=True)
+            source = source.replace(co_firstlineno=source_info.co_firstlineno)
         else:
             source = tp
 
         # this is how annotations are supposed to be unstringifed
         evaluated = eval(source, globals, locals)  # noqa: S307
         # recurse to resolve nested args further
-        evaluated = evaluate_annotation(evaluated, globals, locals, cache, code=code)
+        evaluated = evaluate_annotation(evaluated, globals, locals, cache, source_info=source_info)
 
         cache[tp] = evaluated
         return evaluated
 
     # Annotated[X, Y], where Y is the converter we need
     if get_origin(tp) is Annotated:
-        return evaluate_annotation(tp.__metadata__[0], globals, locals, cache, code=code)
+        return evaluate_annotation(
+            tp.__metadata__[0], globals, locals, cache, source_info=source_info
+        )
 
     # GenericAlias / UnionType
     if hasattr(tp, "__args__"):
@@ -1192,7 +1194,9 @@ def evaluate_annotation(
             # n.b. this became obsolete in Python 3.14+, as `UnionType` and `Union` are the same thing now.
             if tp.__class__ is UnionType:
                 converted = Union[tp.__args__]  # noqa: UP007
-                return evaluate_annotation(converted, globals, locals, cache, code=code)
+                return evaluate_annotation(
+                    converted, globals, locals, cache, source_info=source_info
+                )
 
             return tp
 
@@ -1216,7 +1220,9 @@ def evaluate_annotation(
             is_literal = True
 
         evaluated_args = tuple(
-            evaluate_annotation(arg, globals, locals, cache, implicit_str=implicit_str, code=code)
+            evaluate_annotation(
+                arg, globals, locals, cache, implicit_str=implicit_str, source_info=source_info
+            )
             for arg in args
         )
 
@@ -1323,7 +1329,7 @@ def get_signature_parameters(
             annotation = type(None)
         else:
             annotation = evaluate_annotation(
-                annotation, globalns, globalns, cache, code=function.__code__
+                annotation, globalns, globalns, cache, source_info=function.__code__
             )
 
         params[name] = parameter.replace(annotation=annotation)

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1156,6 +1156,7 @@ def evaluate_annotation(
     cache: dict[str, Any],
     *,
     implicit_str: bool = True,
+    code: types.CodeType | None = None,
 ) -> Any:
     if isinstance(tp, ForwardRef):
         tp = tp.__forward_arg__
@@ -1166,17 +1167,24 @@ def evaluate_annotation(
         if tp in cache:
             return cache[tp]
 
+        if code is not None:
+            # compile the annotation to add filename/line no. data for warnings & tracebacks
+            source = compile(tp, code.co_filename, "eval", dont_inherit=True)
+            source = source.replace(co_firstlineno=code.co_firstlineno)
+        else:
+            source = tp
+
         # this is how annotations are supposed to be unstringifed
-        evaluated = eval(tp, globals, locals)  # noqa: S307
+        evaluated = eval(source, globals, locals)  # noqa: S307
         # recurse to resolve nested args further
-        evaluated = evaluate_annotation(evaluated, globals, locals, cache)
+        evaluated = evaluate_annotation(evaluated, globals, locals, cache, code=code)
 
         cache[tp] = evaluated
         return evaluated
 
     # Annotated[X, Y], where Y is the converter we need
     if get_origin(tp) is Annotated:
-        return evaluate_annotation(tp.__metadata__[0], globals, locals, cache)
+        return evaluate_annotation(tp.__metadata__[0], globals, locals, cache, code=code)
 
     # GenericAlias / UnionType
     if hasattr(tp, "__args__"):
@@ -1184,7 +1192,7 @@ def evaluate_annotation(
             # n.b. this became obsolete in Python 3.14+, as `UnionType` and `Union` are the same thing now.
             if tp.__class__ is UnionType:
                 converted = Union[tp.__args__]  # noqa: UP007
-                return evaluate_annotation(converted, globals, locals, cache)
+                return evaluate_annotation(converted, globals, locals, cache, code=code)
 
             return tp
 
@@ -1208,7 +1216,7 @@ def evaluate_annotation(
             is_literal = True
 
         evaluated_args = tuple(
-            evaluate_annotation(arg, globals, locals, cache, implicit_str=implicit_str)
+            evaluate_annotation(arg, globals, locals, cache, implicit_str=implicit_str, code=code)
             for arg in args
         )
 
@@ -1314,7 +1322,9 @@ def get_signature_parameters(
         if annotation is None:
             annotation = type(None)
         else:
-            annotation = evaluate_annotation(annotation, globalns, globalns, cache)
+            annotation = evaluate_annotation(
+                annotation, globalns, globalns, cache, code=function.__code__
+            )
 
         params[name] = parameter.replace(annotation=annotation)
 


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds extra context to `utils.evaluate_annotation` in the case of stringified annotations.
This lets warnings & tracebacks point to the function definition where the annotation was used.

```py
# dev/test_range.py
from __future__ import annotations  # comment this to disable stringification
from disnake.ext import commands

def my_command(x: commands.Range[1, 2]) -> None: ...  # pyright: ignore[reportGeneralTypeIssues]

commands.params.collect_params(my_command)
```
Present behavior (no `from __future__ import annotations`):
```bash
(disnake) PS G:\Code\disnake> uv run python .\dev\test_range.py
G:\Code\disnake\dev\test_range.py:5: DeprecationWarning: Using `Range` without an explicit type argument is deprecated ...
  def my_command(x: commands.Range[1, 2]) -> None: ...  # pyright: ignore[reportGeneralTypeIssues]
```
With `from __future__ import annotations`:
```bash
(disnake) PS G:\Code\disnake> uv run python .\dev\test_range.py
<string>:1: DeprecationWarning: Using `Range` without an explicit type argument is deprecated ...
```

With `from __future__ import annotations` and the patch from this PR:
```bash
(disnake) PS G:\Code\disnake> uv run python .\dev\test_range.py
G:\Code\disnake\dev\test_range.py:5: DeprecationWarning: Using `Range` without an explicit type argument is deprecated ...
  def my_command(x: commands.Range[1, 2]) -> None: ...  # pyright: ignore[reportGeneralTypeIssues]
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
