### PR TITLE
feat(gateway)!: support zstd transport compression

### DIFF
--- a/changelog/1558.breaking.rst
+++ b/changelog/1558.breaking.rst
@@ -1,0 +1,1 @@
+The ``zlib`` parameter of :class:`GatewayParams` has been renamed to ``compress``, with ``zlib=True`` corresponding to ``compress="zlib-stream"`` and ``zlib=False`` to ``compress=None``.

--- a/changelog/1558.feature.rst
+++ b/changelog/1558.feature.rst
@@ -1,0 +1,1 @@
+Support zstd gateway transport compression (see :class:`GatewayParams`).

--- a/changelog/1558.feature.rst
+++ b/changelog/1558.feature.rst
@@ -1,1 +1,1 @@
-Support zstd gateway transport compression (see :class:`GatewayParams`).
+Support zstd gateway transport compression (see :class:`GatewayParams`). This is now the default compression mode, if available (requires Python 3.14+, or ``backports.zstd``).

--- a/disnake/__init__.py
+++ b/disnake/__init__.py
@@ -45,6 +45,9 @@ from .enums import *
 from .errors import *
 from .file import *
 from .flags import *
+from .gateway import (
+    GatewayParams as GatewayParams,  # don't want to export everything from this module
+)
 from .guild import *
 from .guild_preview import *
 from .guild_scheduled_event import *

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -185,23 +185,27 @@ class SessionStartLimit:
         )
 
 
+# TODO: dataclass?
 class GatewayParams(NamedTuple):
     """Container type for configuring gateway connections.
 
     .. versionadded:: 2.6
+
+    .. versionchanged:: |vnext|
+        Removed ``zlib`` parameter in favour of ``compress``, which now also supports zstd.
 
     Parameters
     ----------
     encoding: :class:`str`
         The payload encoding (``json`` is currently the only supported encoding).
         Defaults to ``"json"``.
-    zlib: :class:`bool`
-        Whether to enable transport compression.
-        Defaults to ``True``.
+    compress: Literal["zlib-stream"] | :data:`None`
+        Which transport compression method to use, if any.
+        Defaults to ``"zlib-stream"``.
     """
 
     encoding: Literal["json"] = "json"
-    zlib: bool = True
+    compress: Literal["zlib-stream"] | None = "zlib-stream"
 
 
 # used for typing the ws parameter dict in the connect() loop
@@ -480,6 +484,7 @@ class Client:
         if self.gateway_params.encoding != "json":
             msg = "Gateway encodings other than `json` are currently not supported."
             raise ValueError(msg)
+        # TODO: move validation and add more
 
         self.extra_events: dict[str, list[CoroFunc]] = {}
 
@@ -1088,8 +1093,7 @@ class Client:
             and this exception will not be raised.
         """
         _, initial_gateway, session_start_limit = await self.http.get_bot_gateway(
-            encoding=self.gateway_params.encoding,
-            zlib=self.gateway_params.zlib,
+            self.gateway_params
         )
         self.session_start_limit = SessionStartLimit(session_start_limit)
 

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -10,7 +10,6 @@ import sys
 import traceback
 import types
 from collections.abc import Callable, Coroutine, Generator, Mapping, Sequence
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from errno import ECONNRESET
 from typing import (
@@ -49,7 +48,7 @@ from .errors import (
     SessionStartLimitReached,
 )
 from .flags import ApplicationFlags, Intents, MemberCacheFlags
-from .gateway import DiscordWebSocket, ReconnectWebSocket
+from .gateway import DiscordWebSocket, GatewayParams, ReconnectWebSocket
 from .guild import Guild
 from .guild_preview import GuildPreview
 from .http import HTTPClient
@@ -92,7 +91,6 @@ if TYPE_CHECKING:
 __all__ = (
     "Client",
     "SessionStartLimit",
-    "GatewayParams",
 )
 
 T = TypeVar("T")
@@ -183,37 +181,6 @@ class SessionStartLimit:
             f"<SessionStartLimit total={self.total!r} remaining={self.remaining!r} "
             f"reset_after={self.reset_after!r} max_concurrency={self.max_concurrency!r} reset_time={self.reset_time!s}>"
         )
-
-
-@dataclass(frozen=True)
-class GatewayParams:
-    """Container type for configuring gateway connections.
-
-    .. versionadded:: 2.6
-
-    .. versionchanged:: |vnext|
-        Removed ``zlib`` parameter in favour of ``compress``, which now also supports zstd.
-
-    Parameters
-    ----------
-    encoding: :class:`str`
-        The payload encoding (``json`` is currently the only supported encoding).
-        Defaults to ``"json"``.
-    compress: Literal["zlib-stream"] | :data:`None`
-        Which transport compression method to use, if any.
-        Defaults to ``"zlib-stream"``.
-    """
-
-    encoding: Literal["json"] = "json"
-    compress: Literal["zlib-stream"] | None = "zlib-stream"
-
-    def __post_init__(self) -> None:
-        if self.encoding != "json":
-            msg = "Gateway encodings other than `json` are currently not supported."
-            raise ValueError(msg)
-        if self.compress not in ("zlib-stream", None):
-            msg = "Gateway transport compression modes other than `zlib-stream` or None are currently not supported."
-            raise ValueError(msg)
 
 
 # used for typing the ws parameter dict in the connect() loop

--- a/disnake/client.py
+++ b/disnake/client.py
@@ -10,13 +10,13 @@ import sys
 import traceback
 import types
 from collections.abc import Callable, Coroutine, Generator, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from errno import ECONNRESET
 from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    NamedTuple,
     TypedDict,
     TypeVar,
     overload,
@@ -185,8 +185,8 @@ class SessionStartLimit:
         )
 
 
-# TODO: dataclass?
-class GatewayParams(NamedTuple):
+@dataclass(frozen=True)
+class GatewayParams:
     """Container type for configuring gateway connections.
 
     .. versionadded:: 2.6
@@ -206,6 +206,14 @@ class GatewayParams(NamedTuple):
 
     encoding: Literal["json"] = "json"
     compress: Literal["zlib-stream"] | None = "zlib-stream"
+
+    def __post_init__(self) -> None:
+        if self.encoding != "json":
+            msg = "Gateway encodings other than `json` are currently not supported."
+            raise ValueError(msg)
+        if self.compress not in ("zlib-stream", None):
+            msg = "Gateway transport compression modes other than `zlib-stream` or None are currently not supported."
+            raise ValueError(msg)
 
 
 # used for typing the ws parameter dict in the connect() loop
@@ -481,10 +489,6 @@ class Client:
         )
 
         self.gateway_params: GatewayParams = gateway_params or GatewayParams()
-        if self.gateway_params.encoding != "json":
-            msg = "Gateway encodings other than `json` are currently not supported."
-            raise ValueError(msg)
-        # TODO: move validation and add more
 
         self.extra_events: dict[str, list[CoroFunc]] = {}
 

--- a/disnake/ext/commands/bot.py
+++ b/disnake/ext/commands/bot.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from disnake.activity import BaseActivity
-    from disnake.client import GatewayParams
     from disnake.enums import Status
     from disnake.flags import (
         ApplicationInstallTypes,
@@ -25,6 +24,7 @@ if TYPE_CHECKING:
         InteractionContextTypes,
         MemberCacheFlags,
     )
+    from disnake.gateway import GatewayParams
     from disnake.i18n import LocalizationProtocol
     from disnake.mentions import AllowedMentions
     from disnake.message import Message

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -13,6 +13,7 @@ import traceback
 import zlib
 from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -80,11 +81,43 @@ __all__ = (
     "VoiceKeepAliveHandler",
     "DiscordVoiceWebSocket",
     "ReconnectWebSocket",
+    "GatewayParams",
 )
 
 _VOICE_VERSION = 8
 
 _log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GatewayParams:
+    """Container type for configuring gateway connections.
+
+    .. versionadded:: 2.6
+
+    .. versionchanged:: |vnext|
+        Removed ``zlib`` parameter in favour of ``compress``, which now also supports zstd.
+
+    Parameters
+    ----------
+    encoding: :class:`str`
+        The payload encoding (``json`` is currently the only supported encoding).
+        Defaults to ``"json"``.
+    compress: Literal["zlib-stream"] | :data:`None`
+        Which transport compression method to use, if any.
+        Defaults to ``"zlib-stream"``.
+    """
+
+    encoding: Literal["json"] = "json"
+    compress: Literal["zlib-stream"] | None = "zlib-stream"
+
+    def __post_init__(self) -> None:
+        if self.encoding != "json":
+            msg = "Gateway encodings other than `json` are currently not supported."
+            raise ValueError(msg)
+        if self.compress not in ("zlib-stream", None):
+            msg = "Gateway transport compression modes other than `zlib-stream` or None are currently not supported."
+            raise ValueError(msg)
 
 
 class ReconnectWebSocket(Exception):

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -108,6 +108,7 @@ class GatewayParams:
 
     .. versionchanged:: |vnext|
         Removed ``zlib`` parameter in favour of ``compress``, which now also supports zstd.
+        The default value of ``compress`` is now ``"zstd-stream"``, if available.
 
     Parameters
     ----------
@@ -116,11 +117,14 @@ class GatewayParams:
         Defaults to ``"json"``.
     compress: :data:`~typing.Literal`\[``"zlib-stream"``, ``"zstd-stream"``] | :data:`None`
         Which transport compression method to use, if any.
-        Defaults to ``"zlib-stream"``.
+        Defaults to ``"zstd-stream"`` if zstd is available, or ``"zlib-stream"`` otherwise.
     """
 
     encoding: Literal["json"] = "json"
-    compress: Literal["zlib-stream", "zstd-stream"] | None = "zlib-stream"
+    compress: Literal["zlib-stream", "zstd-stream"] | None = (
+        # prefer zstd if available
+        "zstd-stream" if HAS_ZSTD else "zlib-stream"
+    )
 
     def __post_init__(self) -> None:
         if self.encoding != "json":

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -1273,7 +1273,6 @@ class DiscordVoiceWebSocket:
 
 
 class _DecompressionContext(Protocol):
-    def __init__(self) -> None: ...
     def decompress(self, data: bytes | bytearray, /) -> bytes | None: ...
 
 

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -1289,14 +1289,18 @@ class ZlibDecompressionContext(_DecompressionContext):
         self.buffer: bytearray = bytearray()
 
     def decompress(self, data: bytes | bytearray) -> bytes | None:
-        # TODO: fast path?
-        self.buffer.extend(data)
-
         if not data.endswith(b"\x00\x00\xff\xff"):
+            # buffer data to combine with subsequent frames
+            self.buffer.extend(data)
             return None
 
-        raw_msg = self.ctx.decompress(self.buffer)
-        self.buffer = bytearray()
+        if self.buffer:
+            self.buffer.extend(data)
+            raw_msg = self.ctx.decompress(self.buffer)
+            self.buffer = bytearray()
+        else:
+            # fast path, if we have a full message without buffering, decompress directly
+            raw_msg = self.ctx.decompress(data)
         return raw_msg
 
 

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -394,8 +394,6 @@ class DiscordWebSocket:
         self.sequence: int | None = None
         # this may or may not include url parameters, we only need the host part of the url anyway
         self.resume_gateway: str | None = None
-        self._zlib: zlib._Decompress = zlib.decompressobj()
-        self._buffer: bytearray = bytearray()
         self._close_code: int | None = None
         self._rate_limiter: GatewayRatelimiter = GatewayRatelimiter()
 
@@ -404,6 +402,7 @@ class DiscordWebSocket:
         self._connection: ConnectionState
         self._discord_parsers: dict[str, Callable[[dict[str, Any]], Any]]
         self.gateway: str
+        self._decompressor: _DecompressionContext
         self.call_hooks: CallHooksFunc
         self._initial_identify: bool
         self.shard_id: int | None
@@ -463,6 +462,8 @@ class DiscordWebSocket:
         ws.session_id = session
         ws.sequence = sequence
         ws._max_heartbeat_timeout = client._connection.heartbeat_timeout
+
+        ws._decompressor = _decompressor_for_params(params)
 
         if client._enable_debug_events:
             ws.send = ws.debug_send
@@ -564,13 +565,9 @@ class DiscordWebSocket:
 
     async def received_message(self, raw_msg: str | bytes, /) -> None:
         if isinstance(raw_msg, bytes):
-            self._buffer.extend(raw_msg)
-
-            if len(raw_msg) < 4 or raw_msg[-4:] != b"\x00\x00\xff\xff":
+            if (decompressed := self._decompressor.decompress(raw_msg)) is None:
                 return
-            raw_msg = self._zlib.decompress(self._buffer)
-            raw_msg = raw_msg.decode("utf-8")
-            self._buffer = bytearray()
+            raw_msg = decompressed.decode("utf-8")
 
         self.log_receive(raw_msg)
         msg: GatewayPayload = utils._from_json(raw_msg)
@@ -1258,3 +1255,45 @@ class DiscordVoiceWebSocket:
 
         self._close_code = code
         await self.ws.close(code=code)
+
+
+class _DecompressionContext(Protocol):
+    def __init__(self) -> None: ...
+    def decompress(self, data: bytes | bytearray) -> bytes | None: ...
+
+
+# In practice, this won't be used. Disabling compression skips the
+# decompressor branch entirely.
+class NullDecompressionContext(_DecompressionContext):
+    def __init__(self) -> None:
+        pass
+
+    def decompress(self, data: bytes | bytearray) -> bytes | None:
+        return bytes(data)
+
+
+class ZlibDecompressionContext(_DecompressionContext):
+    def __init__(self) -> None:
+        self.inflator: zlib._Decompress = zlib.decompressobj()
+        self.buffer: bytearray = bytearray()
+
+    def decompress(self, data: bytes | bytearray) -> bytes | None:
+        # TODO: fast path?
+        self.buffer.extend(data)
+
+        if not data.endswith(b"\x00\x00\xff\xff"):
+            return None
+
+        raw_msg = self.inflator.decompress(self.buffer)
+        self.buffer = bytearray()
+        return raw_msg
+
+
+def _decompressor_for_params(params: GatewayParams) -> _DecompressionContext:
+    tp: type[_DecompressionContext]
+    match params.compress:
+        case "zlib-stream":
+            tp = ZlibDecompressionContext
+        case None:
+            tp = NullDecompressionContext
+    return tp()

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -102,7 +102,7 @@ _log = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class GatewayParams:
-    """Container type for configuring gateway connections.
+    r"""Container type for configuring gateway connections.
 
     .. versionadded:: 2.6
 
@@ -111,10 +111,10 @@ class GatewayParams:
 
     Parameters
     ----------
-    encoding: :class:`str`
+    encoding: :data:`~typing.Literal`\[``"json"``]
         The payload encoding (``json`` is currently the only supported encoding).
         Defaults to ``"json"``.
-    compress: Literal["zlib-stream", "zstd-stream"] | :data:`None`
+    compress: :data:`~typing.Literal`\[``"zlib-stream"``, ``"zstd-stream"``] | :data:`None`
         Which transport compression method to use, if any.
         Defaults to ``"zlib-stream"``.
     """

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -1307,7 +1307,7 @@ class ZlibDecompressionContext(_DecompressionContext):
 class ZstdDecompressionContext(_DecompressionContext):
     def __init__(self) -> None:
         if not HAS_ZSTD:
-            msg = "The `backports.zstd` package is required to use zstd transport compression"
+            msg = "Python 3.14 or the `backports.zstd` package is required to use zstd transport compression"
             raise RuntimeError(msg)
 
         self.ctx: zstd.ZstdDecompressor = zstd.ZstdDecompressor()  # pyright: ignore[reportPossiblyUnboundVariable]

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -408,13 +408,9 @@ class DiscordWebSocket:
         """
         params = client.gateway_params
         if gateway:
-            gateway = client.http._format_gateway_url(
-                gateway,
-                encoding=params.encoding,
-                zlib=params.zlib,
-            )
+            gateway = client.http._format_gateway_url(gateway, params=params)
         else:
-            gateway = await client.http.get_gateway(encoding=params.encoding, zlib=params.zlib)
+            gateway = await client.http.get_gateway(params)
 
         socket = await client.http.ws_connect(gateway)
         ws = cls(socket, loop=client.loop)

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -1274,7 +1274,7 @@ class DiscordVoiceWebSocket:
 
 class _DecompressionContext(Protocol):
     def __init__(self) -> None: ...
-    def decompress(self, data: bytes | bytearray) -> bytes | None: ...
+    def decompress(self, data: bytes | bytearray, /) -> bytes | None: ...
 
 
 # In practice, this won't be used. Disabling compression skips the
@@ -1283,7 +1283,7 @@ class NullDecompressionContext(_DecompressionContext):
     def __init__(self) -> None:
         pass
 
-    def decompress(self, data: bytes | bytearray) -> bytes | None:
+    def decompress(self, data: bytes | bytearray, /) -> bytes | None:
         return bytes(data)
 
 
@@ -1292,7 +1292,7 @@ class ZlibDecompressionContext(_DecompressionContext):
         self.ctx: zlib._Decompress = zlib.decompressobj()
         self.buffer: bytearray = bytearray()
 
-    def decompress(self, data: bytes | bytearray) -> bytes | None:
+    def decompress(self, data: bytes | bytearray, /) -> bytes | None:
         if not data.endswith(b"\x00\x00\xff\xff"):
             # buffer data to combine with subsequent frames
             self.buffer.extend(data)
@@ -1316,7 +1316,7 @@ class ZstdDecompressionContext(_DecompressionContext):
 
         self.ctx: zstd.ZstdDecompressor = zstd.ZstdDecompressor()  # pyright: ignore[reportPossiblyUnboundVariable]
 
-    def decompress(self, data: bytes | bytearray) -> bytes | None:
+    def decompress(self, data: bytes | bytearray, /) -> bytes | None:
         # "each websocket message corresponds to a single gateway message, but does not end a zstd frame"
         return self.ctx.decompress(data)
 

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -1311,7 +1311,7 @@ class ZlibDecompressionContext(_DecompressionContext):
 class ZstdDecompressionContext(_DecompressionContext):
     def __init__(self) -> None:
         if not HAS_ZSTD:
-            msg = "Python 3.14 or the `backports.zstd` package is required to use zstd transport compression"
+            msg = "Python 3.14+ or the `backports.zstd` package is required to use zstd transport compression"
             raise RuntimeError(msg)
 
         self.ctx: zstd.ZstdDecompressor = zstd.ZstdDecompressor()  # pyright: ignore[reportPossiblyUnboundVariable]

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -75,6 +75,17 @@ if TYPE_CHECKING:
         async def __call__(self, *args: Any) -> None: ...
 
 
+try:
+    if sys.version_info >= (3, 14):
+        from compression import zstd
+    else:
+        from backports import zstd
+except ImportError:
+    HAS_ZSTD = False
+else:
+    HAS_ZSTD = True
+
+
 __all__ = (
     "DiscordWebSocket",
     "KeepAliveHandler",
@@ -103,20 +114,20 @@ class GatewayParams:
     encoding: :class:`str`
         The payload encoding (``json`` is currently the only supported encoding).
         Defaults to ``"json"``.
-    compress: Literal["zlib-stream"] | :data:`None`
+    compress: Literal["zlib-stream", "zstd-stream"] | :data:`None`
         Which transport compression method to use, if any.
         Defaults to ``"zlib-stream"``.
     """
 
     encoding: Literal["json"] = "json"
-    compress: Literal["zlib-stream"] | None = "zlib-stream"
+    compress: Literal["zlib-stream", "zstd-stream"] | None = "zlib-stream"
 
     def __post_init__(self) -> None:
         if self.encoding != "json":
             msg = "Gateway encodings other than `json` are currently not supported."
             raise ValueError(msg)
-        if self.compress not in ("zlib-stream", None):
-            msg = "Gateway transport compression modes other than `zlib-stream` or None are currently not supported."
+        if self.compress not in ("zlib-stream", "zstd-stream", None):
+            msg = "Gateway transport compression modes other than `zlib-stream`, `zstd-stream`, or None are currently not supported."
             raise ValueError(msg)
 
 
@@ -1274,7 +1285,7 @@ class NullDecompressionContext(_DecompressionContext):
 
 class ZlibDecompressionContext(_DecompressionContext):
     def __init__(self) -> None:
-        self.inflator: zlib._Decompress = zlib.decompressobj()
+        self.ctx: zlib._Decompress = zlib.decompressobj()
         self.buffer: bytearray = bytearray()
 
     def decompress(self, data: bytes | bytearray) -> bytes | None:
@@ -1284,9 +1295,22 @@ class ZlibDecompressionContext(_DecompressionContext):
         if not data.endswith(b"\x00\x00\xff\xff"):
             return None
 
-        raw_msg = self.inflator.decompress(self.buffer)
+        raw_msg = self.ctx.decompress(self.buffer)
         self.buffer = bytearray()
         return raw_msg
+
+
+class ZstdDecompressionContext(_DecompressionContext):
+    def __init__(self) -> None:
+        if not HAS_ZSTD:
+            msg = "The `backports.zstd` package is required to use zstd transport compression"
+            raise RuntimeError(msg)
+
+        self.ctx: zstd.ZstdDecompressor = zstd.ZstdDecompressor()  # pyright: ignore[reportPossiblyUnboundVariable]
+
+    def decompress(self, data: bytes | bytearray) -> bytes | None:
+        # "each websocket message corresponds to a single gateway message, but does not end a zstd frame"
+        return self.ctx.decompress(data)
 
 
 def _decompressor_for_params(params: GatewayParams) -> _DecompressionContext:
@@ -1294,6 +1318,8 @@ def _decompressor_for_params(params: GatewayParams) -> _DecompressionContext:
     match params.compress:
         case "zlib-stream":
             tp = ZlibDecompressionContext
+        case "zstd-stream":
+            tp = ZstdDecompressionContext
         case None:
             tp = NullDecompressionContext
     return tp()

--- a/disnake/gateway.py
+++ b/disnake/gateway.py
@@ -1300,7 +1300,7 @@ class ZlibDecompressionContext(_DecompressionContext):
         if self.buffer:
             self.buffer.extend(data)
             raw_msg = self.ctx.decompress(self.buffer)
-            self.buffer = bytearray()
+            self.buffer.clear()
         else:
             # fast path, if we have a full message without buffering, decompress directly
             raw_msg = self.ctx.decompress(data)

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -22,7 +22,7 @@ from urllib.parse import quote as _uriquote
 import aiohttp
 import yarl
 
-from . import __version__, client, utils
+from . import __version__, utils
 from .errors import (
     DiscordServerError,
     Forbidden,
@@ -31,7 +31,7 @@ from .errors import (
     LoginFailure,
     NotFound,
 )
-from .gateway import DiscordClientWebSocketResponse
+from .gateway import DiscordClientWebSocketResponse, GatewayParams
 from .utils import MISSING
 
 _log = logging.getLogger(__name__)
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    from .client import GatewayParams
     from .enums import InteractionResponseType
     from .file import File
     from .message import Attachment
@@ -3060,7 +3059,7 @@ class HTTPClient:
 
     @staticmethod
     def _format_gateway_url(url: str, *, params: GatewayParams | None) -> str:
-        params = params or client.GatewayParams()
+        params = params or GatewayParams()
 
         _url = yarl.URL(url)
         query = _url.query.copy()

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -22,7 +22,7 @@ from urllib.parse import quote as _uriquote
 import aiohttp
 import yarl
 
-from . import __version__, utils
+from . import __version__, client, utils
 from .errors import (
     DiscordServerError,
     Forbidden,
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    from .client import GatewayParams
     from .enums import InteractionResponseType
     from .file import File
     from .message import Attachment
@@ -3035,16 +3036,16 @@ class HTTPClient:
             json=records,
         )
 
-    async def get_gateway(self, *, encoding: str = "json", zlib: bool = True) -> str:
+    async def get_gateway(self, params: GatewayParams | None = None) -> str:
         try:
             data: gateway.Gateway = await self.request(Route("GET", "/gateway"))
         except HTTPException as exc:
             raise GatewayNotFound from exc
 
-        return self._format_gateway_url(data["url"], encoding=encoding, zlib=zlib)
+        return self._format_gateway_url(data["url"], params=params)
 
     async def get_bot_gateway(
-        self, *, encoding: str = "json", zlib: bool = True
+        self, params: GatewayParams | None = None
     ) -> tuple[int, str, gateway.SessionStartLimit]:
         try:
             data: gateway.GatewayBot = await self.request(Route("GET", "/gateway/bot"))
@@ -3053,21 +3054,24 @@ class HTTPClient:
 
         return (
             data["shards"],
-            self._format_gateway_url(data["url"], encoding=encoding, zlib=zlib),
+            self._format_gateway_url(data["url"], params=params),
             data["session_start_limit"],
         )
 
     @staticmethod
-    def _format_gateway_url(url: str, *, encoding: str, zlib: bool) -> str:
+    def _format_gateway_url(url: str, *, params: GatewayParams | None) -> str:
+        params = params or client.GatewayParams()
+
         _url = yarl.URL(url)
-        params = _url.query.copy()
-        params["v"] = str(_API_VERSION)
-        params["encoding"] = encoding
-        if zlib:
-            params["compress"] = "zlib-stream"
+        query = _url.query.copy()
+        query["v"] = str(_API_VERSION)
+        query["encoding"] = params.encoding
+        if params.compress:
+            query["compress"] = params.compress
         else:
-            params.popall("compress", None)
-        return str(_url.with_query(params))
+            query.popall("compress", None)
+
+        return str(_url.with_query(query))
 
     def get_user(self, user_id: Snowflake) -> Response[user.User]:
         return self.request(Route("GET", "/users/{user_id}", user_id=user_id))

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -17,7 +17,7 @@ from typing import (
 import aiohttp
 
 from .backoff import ExponentialBackoff
-from .client import Client, GatewayParams, SessionStartLimit
+from .client import Client, SessionStartLimit
 from .enums import Status
 from .errors import (
     ClientException,
@@ -27,7 +27,7 @@ from .errors import (
     PrivilegedIntentsRequired,
     SessionStartLimitReached,
 )
-from .gateway import DiscordWebSocket, ReconnectWebSocket
+from .gateway import DiscordWebSocket, GatewayParams, ReconnectWebSocket
 from .state import AutoShardedConnectionState
 
 if TYPE_CHECKING:

--- a/disnake/shard.py
+++ b/disnake/shard.py
@@ -467,8 +467,7 @@ class AutoShardedClient(Client):
 
     async def launch_shards(self, *, ignore_session_start_limit: bool = False) -> None:
         shard_count, gateway, session_start_limit = await self.http.get_bot_gateway(
-            encoding=self.gateway_params.encoding,
-            zlib=self.gateway_params.zlib,
+            self.gateway_params
         )
 
         self.session_start_limit = SessionStartLimit(session_start_limit)

--- a/docs/api/clients.rst
+++ b/docs/api/clients.rst
@@ -76,8 +76,6 @@ GatewayParams
 .. attributetable:: GatewayParams
 
 .. autoclass:: GatewayParams()
-    :members:
-    :exclude-members: encoding, zlib
 
 Intents
 ~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Repository = "https://github.com/DisnakeDev/disnake"
 speed = [
     "orjson~=3.6",
     "aiohttp[speedups]",
+    'backports.zstd; python_version < "3.14"',
 ]
 voice = [
     "PyNaCl>=1.5.0,<1.7",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -19,6 +19,11 @@ from disnake.http import HTTPClient
             disnake.GatewayParams(encoding="json", compress="zlib-stream"),
             "wss://gateway.discord.com/?v=10&encoding=json&compress=zlib-stream",
         ),
+        (
+            "wss://gateway.discord.com",
+            disnake.GatewayParams(encoding="json", compress="zstd-stream"),
+            "wss://gateway.discord.com/?v=10&encoding=json&compress=zstd-stream",
+        ),
         # should overwrite existing args if needed
         (
             "wss://gateway.discord.com/?v=42&encoding=etf&v=1111",
@@ -31,7 +36,7 @@ from disnake.http import HTTPClient
             disnake.GatewayParams(encoding="json", compress="zlib-stream"),
             "wss://gateway.discord.com/?v=10&stuff=things&a=b&encoding=json&compress=zlib-stream",
         ),
-        # should remove compression if set to false
+        # should remove compression if set to None
         (
             "wss://gateway.discord.com/?v=10&compress=zlib-stream",
             disnake.GatewayParams(encoding="json", compress=None),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -2,46 +2,42 @@
 
 import pytest
 
+import disnake
 from disnake.http import HTTPClient
 
 
 @pytest.mark.parametrize(
-    ("url", "encoding", "zlib", "expected"),
+    ("url", "params", "expected"),
     [
         (
             "wss://gateway.discord.com",
-            "json",
-            False,
+            disnake.GatewayParams(encoding="json", compress=None),
             "wss://gateway.discord.com/?v=10&encoding=json",
         ),
         (
             "wss://gateway.discord.com",
-            "json",
-            True,
+            disnake.GatewayParams(encoding="json", compress="zlib-stream"),
             "wss://gateway.discord.com/?v=10&encoding=json&compress=zlib-stream",
         ),
         # should overwrite existing args if needed
         (
             "wss://gateway.discord.com/?v=42&encoding=etf&v=1111",
-            "json",
-            True,
+            disnake.GatewayParams(encoding="json", compress="zlib-stream"),
             "wss://gateway.discord.com/?v=10&encoding=json&compress=zlib-stream",
         ),
         # should keep other args intact
         (
             "wss://gateway.discord.com/?v=42&stuff=things&a=b",
-            "json",
-            True,
+            disnake.GatewayParams(encoding="json", compress="zlib-stream"),
             "wss://gateway.discord.com/?v=10&stuff=things&a=b&encoding=json&compress=zlib-stream",
         ),
         # should remove compression if set to false
         (
             "wss://gateway.discord.com/?v=10&compress=zlib-stream",
-            "json",
-            False,
+            disnake.GatewayParams(encoding="json", compress=None),
             "wss://gateway.discord.com/?v=10&encoding=json",
         ),
     ],
 )
-def test_format_gateway_url(url: str, encoding: str, zlib: bool, expected: str) -> None:
-    assert HTTPClient._format_gateway_url(url, encoding=encoding, zlib=zlib) == expected
+def test_format_gateway_url(url: str, params: disnake.GatewayParams, expected: str) -> None:
+    assert HTTPClient._format_gateway_url(url, params=params) == expected


### PR DESCRIPTION
## Summary

Adds support for `zstd-stream` transport compression in gateway connections, in addition to the usual `zlib-stream`, and uses it as the default compression method if available.

This uses the builtin [`compression.zstd`](https://docs.python.org/3/library/compression.zstd.html#module-compression.zstd) module on Python 3.14+, or optionally [`backports.zstd`](https://pypi.org/project/backports.zstd/) on earlier Python versions, which is now also part of `disnake[speed]` (would've been included by `aiohttp[speedups]` already anyway),.

At least based on some rudimentary benchmarking and publicly available comparisons, zstd should achieve a little better compression and is a fair bit faster.
Running this branch with two instances of one of my bots in prod at the same time for ~5 minutes, one with each compression mode:
|  | compressed (bytes) | (uncompressed (bytes)) | decompress time (ms) |
|--------|--------|--------|--------|
| zlib-stream | 4272080 | (32234978) | 126.0311 |
| zstd-stream | 4037587 | (32233882) | 71.9549 |

The one minor disadvantage is potentially slightly higher memory usage due to larger lookback buffers, but only to a very limited and negligible degree, especially since it scales linearly with the number of shards.

https://docs.discord.com/developers/events/gateway#zstd-stream

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
