### PR TITLE
fix(guild): add gradient color parameters to `create_role` overloads

### DIFF
--- a/disnake/guild.py
+++ b/disnake/guild.py
@@ -3865,28 +3865,34 @@ class Guild(Hashable):
     async def create_role(
         self,
         *,
-        reason: str | None = ...,
         name: str = ...,
         permissions: Permissions = ...,
         colour: Colour | int = ...,
+        primary_colour: Colour | int = ...,
+        secondary_colour: Colour | int | None = ...,
+        tertiary_colour: Colour | int | None = ...,
         hoist: bool = ...,
         icon: AssetBytes = ...,
         emoji: str = ...,
         mentionable: bool = ...,
+        reason: str | None = None,
     ) -> Role: ...
 
     @overload
     async def create_role(
         self,
         *,
-        reason: str | None = ...,
         name: str = ...,
         permissions: Permissions = ...,
         color: Colour | int = ...,
+        primary_color: Colour | int = ...,
+        secondary_color: Colour | int | None = ...,
+        tertiary_color: Colour | int | None = ...,
         hoist: bool = ...,
         icon: AssetBytes = ...,
         emoji: str = ...,
         mentionable: bool = ...,
+        reason: str | None = None,
     ) -> Role: ...
 
     async def create_role(


### PR DESCRIPTION
## Summary

Adds missing color parameters to the `create_role` overloads. Seems like this is the only case of parameters being in the implementation signature but in none of the overloads, though (silly little script I used to check [here](https://gist.github.com/shiftinv/715a5e71dfb3ec019189f15623cca449)).

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
