### PR TITLE
ci: don't silence `uv sync` output

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -200,7 +200,7 @@ def install_deps(session: nox.Session, *, execution_group: ExecutionGroup | None
     session.run_install(
         *command,
         env=env,
-        silent=True,
+        silent=not CI,
     )
 
     if execution_group.dependencies:


### PR DESCRIPTION
## Summary

Not being able to see which specific dependency versions CI runs are using has sometimes made it more difficult to reproduce certain CI failures in the past.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
