### PR TITLE
fix(docs): restore support for localization in attributetable

### DIFF
--- a/changelog/1563.bugfix.rst
+++ b/changelog/1563.bugfix.rst
@@ -1,1 +1,0 @@
-Fix :class:`RuntimeError` when building translated documentation due to ``badge-type`` values being translated in the ``attributetable.py`` Sphinx extension.

--- a/changelog/1563.bugfix.rst
+++ b/changelog/1563.bugfix.rst
@@ -1,0 +1,1 @@
+Fix :class:`RuntimeError` when building translated documentation due to ``badge-type`` values being translated in the ``attributetable.py`` Sphinx extension.

--- a/changelog/1565.doc.rst
+++ b/changelog/1565.doc.rst
@@ -1,0 +1,1 @@
+Restore support for localization in ``attributetable`` extension.

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1221,7 +1221,7 @@ main .py-attribute-table-column > ul {
   text-decoration: none;
 }
 
-.py-attribute-table-list :where(.badge-coroutine, .badge-method, .badge-decorator, .badge-classmethod) {
+.py-attribute-table-badge {
   flex-basis: 3em;
   text-align: right;
   font-size: 0.9em;

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -59,13 +59,10 @@ def visit_attributetabletitle_node(self: HTMLTranslator, node: nodes.Element) ->
 
 
 def visit_attributetablebadge_node(self: HTMLTranslator, node: nodes.Element) -> None:
-    """Add a class to each badge of the type that it is."""
-    badge_type: str = node["badge-type"]
-    if badge_type not in ("coroutine", "decorator", "method", "classmethod"):
-        msg = f"badge_type {badge_type} is currently unsupported"
-        raise RuntimeError(msg)
     attributes = {
-        "class": f"badge-{badge_type}",
+        "class": "py-attribute-table-badge",
+        # note: in localized documentation builds, this will be an already translated string
+        "title": node["badge-type"],
     }
     self.body.append(self.starttag(node, "span", **attributes))  # pyright: ignore[reportArgumentType]
 
@@ -127,7 +124,7 @@ class PyAttributeTable(SphinxDirective):
                 <span>_('Attributes')</span>
                 <ul>
                     <li>
-                        <a href="...">
+                        <a href="..."></a>
                     </li>
                 </ul>
             </div>
@@ -135,8 +132,8 @@ class PyAttributeTable(SphinxDirective):
                 <span>_('Methods')</span>
                 <ul>
                     <li>
+                        <span class="py-attribute-table-badge" title="decorator">D</span>
                         <a href="..."></a>
-                        <span class="py-attribute-badge" title="decorator">D</span>
                     </li>
                 </ul>
             </div>

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -243,22 +243,22 @@ def get_class_results(
             if inspect.iscoroutinefunction(value) or doc.startswith("|coro|"):
                 key = _("Methods")
                 badge = attributetablebadge("async", "async")
-                badge["badge-type"] = _("coroutine")
+                badge["badge-type"] = "coroutine"
             elif isinstance(value, classmethod):
                 key = _("Methods")
                 label = f"{name}.{attr}"
                 badge = attributetablebadge("cls", "cls")
-                badge["badge-type"] = _("classmethod")
+                badge["badge-type"] = "classmethod"
             elif inspect.isfunction(value):
                 if doc.lstrip().startswith(("A decorator", "A shortcut decorator")):
                     # finicky but surprisingly consistent
                     badge = attributetablebadge("@", "@")
-                    badge["badge-type"] = _("decorator")
+                    badge["badge-type"] = "decorator"
                     key = _("Methods")
                 else:
                     key = _("Methods")
                     badge = attributetablebadge("def", "def")
-                    badge["badge-type"] = _("method")
+                    badge["badge-type"] = "method"
 
         groups[key].append(TableElement(fullname=attrlookup, label=label, badge=badge))
 

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -243,22 +243,22 @@ def get_class_results(
             if inspect.iscoroutinefunction(value) or doc.startswith("|coro|"):
                 key = _("Methods")
                 badge = attributetablebadge("async", "async")
-                badge["badge-type"] = "coroutine"
+                badge["badge-type"] = _("coroutine")
             elif isinstance(value, classmethod):
                 key = _("Methods")
                 label = f"{name}.{attr}"
                 badge = attributetablebadge("cls", "cls")
-                badge["badge-type"] = "classmethod"
+                badge["badge-type"] = _("classmethod")
             elif inspect.isfunction(value):
                 if doc.lstrip().startswith(("A decorator", "A shortcut decorator")):
                     # finicky but surprisingly consistent
                     badge = attributetablebadge("@", "@")
-                    badge["badge-type"] = "decorator"
+                    badge["badge-type"] = _("decorator")
                     key = _("Methods")
                 else:
                     key = _("Methods")
                     badge = attributetablebadge("def", "def")
-                    badge["badge-type"] = "method"
+                    badge["badge-type"] = _("method")
 
         groups[key].append(TableElement(fullname=attrlookup, label=label, badge=badge))
 


### PR DESCRIPTION
## Summary

selector specifity is the same as before (0,1,0), so this should be fine

Close: #1563 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
