### PR TITLE
fix(typing): allow `ForwardedMessage` in `components_from_message` and similar methods

### DIFF
--- a/disnake/ui/_types.py
+++ b/disnake/ui/_types.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, TypeAlias, Union
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, Union
 
 from typing_extensions import ParamSpec, TypeVar
 
 if TYPE_CHECKING:
     from typing import TypeAlias
 
+    from ..components import MessageTopLevelComponent as MessageTopLevelRawComponent
     from . import (
         ActionRow,
         Button,
@@ -97,3 +98,8 @@ ModalComponents = ComponentInput[
     ActionRowModalComponent,  # deprecated
     ModalTopLevelComponent_,
 ]
+
+
+class MessageWithComponents(Protocol):
+    @property
+    def components(self) -> Sequence[MessageTopLevelRawComponent]: ...

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     from ..abc import AnyChannel
     from ..emoji import Emoji
     from ..member import Member
-    from ..message import Message
+    from ..message import ForwardedMessage, Message
     from ..partial_emoji import PartialEmoji
     from ..role import Role
     from ..types.components import (
@@ -877,7 +877,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildDefaultT]):
     @classmethod
     def rows_from_message(
         cls,
-        message: Message,
+        message: Message | ForwardedMessage,
         *,
         strict: bool = True,
     ) -> list[ActionRow[ActionRowMessageComponent]]:
@@ -895,7 +895,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildDefaultT]):
 
         Parameters
         ----------
-        message: :class:`disnake.Message`
+        message: :class:`~disnake.Message` | :class:`~disnake.ForwardedMessage`
             The message from which to extract the components.
         strict: :class:`bool`
             Whether or not to raise an exception if an unknown component type is encountered.
@@ -1096,7 +1096,7 @@ def walk_components(components: Sequence[ComponentT]) -> Iterator[ComponentT]:
         yield from _walk_internal(item, seen)
 
 
-def components_from_message(message: Message) -> list[MessageTopLevelComponent]:
+def components_from_message(message: Message | ForwardedMessage) -> list[MessageTopLevelComponent]:
     r"""Create a list of :class:`UIComponent`\s from the components of an existing message.
 
     This will abide by existing component format on the message, including component
@@ -1107,7 +1107,7 @@ def components_from_message(message: Message) -> list[MessageTopLevelComponent]:
 
     Parameters
     ----------
-    message: :class:`disnake.Message`
+    message: :class:`~disnake.Message` | :class:`~disnake.ForwardedMessage`
         The message from which to extract the components.
 
     Raises

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -50,6 +50,7 @@ from ._types import (
     ActionRowModalComponent,
     ComponentInput,
     MessageTopLevelComponent,
+    MessageWithComponents,
     NonActionRowChildT,
 )
 from .button import Button
@@ -77,7 +78,6 @@ if TYPE_CHECKING:
     from ..abc import AnyChannel
     from ..emoji import Emoji
     from ..member import Member
-    from ..message import ForwardedMessage, Message
     from ..partial_emoji import PartialEmoji
     from ..role import Role
     from ..types.components import (
@@ -877,7 +877,7 @@ class ActionRow(UIComponent, Generic[ActionRowChildDefaultT]):
     @classmethod
     def rows_from_message(
         cls,
-        message: Message | ForwardedMessage,
+        message: MessageWithComponents,
         *,
         strict: bool = True,
     ) -> list[ActionRow[ActionRowMessageComponent]]:
@@ -1096,7 +1096,7 @@ def walk_components(components: Sequence[ComponentT]) -> Iterator[ComponentT]:
         yield from _walk_internal(item, seen)
 
 
-def components_from_message(message: Message | ForwardedMessage) -> list[MessageTopLevelComponent]:
+def components_from_message(message: MessageWithComponents) -> list[MessageTopLevelComponent]:
     r"""Create a list of :class:`UIComponent`\s from the components of an existing message.
 
     This will abide by existing component format on the message, including component

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -32,9 +32,9 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from ..interactions import MessageInteraction
-    from ..message import ForwardedMessage, Message
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
+    from ._types import MessageWithComponents
     from .item import ItemCallbackType
 
 
@@ -195,7 +195,7 @@ class View:
 
     @classmethod
     def from_message(
-        cls, message: Message | ForwardedMessage, /, *, timeout: float | None = 180.0
+        cls, message: MessageWithComponents, /, *, timeout: float | None = 180.0
     ) -> View:
         """Converts a message's components into a :class:`View`.
 

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from ..interactions import MessageInteraction
-    from ..message import Message
+    from ..message import ForwardedMessage, Message
     from ..state import ConnectionState
     from ..types.components import ActionRow as ActionRowPayload, Component as ComponentPayload
     from .item import ItemCallbackType
@@ -194,7 +194,9 @@ class View:
         return components
 
     @classmethod
-    def from_message(cls, message: Message, /, *, timeout: float | None = 180.0) -> View:
+    def from_message(
+        cls, message: Message | ForwardedMessage, /, *, timeout: float | None = 180.0
+    ) -> View:
         """Converts a message's components into a :class:`View`.
 
         The :attr:`.Message.components` of a message are read-only
@@ -204,7 +206,7 @@ class View:
 
         Parameters
         ----------
-        message: :class:`disnake.Message`
+        message: :class:`~disnake.Message` | :class:`~disnake.ForwardedMessage`
             The message with components to convert into a view.
         timeout: :class:`float` | :data:`None`
             The timeout of the converted view.


### PR DESCRIPTION
## Summary

Adds support for `ForwardedMessage` to `ActionRow.rows_from_message`, `components_from_message`, and `View.from_message`. This already worked perfectly fine at runtime, but showed a type-checker error due to an overly restrictive param type.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
