### PR TITLE
feat(interactions): return callback data from interaction response methods

### DIFF
--- a/changelog/1571.breaking.rst
+++ b/changelog/1571.breaking.rst
@@ -1,0 +1,1 @@
+Applicable :class:`InteractionResponse` methods (e.g. :meth:`~InteractionResponse.send_message`), as well as :meth:`Interaction.send`, now return an :class:`InteractionCallbackResponse` object instead of :data:`None`.

--- a/changelog/1571.feature.rst
+++ b/changelog/1571.feature.rst
@@ -1,0 +1,1 @@
+Return :class:`InteractionCallbackResponse` from applicable :class:`InteractionResponse` methods (e.g. :meth:`~InteractionResponse.send_message`), providing information about the affected resource.

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -2721,7 +2721,7 @@ class HTTPClient:
         token: str,
         *,
         type: InteractionResponseType,
-        data: interactions.InteractionCallbackData | None = None,
+        data: interactions.InteractionResponseData | None = None,
     ) -> Response[None]:
         r = Route(
             "POST",

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -806,39 +806,43 @@ class Interaction(Generic[ClientT]):
 
             .. versionadded:: |vnext|
         """
-        if self.response._response_type is not None:
-            # workaround for types not correctly representing the fact that `wait` is
-            # always implicitly true for interaction followups
-            if TYPE_CHECKING:
-                from functools import partial
-
-                sender = partial(self.followup.send, wait=True)
-            else:
-                sender = self.followup.send
+        if self.response._response_type is None:
+            callback_response = await self.response.send_message(
+                content=content,
+                embed=embed,
+                embeds=embeds,
+                file=file,
+                files=files,
+                view=view,
+                components=components,
+                tts=tts,
+                ephemeral=ephemeral,
+                suppress_embeds=suppress_embeds,
+                flags=flags,
+                poll=poll,
+                allowed_mentions=allowed_mentions,
+                delete_after=delete_after,
+            )
+            return callback_response.resource
         else:
-            sender = self.response.send_message
-
-        res = await sender(
-            content=content,
-            embed=embed,
-            embeds=embeds,
-            file=file,
-            files=files,
-            allowed_mentions=allowed_mentions,
-            view=view,
-            components=components,
-            tts=tts,
-            ephemeral=ephemeral,
-            suppress_embeds=suppress_embeds,
-            flags=flags,
-            delete_after=delete_after,
-            poll=poll,
-        )
-
-        if isinstance(res, InteractionCallbackResponse):
-            return res.resource
-        else:
-            return res
+            return await self.followup.send(
+                content=content,
+                embed=embed,
+                embeds=embeds,
+                file=file,
+                files=files,
+                view=view,
+                components=components,
+                tts=tts,
+                ephemeral=ephemeral,
+                suppress_embeds=suppress_embeds,
+                flags=flags,
+                poll=poll,
+                allowed_mentions=allowed_mentions,
+                delete_after=delete_after,
+                # this is already implicitly true for interactions, but specified here for typing purposes
+                wait=True,
+            )
 
 
 class InteractionResponse:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -800,6 +800,12 @@ class Interaction(Generic[ClientT]):
         ValueError
             The length of ``embeds`` was invalid, or
             you tried to send v2 components together with ``content``, ``embeds``, or ``poll``.
+
+        Returns
+        -------
+        :class:`InteractionCallbackResponse` | :class:`WebhookMessage`
+            The callback response data if the interaction hadn't been responded to yet,
+            or the message if this was sent as a followup.
         """
         if self.response._response_type is not None:
             # workaround for types not correctly representing the fact that `wait` is
@@ -870,7 +876,7 @@ class InteractionResponse:
         *,
         with_message: bool = MISSING,
         ephemeral: bool = MISSING,
-    ) -> InteractionCallbackResponse[Message | None]:  # TODO: document return type everywhere
+    ) -> InteractionCallbackResponse[Message | None]:
         """|coro|
 
         Defers the interaction response.
@@ -916,6 +922,11 @@ class InteractionResponse:
             This interaction has already been responded to before.
         TypeError
             This interaction cannot be deferred.
+
+        Returns
+        -------
+        :class:`InteractionCallbackResponse`
+            The callback response data. If ``with_message=True``, this also contains a message resource.
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1089,6 +1100,11 @@ class InteractionResponse:
             you tried to send v2 components together with ``content``, ``embeds``, or ``poll``.
         InteractionResponded
             This interaction has already been responded to before.
+
+        Returns
+        -------
+        :class:`InteractionCallbackResponse`
+            The callback response data, with a message resource.
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1314,6 +1330,11 @@ class InteractionResponse:
             You tried to send v2 components together with ``content`` or ``embeds``.
         InteractionResponded
             This interaction has already been responded to before.
+
+        Returns
+        -------
+        :class:`InteractionCallbackResponse`
+            The callback response data, with a message resource.
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1446,6 +1467,11 @@ class InteractionResponse:
             Autocomplete response has failed.
         InteractionResponded
             This interaction has already been responded to before.
+
+        Returns
+        -------
+        :class:`InteractionCallbackResponse`
+            The callback response data.
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1551,6 +1577,11 @@ class InteractionResponse:
             This interaction cannot be responded with a modal.
         InteractionResponded
             This interaction has already been responded to before.
+
+        Returns
+        -------
+        :class:`InteractionCallbackResponse`
+            The callback response data.
         """
         if modal is not None and any((title, components, custom_id)):
             msg = "Cannot mix modal argument and title, custom_id, components arguments"
@@ -2194,7 +2225,26 @@ ResourceT = TypeVar("ResourceT", bound=Message | None, default=Message | None, c
 
 
 class InteractionCallbackResponse(Generic[ResourceT]):
-    """TODO"""
+    """Represents the response data from sending an interaction callback,
+    e.g. using :meth:`InteractionResponse.send_message`.
+
+    .. versionadded:: |vnext|
+
+    Attributes
+    ----------
+    id: :class:`int`
+        The ID of the source interaction.
+    message_id: :class:`int` | :data:`None`
+        The ID of the message that was affected (i.e. created or edited) by the
+        interaction response, if any.
+    message_loading: :class:`bool` | :data:`None`
+        Whether the message is in a :attr:`~MessageFlags.loading` state.
+    message_ephemeral: :class:`bool` | :data:`None`
+        Whether the message is :attr:`~MessageFlags.ephemeral`.
+    resource: :class:`Message` | :data:`None`
+        The resource that was created (or edited) by the interaction response, if any.
+        The type of this attribute depends on the type of interaction callback that was sent.
+    """
 
     __slots__ = (
         "id",

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -56,6 +56,7 @@ __all__ = (
     "InteractionResponse",
     "InteractionMessage",
     "InteractionDataResolved",
+    "InteractionCallbackActivityInstance",
     "InteractionCallbackResponse",
 )
 
@@ -80,6 +81,7 @@ if TYPE_CHECKING:
     from ..types.interactions import (
         ApplicationCommandOptionChoice as ApplicationCommandOptionChoicePayload,
         Interaction as InteractionPayload,
+        InteractionCallbackActivityInstance as InteractionCallbackActivityInstancePayload,
         InteractionCallbackResponse as InteractionCallbackResponsePayload,
         InteractionDataResolved as InteractionDataResolvedPayload,
     )
@@ -2228,10 +2230,27 @@ class InteractionDataResolved(dict[str, Any]):
         return None
 
 
+class InteractionCallbackActivityInstance:
+    """Represents the activity launched by an interaction.
+
+    .. versionadded:: |vnext|
+
+    Attributes
+    ----------
+    id: :class:`str`
+        The instance ID of the launched/joined activity.
+    """
+
+    __slots__ = ("id",)
+
+    def __init__(self, data: InteractionCallbackActivityInstancePayload) -> None:
+        self.id: str = data["id"]
+
+
 ResourceT = TypeVar(
     "ResourceT",
-    bound=InteractionMessage | None,
-    default=InteractionMessage | None,
+    bound=InteractionMessage | InteractionCallbackActivityInstance | None,
+    default=InteractionMessage | InteractionCallbackActivityInstance | None,
     covariant=True,
 )
 
@@ -2248,6 +2267,8 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         The ID of the source interaction.
     type: :class:`InteractionType`
         The type of the source interaction.
+    activity_instance_id: :class:`str` | :data:`None`
+        The instance ID of the launched/joined activity, if any.
     message_id: :class:`int` | :data:`None`
         The ID of the message that was affected (i.e. created or edited) by the
         interaction response, if any.
@@ -2255,14 +2276,15 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         Whether the message is in a :attr:`~MessageFlags.loading` state.
     message_ephemeral: :class:`bool` | :data:`None`
         Whether the message is :attr:`~MessageFlags.ephemeral`.
-    resource: :class:`InteractionMessage` | :data:`None`
-        The resource that was created (or edited) by the interaction response, if any.
+    resource: :class:`InteractionMessage` | :class:`InteractionCallbackActivityInstance` | :data:`None`
+        The resource that was created/affected by the interaction response, if any.
         The type of this attribute depends on the type of interaction callback that was sent.
     """
 
     __slots__ = (
         "id",
         "type",
+        "activity_instance_id",
         "message_id",
         "message_loading",
         "message_ephemeral",
@@ -2275,6 +2297,9 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         interaction_data = data["interaction"]
         self.id: int = int(interaction_data["id"])
         self.type: InteractionType = try_enum(InteractionType, interaction_data["type"])
+
+        self.activity_instance_id: str | None = interaction_data.get("activity_instance_id")
+
         # NOTE: these are not only for *created* messages, but are also set when using
         # defer(with_message=False) or edit(), in which case it refers to the original message
         self.message_id: int | None = utils._get_as_snowflake(
@@ -2283,10 +2308,13 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         self.message_loading: bool | None = interaction_data.get("response_message_loading")
         self.message_ephemeral: bool | None = interaction_data.get("response_message_ephemeral")
 
-        resource: InteractionMessage | None = None
-        if (resource_data := data.get("resource")) and (
-            message_data := resource_data.get("message")
-        ):
-            state = _InteractionMessageState(parent, parent._state)
-            resource = InteractionMessage(state=state, channel=parent.channel, data=message_data)  # pyright: ignore[reportArgumentType]
+        resource: InteractionMessage | InteractionCallbackActivityInstance | None = None
+        if resource_data := data.get("resource"):
+            if message_data := resource_data.get("message"):
+                state = _InteractionMessageState(parent, parent._state)
+                resource = InteractionMessage(
+                    state=cast("ConnectionState", state), channel=parent.channel, data=message_data
+                )
+            elif activity_data := resource_data.get("activity_instance"):
+                resource = InteractionCallbackActivityInstance(activity_data)
         self.resource: ResourceT = resource  # pyright: ignore[reportAttributeAccessIssue]

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -48,13 +48,14 @@ from ..permissions import Permissions
 from ..role import Role
 from ..ui.action_row import normalize_components, normalize_components_to_dict
 from ..user import ClientUser, User
-from ..webhook.async_ import Webhook, async_context, handle_message_parameters
+from ..webhook.async_ import Webhook, WebhookMessage, async_context, handle_message_parameters
 
 __all__ = (
     "Interaction",
-    "InteractionMessage",
     "InteractionResponse",
+    "InteractionMessage",
     "InteractionDataResolved",
+    "InteractionCallbackResponse",
 )
 
 if TYPE_CHECKING:
@@ -78,6 +79,7 @@ if TYPE_CHECKING:
     from ..types.interactions import (
         ApplicationCommandOptionChoice as ApplicationCommandOptionChoicePayload,
         Interaction as InteractionPayload,
+        InteractionCallbackResponse as InteractionCallbackResponsePayload,
         InteractionDataResolved as InteractionDataResolvedPayload,
     )
     from ..types.snowflake import Snowflake
@@ -701,7 +703,7 @@ class Interaction(Generic[ClientT]):
         flags: MessageFlags = MISSING,
         delete_after: float = MISSING,
         poll: Poll = MISSING,
-    ) -> None:
+    ) -> WebhookMessage | InteractionCallbackResponse:
         r"""|coro|
 
         Sends a message using either :meth:`response.send_message <InteractionResponse.send_message>`
@@ -799,10 +801,17 @@ class Interaction(Generic[ClientT]):
             you tried to send v2 components together with ``content``, ``embeds``, or ``poll``.
         """
         if self.response._response_type is not None:
-            sender = self.followup.send
+            # workaround for types not correctly representing the fact that `wait` is
+            # always implicitly true for interaction followups
+            if TYPE_CHECKING:
+                from functools import partial
+
+                sender = partial(self.followup.send, wait=True)
+            else:
+                sender = self.followup.send
         else:
             sender = self.response.send_message
-        await sender(
+        return await sender(
             content=content,
             embed=embed,
             embeds=embeds,
@@ -859,7 +868,7 @@ class InteractionResponse:
         *,
         with_message: bool = MISSING,
         ephemeral: bool = MISSING,
-    ) -> None:
+    ) -> InteractionCallbackResponse:  # TODO: document return type everywhere
         """|coro|
 
         Defers the interaction response.
@@ -936,7 +945,7 @@ class InteractionResponse:
                 data["flags"] |= MessageFlags.ephemeral.flag
 
         adapter = async_context.get()
-        await adapter.create_interaction_response(
+        callback_data = await adapter.create_interaction_response(
             parent.id,
             parent.token,
             session=parent._session,
@@ -944,6 +953,8 @@ class InteractionResponse:
             data=data or None,
         )
         self._response_type = defer_type
+
+        return InteractionCallbackResponse(callback_data, parent=self._parent)
 
     async def pong(self) -> None:
         """|coro|
@@ -991,7 +1002,7 @@ class InteractionResponse:
         flags: MessageFlags = MISSING,
         delete_after: float = MISSING,
         poll: Poll = MISSING,
-    ) -> None:
+    ) -> InteractionCallbackResponse:
         r"""|coro|
 
         Responds to this interaction by sending a message.
@@ -1161,7 +1172,7 @@ class InteractionResponse:
         adapter = async_context.get()
         response_type = InteractionResponseType.channel_message
         try:
-            await adapter.create_interaction_response(
+            callback_data = await adapter.create_interaction_response(
                 parent.id,
                 parent.token,
                 session=parent._session,
@@ -1189,6 +1200,8 @@ class InteractionResponse:
         if delete_after is not MISSING:
             await self._parent.delete_original_response(delay=delete_after)
 
+        return InteractionCallbackResponse(callback_data, parent=self._parent)
+
     async def edit_message(
         self,
         content: str | None = MISSING,
@@ -1203,7 +1216,7 @@ class InteractionResponse:
         flags: MessageFlags = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         delete_after: float | None = None,
-    ) -> None:
+    ) -> InteractionCallbackResponse:
         r"""|coro|
 
         Responds to this interaction by editing the original message of
@@ -1391,7 +1404,7 @@ class InteractionResponse:
         adapter = async_context.get()
         response_type = InteractionResponseType.message_update
         try:
-            await adapter.create_interaction_response(
+            callback_data = await adapter.create_interaction_response(
                 parent.id,
                 parent.token,
                 session=parent._session,
@@ -1412,7 +1425,9 @@ class InteractionResponse:
         if delete_after is not None:
             await self._parent.delete_original_response(delay=delete_after)
 
-    async def autocomplete(self, *, choices: Choices) -> None:
+        return InteractionCallbackResponse(callback_data, parent=self._parent)
+
+    async def autocomplete(self, *, choices: Choices) -> InteractionCallbackResponse:
         r"""|coro|
 
         Responds to this interaction by displaying a list of possible autocomplete results.
@@ -1458,7 +1473,7 @@ class InteractionResponse:
         parent = self._parent
         adapter = async_context.get()
         response_type = InteractionResponseType.application_command_autocomplete_result
-        await adapter.create_interaction_response(
+        callback_data = await adapter.create_interaction_response(
             parent.id,
             parent.token,
             session=parent._session,
@@ -1468,8 +1483,10 @@ class InteractionResponse:
 
         self._response_type = response_type
 
+        return InteractionCallbackResponse(callback_data, parent=self._parent)
+
     @overload
-    async def send_modal(self, modal: Modal) -> None: ...
+    async def send_modal(self, modal: Modal) -> InteractionCallbackResponse: ...
 
     @overload
     async def send_modal(
@@ -1478,7 +1495,7 @@ class InteractionResponse:
         title: str,
         custom_id: str,
         components: ModalComponents,
-    ) -> None: ...
+    ) -> InteractionCallbackResponse: ...
 
     async def send_modal(
         self,
@@ -1487,7 +1504,7 @@ class InteractionResponse:
         title: str | None = None,
         custom_id: str | None = None,
         components: ModalComponents | None = None,
-    ) -> None:
+    ) -> InteractionCallbackResponse:
         """|coro|
 
         Responds to this interaction by displaying a modal.
@@ -1569,7 +1586,7 @@ class InteractionResponse:
 
         adapter = async_context.get()
         response_type = InteractionResponseType.modal
-        await adapter.create_interaction_response(
+        callback_data = await adapter.create_interaction_response(
             parent.id,
             parent.token,
             session=parent._session,
@@ -1580,6 +1597,8 @@ class InteractionResponse:
 
         if modal is not None:
             parent._state.store_modal(parent.author.id, modal)
+
+        return InteractionCallbackResponse(callback_data, parent=self._parent)
 
     @utils.deprecated("Use `ui.Button(sku_id=...)` instead.")
     async def require_premium(self) -> None:
@@ -2167,3 +2186,36 @@ class InteractionDataResolved(dict[str, Any]):
             return res
 
         return None
+
+
+# TODO: make generic over resource type?
+class InteractionCallbackResponse:
+    """TODO"""
+
+    __slots__ = (
+        "id",
+        "message_id",
+        "message_deferred",
+        "message_ephemeral",
+        "resource",
+    )
+
+    def __init__(
+        self, data: InteractionCallbackResponsePayload, *, parent: Interaction[Any]
+    ) -> None:
+        interaction_data = data["interaction"]
+        self.id: int = int(interaction_data["id"])
+        # NOTE: these are not only for *created* messages, but are also set when using defer(with_message=False), in which case it refers to the original message
+        self.message_id: int | None = utils._get_as_snowflake(
+            interaction_data, "response_message_id"
+        )
+        self.message_deferred: bool | None = interaction_data.get("response_message_loading")
+        self.message_ephemeral: bool | None = interaction_data.get("response_message_ephemeral")
+
+        # XXX: data also contains interaction type and response type, but those are probably not all that interesting here?
+
+        self.resource: Message | None = None
+        if (resource_data := data.get("resource")) and (
+            message_data := resource_data.get("message")
+        ):
+            self.resource = Message(state=parent._state, channel=parent.channel, data=message_data)

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -10,10 +10,11 @@ from typing import (
     Any,
     Generic,
     TypeAlias,
-    TypeVar,
     cast,
     overload,
 )
+
+from typing_extensions import TypeVar
 
 from .. import utils
 from ..app_commands import OptionChoice
@@ -863,12 +864,13 @@ class InteractionResponse:
         """
         return self._response_type is not None
 
+    # TODO: add overloads depending on with_message?
     async def defer(
         self,
         *,
         with_message: bool = MISSING,
         ephemeral: bool = MISSING,
-    ) -> InteractionCallbackResponse:  # TODO: document return type everywhere
+    ) -> InteractionCallbackResponse[Message | None]:  # TODO: document return type everywhere
         """|coro|
 
         Defers the interaction response.
@@ -1002,7 +1004,7 @@ class InteractionResponse:
         flags: MessageFlags = MISSING,
         delete_after: float = MISSING,
         poll: Poll = MISSING,
-    ) -> InteractionCallbackResponse:
+    ) -> InteractionCallbackResponse[Message]:
         r"""|coro|
 
         Responds to this interaction by sending a message.
@@ -1216,7 +1218,7 @@ class InteractionResponse:
         flags: MessageFlags = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         delete_after: float | None = None,
-    ) -> InteractionCallbackResponse:
+    ) -> InteractionCallbackResponse[Message]:
         r"""|coro|
 
         Responds to this interaction by editing the original message of
@@ -1427,7 +1429,7 @@ class InteractionResponse:
 
         return InteractionCallbackResponse(callback_data, parent=self._parent)
 
-    async def autocomplete(self, *, choices: Choices) -> InteractionCallbackResponse:
+    async def autocomplete(self, *, choices: Choices) -> InteractionCallbackResponse[None]:
         r"""|coro|
 
         Responds to this interaction by displaying a list of possible autocomplete results.
@@ -1486,7 +1488,7 @@ class InteractionResponse:
         return InteractionCallbackResponse(callback_data, parent=self._parent)
 
     @overload
-    async def send_modal(self, modal: Modal) -> InteractionCallbackResponse: ...
+    async def send_modal(self, modal: Modal) -> InteractionCallbackResponse[None]: ...
 
     @overload
     async def send_modal(
@@ -1495,7 +1497,7 @@ class InteractionResponse:
         title: str,
         custom_id: str,
         components: ModalComponents,
-    ) -> InteractionCallbackResponse: ...
+    ) -> InteractionCallbackResponse[None]: ...
 
     async def send_modal(
         self,
@@ -1504,7 +1506,7 @@ class InteractionResponse:
         title: str | None = None,
         custom_id: str | None = None,
         components: ModalComponents | None = None,
-    ) -> InteractionCallbackResponse:
+    ) -> InteractionCallbackResponse[None]:
         """|coro|
 
         Responds to this interaction by displaying a modal.
@@ -2188,8 +2190,10 @@ class InteractionDataResolved(dict[str, Any]):
         return None
 
 
-# TODO: make generic over resource type?
-class InteractionCallbackResponse:
+ResourceT = TypeVar("ResourceT", bound=Message | None, default=Message | None, covariant=True)
+
+
+class InteractionCallbackResponse(Generic[ResourceT]):
     """TODO"""
 
     __slots__ = (
@@ -2214,8 +2218,9 @@ class InteractionCallbackResponse:
 
         # XXX: data also contains interaction type and response type, but those are probably not all that interesting here?
 
-        self.resource: Message | None = None
+        resource: Message | None = None
         if (resource_data := data.get("resource")) and (
             message_data := resource_data.get("message")
         ):
-            self.resource = Message(state=parent._state, channel=parent.channel, data=message_data)
+            resource = Message(state=parent._state, channel=parent.channel, data=message_data)
+        self.resource: ResourceT = resource  # pyright: ignore[reportAttributeAccessIssue]

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -2199,7 +2199,7 @@ class InteractionCallbackResponse(Generic[ResourceT]):
     __slots__ = (
         "id",
         "message_id",
-        "message_deferred",
+        "message_loading",
         "message_ephemeral",
         "resource",
     )
@@ -2213,7 +2213,7 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         self.message_id: int | None = utils._get_as_snowflake(
             interaction_data, "response_message_id"
         )
-        self.message_deferred: bool | None = interaction_data.get("response_message_loading")
+        self.message_loading: bool | None = interaction_data.get("response_message_loading")
         self.message_ephemeral: bool | None = interaction_data.get("response_message_ephemeral")
 
         # XXX: data also contains interaction type and response type, but those are probably not all that interesting here?

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -713,11 +713,6 @@ class Interaction(Generic[ClientT]):
         If the interaction hasn't been responded to yet, this method will call :meth:`response.send_message <InteractionResponse.send_message>`.
         Otherwise, it will call :meth:`followup.send <Webhook.send>`.
 
-        .. note::
-            This method does not return a :class:`Message` object. If you need a message object,
-            use :meth:`original_response` to fetch it, or use :meth:`followup.send <Webhook.send>`
-            directly instead of this method if you're sending a followup message.
-
         Parameters
         ----------
         content: :class:`str` | :data:`None`
@@ -806,6 +801,8 @@ class Interaction(Generic[ClientT]):
         :class:`InteractionCallbackResponse` | :class:`WebhookMessage`
             The callback response data if the interaction hadn't been responded to yet,
             or the message if this was sent as a followup.
+
+            .. versionadded:: |vnext|
         """
         if self.response._response_type is not None:
             # workaround for types not correctly representing the fact that `wait` is
@@ -927,6 +924,8 @@ class InteractionResponse:
         -------
         :class:`InteractionCallbackResponse`
             The callback response data. If ``with_message=True``, this also contains a message resource.
+
+            .. versionadded:: |vnext|
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1105,6 +1104,8 @@ class InteractionResponse:
         -------
         :class:`InteractionCallbackResponse`
             The callback response data, with a message resource.
+
+            .. versionadded:: |vnext|
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1335,6 +1336,8 @@ class InteractionResponse:
         -------
         :class:`InteractionCallbackResponse`
             The callback response data, with a message resource.
+
+            .. versionadded:: |vnext|
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1472,6 +1475,8 @@ class InteractionResponse:
         -------
         :class:`InteractionCallbackResponse`
             The callback response data.
+
+            .. versionadded:: |vnext|
         """
         if self._response_type is not None:
             raise InteractionResponded(self._parent)
@@ -1582,6 +1587,8 @@ class InteractionResponse:
         -------
         :class:`InteractionCallbackResponse`
             The callback response data.
+
+            .. versionadded:: |vnext|
         """
         if modal is not None and any((title, components, custom_id)):
             msg = "Cannot mix modal argument and title, custom_id, components arguments"

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -706,7 +706,7 @@ class Interaction(Generic[ClientT]):
         flags: MessageFlags = MISSING,
         delete_after: float = MISSING,
         poll: Poll = MISSING,
-    ) -> InteractionCallbackResponse[InteractionMessage] | WebhookMessage:
+    ) -> InteractionMessage | WebhookMessage:
         r"""|coro|
 
         Sends a message using either :meth:`response.send_message <InteractionResponse.send_message>`
@@ -800,9 +800,9 @@ class Interaction(Generic[ClientT]):
 
         Returns
         -------
-        :class:`InteractionCallbackResponse` | :class:`WebhookMessage`
-            The callback response data if the interaction hadn't been responded to yet,
-            or the message if this was sent as a followup.
+        :class:`InteractionMessage` | :class:`WebhookMessage`
+            The message that was sent. The specific type depends on whether the interaction
+            had already been responded to.
 
             .. versionadded:: |vnext|
         """
@@ -817,7 +817,8 @@ class Interaction(Generic[ClientT]):
                 sender = self.followup.send
         else:
             sender = self.response.send_message
-        return await sender(
+
+        res = await sender(
             content=content,
             embed=embed,
             embeds=embeds,
@@ -833,6 +834,11 @@ class Interaction(Generic[ClientT]):
             delete_after=delete_after,
             poll=poll,
         )
+
+        if isinstance(res, InteractionCallbackResponse):
+            return res.resource
+        else:
+            return res
 
 
 class InteractionResponse:

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1727,7 +1727,10 @@ class InteractionMessage(Message):
     r"""Represents the original interaction response message.
 
     This allows you to edit or delete the message associated with
-    the interaction response. To retrieve this object see :meth:`Interaction.original_response`.
+    the interaction response. You can usually receive this object as the
+    :attr:`~InteractionCallbackResponse.resource` returned by methods such as
+    :meth:`InteractionResponse.send_message`.
+    As an alternative, see :meth:`Interaction.original_response`.
 
     This inherits from :class:`disnake.Message` with changes to
     :meth:`edit` and :meth:`delete` to work.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -704,7 +704,7 @@ class Interaction(Generic[ClientT]):
         flags: MessageFlags = MISSING,
         delete_after: float = MISSING,
         poll: Poll = MISSING,
-    ) -> InteractionCallbackResponse[Message] | WebhookMessage:
+    ) -> InteractionCallbackResponse[InteractionMessage] | WebhookMessage:
         r"""|coro|
 
         Sends a message using either :meth:`response.send_message <InteractionResponse.send_message>`
@@ -873,7 +873,7 @@ class InteractionResponse:
         *,
         with_message: bool = MISSING,
         ephemeral: bool = MISSING,
-    ) -> InteractionCallbackResponse[Message | None]:
+    ) -> InteractionCallbackResponse[InteractionMessage | None]:
         """|coro|
 
         Defers the interaction response.
@@ -1014,7 +1014,7 @@ class InteractionResponse:
         flags: MessageFlags = MISSING,
         delete_after: float = MISSING,
         poll: Poll = MISSING,
-    ) -> InteractionCallbackResponse[Message]:
+    ) -> InteractionCallbackResponse[InteractionMessage]:
         r"""|coro|
 
         Responds to this interaction by sending a message.
@@ -1235,7 +1235,7 @@ class InteractionResponse:
         flags: MessageFlags = MISSING,
         allowed_mentions: AllowedMentions = MISSING,
         delete_after: float | None = None,
-    ) -> InteractionCallbackResponse[Message]:
+    ) -> InteractionCallbackResponse[InteractionMessage]:
         r"""|coro|
 
         Responds to this interaction by editing the original message of
@@ -2228,7 +2228,12 @@ class InteractionDataResolved(dict[str, Any]):
         return None
 
 
-ResourceT = TypeVar("ResourceT", bound=Message | None, default=Message | None, covariant=True)
+ResourceT = TypeVar(
+    "ResourceT",
+    bound=InteractionMessage | None,
+    default=InteractionMessage | None,
+    covariant=True,
+)
 
 
 class InteractionCallbackResponse(Generic[ResourceT]):
@@ -2250,7 +2255,7 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         Whether the message is in a :attr:`~MessageFlags.loading` state.
     message_ephemeral: :class:`bool` | :data:`None`
         Whether the message is :attr:`~MessageFlags.ephemeral`.
-    resource: :class:`Message` | :data:`None`
+    resource: :class:`InteractionMessage` | :data:`None`
         The resource that was created (or edited) by the interaction response, if any.
         The type of this attribute depends on the type of interaction callback that was sent.
     """
@@ -2278,9 +2283,10 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         self.message_loading: bool | None = interaction_data.get("response_message_loading")
         self.message_ephemeral: bool | None = interaction_data.get("response_message_ephemeral")
 
-        resource: Message | None = None
+        resource: InteractionMessage | None = None
         if (resource_data := data.get("resource")) and (
             message_data := resource_data.get("message")
         ):
-            resource = Message(state=parent._state, channel=parent.channel, data=message_data)
+            state = _InteractionMessageState(parent, parent._state)
+            resource = InteractionMessage(state=state, channel=parent.channel, data=message_data)  # pyright: ignore[reportArgumentType]
         self.resource: ResourceT = resource  # pyright: ignore[reportAttributeAccessIssue]

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -2234,6 +2234,8 @@ class InteractionCallbackResponse(Generic[ResourceT]):
     ----------
     id: :class:`int`
         The ID of the source interaction.
+    type: :class:`InteractionType`
+        The type of the source interaction.
     message_id: :class:`int` | :data:`None`
         The ID of the message that was affected (i.e. created or edited) by the
         interaction response, if any.
@@ -2248,6 +2250,7 @@ class InteractionCallbackResponse(Generic[ResourceT]):
 
     __slots__ = (
         "id",
+        "type",
         "message_id",
         "message_loading",
         "message_ephemeral",
@@ -2259,14 +2262,13 @@ class InteractionCallbackResponse(Generic[ResourceT]):
     ) -> None:
         interaction_data = data["interaction"]
         self.id: int = int(interaction_data["id"])
+        self.type: InteractionType = try_enum(InteractionType, interaction_data["type"])
         # NOTE: these are not only for *created* messages, but are also set when using defer(with_message=False), in which case it refers to the original message
         self.message_id: int | None = utils._get_as_snowflake(
             interaction_data, "response_message_id"
         )
         self.message_loading: bool | None = interaction_data.get("response_message_loading")
         self.message_ephemeral: bool | None = interaction_data.get("response_message_ephemeral")
-
-        # XXX: data also contains interaction type and response type, but those are probably not all that interesting here?
 
         resource: Message | None = None
         if (resource_data := data.get("resource")) and (

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -2263,7 +2263,8 @@ class InteractionCallbackResponse(Generic[ResourceT]):
         interaction_data = data["interaction"]
         self.id: int = int(interaction_data["id"])
         self.type: InteractionType = try_enum(InteractionType, interaction_data["type"])
-        # NOTE: these are not only for *created* messages, but are also set when using defer(with_message=False), in which case it refers to the original message
+        # NOTE: these are not only for *created* messages, but are also set when using
+        # defer(with_message=False) or edit(), in which case it refers to the original message
         self.message_id: int | None = utils._get_as_snowflake(
             interaction_data, "response_message_id"
         )

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -704,7 +704,7 @@ class Interaction(Generic[ClientT]):
         flags: MessageFlags = MISSING,
         delete_after: float = MISSING,
         poll: Poll = MISSING,
-    ) -> WebhookMessage | InteractionCallbackResponse:
+    ) -> InteractionCallbackResponse[Message] | WebhookMessage:
         r"""|coro|
 
         Sends a message using either :meth:`response.send_message <InteractionResponse.send_message>`

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    Literal,
     TypeAlias,
     cast,
     overload,
@@ -879,7 +880,32 @@ class InteractionResponse:
         """
         return self._response_type is not None
 
-    # TODO: add overloads depending on with_message?
+    @overload
+    async def defer(
+        self,
+        *,
+        with_message: Literal[True],
+        ephemeral: bool = ...,
+    ) -> InteractionCallbackResponse[InteractionMessage]: ...
+
+    @overload
+    async def defer(
+        self,
+        *,
+        with_message: Literal[False],
+        ephemeral: bool = ...,
+    ) -> InteractionCallbackResponse[None]: ...
+
+    # if `with_message` is not explicitly given, the exact callback resource type isn't
+    # known, as it depends on the source interaction type
+    @overload
+    async def defer(
+        self,
+        *,
+        with_message: bool = ...,
+        ephemeral: bool = ...,
+    ) -> InteractionCallbackResponse[InteractionMessage | None]: ...
+
     async def defer(
         self,
         *,

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -454,7 +454,7 @@ InteractionMetadata: TypeAlias = (
 
 
 class InteractionCallbackMetadata(TypedDict):
-    id: Snowflake
+    id: Snowflake  # interaction ID
     type: InteractionType
     # activity_instance_id: NotRequired[str]  # activity launching not implemented yet
     response_message_id: NotRequired[Snowflake]

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -464,7 +464,7 @@ class InteractionCallbackMetadata(TypedDict):
 
 class InteractionCallbackResource(TypedDict):
     type: InteractionResponseType
-    # activity_instance: NotRequired[InteractionCallbackActivityInstance]
+    # activity_instance: NotRequired[InteractionCallbackActivityInstance]  # see above
     message: NotRequired[Message]
 
 

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -394,7 +394,7 @@ Interaction: TypeAlias = ApplicationCommandInteraction | MessageInteraction | Mo
 BaseInteraction: TypeAlias = Interaction | PingInteraction
 
 
-class InteractionApplicationCommandCallbackData(TypedDict, total=False):
+class InteractionApplicationCommandResponseData(TypedDict, total=False):
     tts: bool
     content: str
     embeds: list[Embed]
@@ -404,20 +404,15 @@ class InteractionApplicationCommandCallbackData(TypedDict, total=False):
     attachments: list[Attachment]
 
 
-class InteractionAutocompleteCallbackData(TypedDict):
+class InteractionAutocompleteResponseData(TypedDict):
     choices: list[ApplicationCommandOptionChoice]
 
 
 InteractionResponseType: TypeAlias = Literal[1, 4, 5, 6, 7, 10]
 
-InteractionCallbackData: TypeAlias = (
-    InteractionApplicationCommandCallbackData | InteractionAutocompleteCallbackData | Modal
+InteractionResponseData: TypeAlias = (
+    InteractionApplicationCommandResponseData | InteractionAutocompleteResponseData | Modal
 )
-
-
-class InteractionResponse(TypedDict):
-    type: InteractionResponseType
-    data: NotRequired[InteractionCallbackData]
 
 
 class InteractionMessageReference(TypedDict):
@@ -456,6 +451,26 @@ InteractionMetadata: TypeAlias = (
     | MessageComponentInteractionMetadata
     | ModalInteractionMetadata
 )
+
+
+class InteractionCallbackMetadata(TypedDict):
+    id: Snowflake
+    type: InteractionType
+    # activity_instance_id: NotRequired[str]  # activity launching not implemented yet
+    response_message_id: NotRequired[Snowflake]
+    response_message_loading: NotRequired[bool]
+    response_message_ephemeral: NotRequired[bool]
+
+
+class InteractionCallbackResource(TypedDict):
+    type: InteractionResponseType
+    # activity_instance: NotRequired[InteractionCallbackActivityInstance]
+    message: NotRequired[Message]
+
+
+class InteractionCallbackResponse(TypedDict):
+    interaction: InteractionCallbackMetadata
+    resource: NotRequired[InteractionCallbackResource]
 
 
 class EditApplicationCommand(TypedDict):

--- a/disnake/types/interactions.py
+++ b/disnake/types/interactions.py
@@ -456,15 +456,19 @@ InteractionMetadata: TypeAlias = (
 class InteractionCallbackMetadata(TypedDict):
     id: Snowflake  # interaction ID
     type: InteractionType
-    # activity_instance_id: NotRequired[str]  # activity launching not implemented yet
+    activity_instance_id: NotRequired[str]
     response_message_id: NotRequired[Snowflake]
     response_message_loading: NotRequired[bool]
     response_message_ephemeral: NotRequired[bool]
 
 
+class InteractionCallbackActivityInstance(TypedDict):
+    id: str
+
+
 class InteractionCallbackResource(TypedDict):
     type: InteractionResponseType
-    # activity_instance: NotRequired[InteractionCallbackActivityInstance]  # see above
+    activity_instance: NotRequired[InteractionCallbackActivityInstance]
     message: NotRequired[Message]
 
 

--- a/disnake/webhook/async_.py
+++ b/disnake/webhook/async_.py
@@ -62,6 +62,9 @@ if TYPE_CHECKING:
     from ..poll import Poll
     from ..state import ConnectionState
     from ..sticker import GuildSticker, StandardSticker, StickerItem
+    from ..types.interactions import (
+        InteractionCallbackResponse as InteractionCallbackResponsePayload,
+    )
     from ..types.message import Message as MessagePayload
     from ..types.webhook import Webhook as WebhookPayload
     from ..ui._types import MessageComponents
@@ -410,10 +413,10 @@ class AsyncWebhookAdapter:
         type: int,
         data: dict[str, Any] | None = None,
         files: list[File] | None = None,
-    ) -> Response[None]:
+    ) -> Response[InteractionCallbackResponsePayload]:
         route = Route(
             "POST",
-            "/interactions/{webhook_id}/{webhook_token}/callback",
+            "/interactions/{webhook_id}/{webhook_token}/callback?with_response=1",
             webhook_id=interaction_id,
             webhook_token=token,
         )

--- a/docs/api/interactions.rst
+++ b/docs/api/interactions.rst
@@ -140,6 +140,14 @@ InteractionDataResolved
 .. autoclass:: InteractionDataResolved()
     :members:
 
+InteractionCallbackResponse
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: InteractionCallbackResponse
+
+.. autoclass:: InteractionCallbackResponse()
+    :members:
+
 ApplicationCommandInteractionData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/api/interactions.rst
+++ b/docs/api/interactions.rst
@@ -148,6 +148,14 @@ InteractionCallbackResponse
 .. autoclass:: InteractionCallbackResponse()
     :members:
 
+InteractionCallbackActivityInstance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. attributetable:: InteractionCallbackActivityInstance
+
+.. autoclass:: InteractionCallbackActivityInstance()
+    :members:
+
 ApplicationCommandInteractionData
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/interactions/test_base.py
+++ b/tests/interactions/test_base.py
@@ -13,9 +13,17 @@ from disnake.state import ConnectionState
 from disnake.utils import MISSING
 
 if TYPE_CHECKING:
-    from disnake.types.interactions import InteractionChannel as InteractionChannelPayload
+    from disnake.types.interactions import (
+        InteractionCallbackResponse as InteractionCallbackResponsePayload,
+        InteractionChannel as InteractionChannelPayload,
+    )
     from disnake.types.member import Member as MemberPayload
     from disnake.types.user import User as UserPayload
+
+
+interaction_callback_response: InteractionCallbackResponsePayload = {
+    "interaction": {"id": 0, "type": 4}
+}
 
 
 @pytest.mark.asyncio
@@ -28,6 +36,9 @@ class TestInteractionResponse:
     @pytest.fixture
     def adapter(self) -> mock.AsyncMock:
         adapter = mock.AsyncMock()
+        adapter.create_interaction_response = mock.AsyncMock(
+            return_value=interaction_callback_response
+        )
         disnake.interactions.base.async_context.set(adapter)
         return adapter
 


### PR DESCRIPTION
## Summary

The other half of https://github.com/discord/discord-api-docs/commit/8bc883cb09135521fda2ae2a123c5d3ae791b605.

This adds the `InteractionCallbackResponse` model, which is returned from all (relevant) `InteractionResponse.*` methods, and contains metadata about the affected API resource. The most interesting use case is probably the fact that it provides a full message object upon `.send_message()`/`.edit_message()`/etc. <sup>(which will also allow #329 to finally be fixed *properly*)</sup>.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
