### PR TITLE
fix(typing): silence `ws_connect` pyright warning

### DIFF
--- a/disnake/http.py
+++ b/disnake/http.py
@@ -257,7 +257,7 @@ class HTTPClient:
             if hasattr(aiohttp, "ClientWSTimeout")
             else 30.0,
         )
-        return await self.__session.ws_connect(
+        ws = await self.__session.ws_connect(
             url,
             proxy_auth=self.proxy_auth,
             proxy=self.proxy,
@@ -269,6 +269,9 @@ class HTTPClient:
             },
             compress=compress,
         )
+        # basically a glorified type:ignore to avoid a typing issue in Python 3.10,
+        # where ws_connect() returns a `Response[bool]` instead of `Response[Literal[True]]`
+        return cast("Any", ws)
 
     async def request(
         self,

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -257,7 +257,10 @@ class HTTPClient:
             if hasattr(aiohttp, "ClientWSTimeout")
             else 30.0,
         )
-        ws = await self.__session.ws_connect(
+
+        # in Python 3.10, ws_connect() returns a `Response[bool]` instead of `Response[Literal[True]]`,
+        # so this explicit annotation is required to avoid typing issues
+        ws: aiohttp.ClientWebSocketResponse[Any] = await self.__session.ws_connect(
             url,
             proxy_auth=self.proxy_auth,
             proxy=self.proxy,
@@ -269,9 +272,7 @@ class HTTPClient:
             },
             compress=compress,
         )
-        # basically a glorified type:ignore to avoid a typing issue in Python 3.10,
-        # where ws_connect() returns a `Response[bool]` instead of `Response[Literal[True]]`
-        return cast("Any", ws)
+        return ws
 
     async def request(
         self,


### PR DESCRIPTION
## Summary

See https://github.com/DisnakeDev/disnake/actions/runs/29743303677/job/88356807035#step:6:26, for instance.
This only happens on 3.10, as the `ClientSession.ws_connect` overloads that would prevent this issue are restricted to 3.11+.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
