### PR TITLE
fix(views): correctly dispatch components with the same `custom_id` in interactions

### DIFF
--- a/changelog/1580.bugfix.rst
+++ b/changelog/1580.bugfix.rst
@@ -1,0 +1,1 @@
+Fix dispatching components in views with the same ``custom_id`` when sent via :meth:`InteractionResponse.send_message`. Previously, sending a view would override already tracked components of views with the same ``custom_id`` from prior interaction responses.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -1247,17 +1247,20 @@ class InteractionResponse:
                     f.close()
 
         self._response_type = response_type
+        response: InteractionCallbackResponse[InteractionMessage] = InteractionCallbackResponse(
+            callback_data, parent=self._parent
+        )
 
         if view is not MISSING:
             if ephemeral and view.timeout is None:
                 view.timeout = 15 * 60.0
 
-            self._parent._state.store_view(view)
+            self._parent._state.store_view(view, response.message_id)
 
         if delete_after is not MISSING:
             await self._parent.delete_original_response(delay=delete_after)
 
-        return InteractionCallbackResponse(callback_data, parent=self._parent)
+        return response
 
     async def edit_message(
         self,


### PR DESCRIPTION
## Summary

Supersedes #329.

Fixes dispatching components in views with the same ``custom_id`` when sent via `InteractionResponse.send_message`. Previously, sending a view would override already tracked components of views with the same ``custom_id`` from prior interaction responses, since the message ID wasn't returned from `/callback`, which meant tracked components were not bound to a specific message as they usually are.
As of #1571, the message ID is returned as part of the callback response, which finally fixes this view store quirk.

Taking the example from #329, the previous behavior when sending two responses with a fixed component `custom_id`:
```py
# after sending view once
view store: [(2, None, 'test')]
# after sending view again
view store: [(2, None, 'test')]
```
new:
```py
# once
view store: [(2, 1530948302659387536, 'test')]
# again
view store: [(2, 1530948302659387536, 'test'), (2, 1530948315695550557, 'test')]
```

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
