### PR TITLE
fix(http): use user-agent format exactly as described in docs

### DIFF
--- a/disnake/http.py
+++ b/disnake/http.py
@@ -102,7 +102,7 @@ def _workaround_set_api_version(version: Literal[9, 10]) -> None:
 
 
 USER_AGENT: Final[str] = (  # noqa: UP032
-    "DiscordBot (https://github.com/DisnakeDev/disnake {0}) Python/{1[0]}.{1[1]} aiohttp/{2}"
+    "DiscordBot (https://github.com/DisnakeDev/disnake, {0}) Python/{1[0]}.{1[1]} aiohttp/{2}"
 ).format(__version__, sys.version_info, aiohttp.__version__)
 
 


### PR DESCRIPTION
## Summary

There's not much to it, this adds a singular `,`. Presumably it's fine either way, considering it has been fine for about a decade now, but might as well.
See https://docs.discord.com/developers/reference#user-agent.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
