### PR TITLE
fix(interactions): use previous flags value when editing messages

### DIFF
--- a/changelog/1582.bugfix.rst
+++ b/changelog/1582.bugfix.rst
@@ -1,0 +1,1 @@
+Retain original message's :attr:`~InteractionMessage.flags` when editing an interaction response using :meth:`Interaction.edit_original_response`.

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -230,6 +230,7 @@ class Interaction(Generic[ClientT]):
         "_state",
         "_session",
         "_original_response",
+        "_current_response",
         "_cs_response",
         "_cs_followup",
         "_cs_me",
@@ -242,7 +243,12 @@ class Interaction(Generic[ClientT]):
         # TODO: Maybe use a unique session
         self._session: ClientSession = state.http._HTTPClient__session  # pyright: ignore[reportAttributeAccessIssue]
         self.client: ClientT = cast("ClientT", state._get_client())
+
+        # TODO(3.0): merge these fields
+        # cached return value for .original_response()
         self._original_response: InteractionMessage | None = None
+        # (presumably) current message state taking into account all edits etc.
+        self._current_response: InteractionMessage | None = None
 
         self.id: int = int(data["id"])
         self.type: InteractionType = try_enum(InteractionType, data["type"])
@@ -410,6 +416,14 @@ class Interaction(Generic[ClientT]):
         :return type: :class:`bool`
         """
         return self.expires_at <= utils.utcnow()
+
+    def _update_current_response(
+        self, response: InteractionMessage | InteractionCallbackResponse[InteractionMessage | None]
+    ) -> None:
+        if isinstance(response, InteractionMessage):
+            self._current_response = response
+        elif isinstance(response.resource, InteractionMessage):
+            self._current_response = response.resource
 
     async def original_response(self) -> InteractionMessage:
         """|coro|
@@ -625,6 +639,7 @@ class Interaction(Generic[ClientT]):
         # The message channel types should always match
         state = _InteractionMessageState(self, self._state)
         message = InteractionMessage(state=state, channel=self.channel, data=data)  # pyright: ignore[reportArgumentType]
+        self._update_current_response(message)
 
         if view and not view.is_finished():
             self._state.store_view(view, message.id)
@@ -1009,7 +1024,11 @@ class InteractionResponse:
         )
         self._response_type = defer_type
 
-        return InteractionCallbackResponse(callback_data, parent=self._parent)
+        response = InteractionCallbackResponse[InteractionMessage | None](
+            callback_data, parent=self._parent
+        )
+        self._parent._update_current_response(response)
+        return response
 
     async def pong(self) -> None:
         """|coro|
@@ -1186,11 +1205,16 @@ class InteractionResponse:
                     data=params.payload,
                     files=params.files,
                 )
-                self._response_type = response_type
             except NotFound as e:
                 if e.code == 10062:
                     raise InteractionTimedOut(self._parent) from e
                 raise
+
+        self._response_type = response_type
+        response = InteractionCallbackResponse[InteractionMessage](
+            callback_data, parent=self._parent
+        )
+        self._parent._update_current_response(response)
 
         if view is not MISSING:
             if ephemeral and view.timeout is None:
@@ -1201,7 +1225,7 @@ class InteractionResponse:
         if delete_after is not MISSING:
             await parent.delete_original_response(delay=delete_after)
 
-        return InteractionCallbackResponse(callback_data, parent=self._parent)
+        return response
 
     async def edit_message(
         self,
@@ -1371,15 +1395,19 @@ class InteractionResponse:
                 files=params.files,
             )
 
+        self._response_type = response_type
+        response = InteractionCallbackResponse[InteractionMessage](
+            callback_data, parent=self._parent
+        )
+        self._parent._update_current_response(response)
+
         if view and not view.is_finished():
             parent._state.store_view(view, message.id)
-
-        self._response_type = response_type
 
         if delete_after is not None:
             await parent.delete_original_response(delay=delete_after)
 
-        return InteractionCallbackResponse(callback_data, parent=self._parent)
+        return response
 
     async def autocomplete(self, *, choices: Choices) -> InteractionCallbackResponse[None]:
         r"""|coro|

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -230,7 +230,7 @@ class Interaction(Generic[ClientT]):
         "_state",
         "_session",
         "_original_response",
-        "_current_response",
+        "_last_response",
         "_cs_response",
         "_cs_followup",
         "_cs_me",
@@ -248,7 +248,7 @@ class Interaction(Generic[ClientT]):
         # cached return value for .original_response()
         self._original_response: InteractionMessage | None = None
         # current message state taking into account all edits etc.
-        self._current_response: InteractionMessage | None = None
+        self._last_response: InteractionMessage | None = None
 
         self.id: int = int(data["id"])
         self.type: InteractionType = try_enum(InteractionType, data["type"])
@@ -417,13 +417,13 @@ class Interaction(Generic[ClientT]):
         """
         return self.expires_at <= utils.utcnow()
 
-    def _update_current_response(
+    def _update_last_response(
         self, response: InteractionMessage | InteractionCallbackResponse[InteractionMessage | None]
     ) -> None:
         if isinstance(response, InteractionMessage):
-            self._current_response = response
+            self._last_response = response
         elif isinstance(response.resource, InteractionMessage):
-            self._current_response = response.resource
+            self._last_response = response.resource
 
     async def original_response(self) -> InteractionMessage:
         """|coro|
@@ -598,13 +598,13 @@ class Interaction(Generic[ClientT]):
             The newly edited message.
         """
         previous_flags: int = 0
-        if self._current_response:
-            previous_flags = self._current_response.flags.value
+        if self._last_response:
+            previous_flags = self._last_response.flags.value
 
             # if no attachment list was provided but we're uploading new files,
             # use current attachments as the base
             if attachments is MISSING and (file or files):
-                attachments = self._current_response.attachments
+                attachments = self._last_response.attachments
 
         previous_mentions: AllowedMentions | None = self._state.allowed_mentions
 
@@ -642,7 +642,7 @@ class Interaction(Generic[ClientT]):
         # The message channel types should always match
         state = _InteractionMessageState(self, self._state)
         message = InteractionMessage(state=state, channel=self.channel, data=data)  # pyright: ignore[reportArgumentType]
-        self._update_current_response(message)
+        self._update_last_response(message)
 
         if view and not view.is_finished():
             self._state.store_view(view, message.id)
@@ -1030,7 +1030,7 @@ class InteractionResponse:
         response = InteractionCallbackResponse[InteractionMessage | None](
             callback_data, parent=self._parent
         )
-        self._parent._update_current_response(response)
+        self._parent._update_last_response(response)
         return response
 
     async def pong(self) -> None:
@@ -1217,7 +1217,7 @@ class InteractionResponse:
         response = InteractionCallbackResponse[InteractionMessage](
             callback_data, parent=self._parent
         )
-        self._parent._update_current_response(response)
+        self._parent._update_last_response(response)
 
         if view is not MISSING:
             if ephemeral and view.timeout is None:
@@ -1402,7 +1402,7 @@ class InteractionResponse:
         response = InteractionCallbackResponse[InteractionMessage](
             callback_data, parent=self._parent
         )
-        self._parent._update_current_response(response)
+        self._parent._update_last_response(response)
 
         if view and not view.is_finished():
             parent._state.store_view(view, message.id)

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -597,12 +597,14 @@ class Interaction(Generic[ClientT]):
         :class:`InteractionMessage`
             The newly edited message.
         """
-        # if no attachment list was provided but we're uploading new files,
-        # use current attachments as the base
-        # FIXME: avoid original_response(), use callback data once implemented
-        # FIXME: set previous_flags as well
-        if attachments is MISSING and (file or files):
-            attachments = (await self.original_response()).attachments
+        previous_flags: int = 0
+        if self._current_response:
+            previous_flags = self._current_response.flags.value
+
+            # if no attachment list was provided but we're uploading new files,
+            # use current attachments as the base
+            if attachments is MISSING and (file or files):
+                attachments = self._current_response.attachments
 
         previous_mentions: AllowedMentions | None = self._state.allowed_mentions
 
@@ -621,6 +623,7 @@ class Interaction(Generic[ClientT]):
             flags=flags,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=previous_mentions,
+            previous_flags=previous_flags,
         ) as params:
             try:
                 data = await adapter.edit_original_interaction_response(
@@ -1381,7 +1384,7 @@ class InteractionResponse:
             flags=flags,
             allowed_mentions=allowed_mentions,
             previous_allowed_mentions=base_allowed_mentions,
-            # FIXME: previous_flags ?
+            previous_flags=message.flags.value,
         ) as params:
             if view is not MISSING:
                 parent._state.prevent_view_updates_for(message.id)
@@ -1951,13 +1954,6 @@ class InteractionMessage(Message):
                 **params,
             )
 
-        # if no attachment list was provided but we're uploading new files,
-        # use current attachments as the base
-        # this isn't necessary when using the superclass, as the implementation there takes care of attachments
-        if attachments is MISSING and (file or files):
-            attachments = self.attachments
-
-        # FIXME: suppress_embeds overwrites existing flags, should set previous_flags
         return await self._state._interaction.edit_original_response(
             content=content,
             embed=embed,

--- a/disnake/interactions/base.py
+++ b/disnake/interactions/base.py
@@ -247,7 +247,7 @@ class Interaction(Generic[ClientT]):
         # TODO(3.0): merge these fields
         # cached return value for .original_response()
         self._original_response: InteractionMessage | None = None
-        # (presumably) current message state taking into account all edits etc.
+        # current message state taking into account all edits etc.
         self._current_response: InteractionMessage | None = None
 
         self.id: int = int(data["id"])


### PR DESCRIPTION
## Summary

Retains sent interaction response messages and uses that message's `flags` as the baseline when later editing the message using `InteractionResponse.edit_original_response`. I would assume it's fairly rare to hit any issues with the current code, but something like this previously did not work:
```py
await inter.send(components=disnake.ui.TextDisplay("hii"))
await inter.edit_original_response(suppress_embeds=True)
```
Setting `suppress_embeds` would edit the message with `flags: 128`, which fails as the cv2 flag (`32768`) cannot be unset.
As an added bonus, the code no longer has to fetch `.original_response()` when adding new files in an edit.-

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
