### PR TITLE
fix(http): release global rate limit lock when a request is cancelled

### DIFF
--- a/changelog/1585.bugfix.rst
+++ b/changelog/1585.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a deadlock where cancelling a request while it was waiting out a global rate limit would leave every subsequent request waiting forever.

--- a/disnake/http.py
+++ b/disnake/http.py
@@ -409,14 +409,19 @@ class HTTPClient:
                                 )
                                 self._global_over.clear()
 
-                            await asyncio.sleep(retry_after)
-                            _log.debug("Done sleeping for the rate limit. Retrying...")
-
-                            # release the global lock now that the
-                            # global rate limit has passed
-                            if is_global:
-                                self._global_over.set()
-                                _log.debug("Global rate limit is now over.")
+                            try:
+                                await asyncio.sleep(retry_after)
+                                _log.debug("Done sleeping for the rate limit. Retrying...")
+                            finally:
+                                # release the global lock now that the
+                                # global rate limit has passed.
+                                # this has to happen in a finally, otherwise a
+                                # request cancelled while sleeping would leave
+                                # the event cleared forever, and every later
+                                # request would block on it indefinitely
+                                if is_global:
+                                    self._global_over.set()
+                                    _log.debug("Global rate limit is now over.")
 
                             continue
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: MIT
 
+import asyncio
+from typing import ClassVar
+
 import pytest
+from typing_extensions import Self
 
 import disnake
-from disnake.http import HTTPClient
+from disnake.http import HTTPClient, Route
 
 
 @pytest.mark.parametrize(
@@ -46,3 +50,50 @@ from disnake.http import HTTPClient
 )
 def test_format_gateway_url(url: str, params: disnake.GatewayParams, expected: str) -> None:
     assert HTTPClient._format_gateway_url(url, params=params) == expected
+
+
+class _GlobalRateLimitResponse:
+    """A ``429`` carrying ``global: true``, as sent by Discord."""
+
+    status = 429
+    headers: ClassVar[dict[str, str]] = {
+        "content-type": "application/json",
+        "Via": "1.1 google",
+    }
+
+    async def text(self, encoding: str = "utf-8") -> str:
+        return '{"global": true, "retry_after": 60.0}'
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
+class _GlobalRateLimitSession:
+    def request(self, method: str, url: str, **kwargs: object) -> _GlobalRateLimitResponse:
+        return _GlobalRateLimitResponse()
+
+
+@pytest.mark.asyncio
+async def test_global_rate_limit_released_on_cancellation() -> None:
+    # a request cancelled while sleeping off a global rate limit must still
+    # re-set `_global_over`, otherwise every later request blocks on it forever
+    http = HTTPClient(loop=asyncio.get_running_loop())
+    http._HTTPClient__session = _GlobalRateLimitSession()  # pyright: ignore[reportAttributeAccessIssue]
+
+    task = asyncio.create_task(http.request(Route("GET", "/users/@me")))
+
+    # let the request reach the sleep, with the global event now cleared
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if not http._global_over.is_set():
+            break
+    assert not http._global_over.is_set()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert http._global_over.is_set()


### PR DESCRIPTION
## Summary

A request that is cancelled while sleeping off a **global** rate limit permanently deadlocks the entire HTTP client.

In `HTTPClient.request`:

```python
if is_global:
    _log.warning("Global rate limit has been hit. Retrying in %.2f seconds.", retry_after)
    self._global_over.clear()

await asyncio.sleep(retry_after)
_log.debug("Done sleeping for the rate limit. Retrying...")

# release the global lock now that the
# global rate limit has passed
if is_global:
    self._global_over.set()
    _log.debug("Global rate limit is now over.")
```

The `set()` is not protected. If the task is cancelled during `asyncio.sleep(retry_after)`, `CancelledError` propagates out and the event is never re-set.

From then on, every request in the process blocks forever near the top of `request`:

```python
if not self._global_over.is_set():
    # wait until the global lock is complete
    await self._global_over.wait()
```

There is no recovery path. The client has to be restarted.

### Why this is easy to hit

The gateway is a separate websocket and is unaffected, so the bot stays connected, keeps receiving events, and keeps passing any health check that does not exercise the HTTP API. It simply stops being able to send anything. That makes it look like an intermittent "some commands stopped responding" problem rather than a deadlock.

Cancellation inside that window happens in ordinary usage:

* a send wrapped in `asyncio.wait_for` that times out
* tasks cancelled during shutdown
* any user code calling `Task.cancel()`
* library-level cancellation of pending work

It needs a global 429 to coincide with a cancellation, so it is rare, but it is unrecoverable when it does happen. We hit it in production on a bot across a few thousand guilds: online, healthy, gateway fine, and not a single outbound request completing until a restart.

## Fix

Move the release into a `finally`, so the global lock is dropped whether the sleep finishes or the request is cancelled. Behaviour is otherwise unchanged: on the normal path the event is still set right after the sleep, before the retry.

## Tests

Added `test_global_rate_limit_released_on_cancellation` to `tests/test_http.py`. It drives a real `HTTPClient.request` against a stub session that returns a global 429, cancels the request while it is sleeping, and asserts `_global_over` ends up set.

Verified it fails on `master` and passes with this change:

```
# without the fix
>       assert http._global_over.is_set()
E       assert False
1 failed

# with the fix
1 passed
```

## Notes

`discord.py` has the same issue in the equivalent code path, in case it is worth flagging upstream.

Changelog fragment added as `changelog/1585.bugfix.rst`.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)


