### PR TITLE
docs: add link to `file_types` groups in API reference

### DIFF
--- a/changelog/1591.feature.0.rst
+++ b/changelog/1591.feature.0.rst
@@ -1,0 +1,1 @@
+Support restricting allowed file types in :class:`.ui.FileUpload` modal components using :class:`file_types <.ui.FileUpload>`.

--- a/changelog/1591.feature.1.rst
+++ b/changelog/1591.feature.1.rst
@@ -1,0 +1,1 @@
+|commands| Support restricting allowed file types in :class:`Attachment` slash command parameters using ``Param(file_types=[...])`` (see :attr:`Option.file_types`).

--- a/disnake/app_commands.py
+++ b/disnake/app_commands.py
@@ -211,7 +211,8 @@ class Option:
 
     file_types: :class:`~collections.abc.Sequence`\[:class:`str`] | :data:`None`
         The list of file types that can be uploaded with this option, if the type is :class:`OptionType.attachment`.
-        Allowed values are ``image``, ``video``, and ``audio``, as well as
+        Allowed values are ``image``, ``video``, and ``audio`` (see
+        :ddocs:`API Reference <reference#file-type-filtering>`), as well as
         any dot-prefixed extension such as ``.pdf`` (up to 10).
         Defaults to all types (i.e. :data:`None`).
 
@@ -253,7 +254,8 @@ class Option:
 
     file_types: :class:`~collections.abc.Sequence`\[:class:`str`] | :data:`None`
         The list of file types that can be uploaded with this option, if the type is :class:`OptionType.attachment`.
-        Allowed values are ``image``, ``video``, and ``audio``, as well as
+        Allowed values are ``image``, ``video``, and ``audio`` (see
+        :ddocs:`API Reference <reference#file-type-filtering>`), as well as
         any dot-prefixed extension such as ``.pdf`` (up to 10).
         Defaults to all types (i.e. :data:`None`).
 

--- a/disnake/components.py
+++ b/disnake/components.py
@@ -1602,7 +1602,8 @@ class FileUpload(Component):
         Defaults to ``True``.
     file_types: :class:`~collections.abc.Sequence`\[:class:`str`] | :data:`None`
         A list of file types that can be uploaded with this component.
-        Allowed values are ``image``, ``video``, and ``audio``, as well as
+        Allowed values are ``image``, ``video``, and ``audio`` (see
+        :ddocs:`API Reference <reference#file-type-filtering>`), as well as
         any dot-prefixed extension such as ``.pdf`` (up to 10).
         If :data:`None`, files of all types may be uploaded.
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -1391,7 +1391,8 @@ def Param(
 
     file_types: :class:`~collections.abc.Sequence`\[:class:`str`] | :data:`None`
         The list of file types that can be uploaded with this option, if it is an :class:`.Attachment` option.
-        Allowed values are ``image``, ``video``, and ``audio``, as well as
+        Allowed values are ``image``, ``video``, and ``audio`` (see
+        :ddocs:`API Reference <reference#file-type-filtering>`), as well as
         any dot-prefixed extension such as ``.pdf`` (up to 10).
         Defaults to all types (i.e. :data:`None`).
 

--- a/disnake/ui/file_upload.py
+++ b/disnake/ui/file_upload.py
@@ -38,7 +38,8 @@ class FileUpload(UIComponent):
         Defaults to ``True``.
     file_types: :class:`~collections.abc.Sequence`\[:class:`str`] | :data:`None`
         A list of file types that can be uploaded with this component.
-        Allowed values are ``image``, ``video``, and ``audio``, as well as
+        Allowed values are ``image``, ``video``, and ``audio`` (see
+        :ddocs:`API Reference <reference#file-type-filtering>`), as well as
         any dot-prefixed extension such as ``.pdf`` (up to 10).
         Defaults to all types (i.e. :data:`None`).
 


### PR DESCRIPTION
## Summary

Adds a link to the relevant section for `file_types` in the API docs, primarily to have a reference for the predefined `image`/`video`/`audio` groups.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
