### PR TITLE
build: update twine to v7.0

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Check README.md renders properly on PyPI
         run: |
-          uvx twine~=6.1 check --strict dist/*
+          uvx twine~=7.0 check --strict dist/*
 
   codemod:
     name: LibCST codemods

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
           ls -la dist/
 
       - name: Twine check
-        run: uvx twine~=6.1 check --strict dist/*
+        run: uvx twine~=7.0 check --strict dist/*
 
       - name: Show metadata
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,8 @@ test = [
     "coverage[toml]~=7.14",
 ]
 build = [
-    "build>=1.2.2.post1",
-    "twine>=6.1.0",
+    "build~=1.3",
+    "twine~=7.0",
     "versioningit>=3.3.0,<4",
 ]
 


### PR DESCRIPTION
## Summary

[hatch v1.32.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.32.0) now defaults to core metadata 2.5, which requires [twine>=7.0](https://twine.readthedocs.io/en/stable/changelog.html#twine-7-0-0-2026-07-27). Currently, twine~=6.1 complains about the core metadata version being unknown, which breaks CI.

Using core metadata 2.5 also means we could add [`import-names`](https://packaging.python.org/en/latest/specifications/core-metadata/#import-name-multiple-use), but I haven't really looked into if/how it works with our sort-of-but-not-really namespace packages.

## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
