### PR TITLE
fix(dev): use outer `.venv`  instead of `_nox_script_mode` for `nox -s dev`

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -39,8 +39,7 @@ jobs:
     # The only purpose of this is to create a lockfile, which will be cached
     # to be used with subsequent jobs.
     # This provides somewhat of a middle ground and avoids having each job lock dependencies on its own,
-    # while still not needing to commit a lockfile to the repo, which is discouraged for libraries as per
-    # https://pdm-project.org/en/latest/usage/lockfile/
+    # while still not needing to commit a lockfile to the repo, which is discouraged for libraries
     runs-on: ubuntu-latest
     env:
       UV_RESOLUTION: highest
@@ -199,10 +198,6 @@ jobs:
           echo python="$(uv python find)" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
-        # `--no-venv` to install in the main pdm venv instead of nox's pyright-specific one
-        # because nox uses pdm internally to install, this means that the venv that is used is
-        # the one that pdm would create in project: `.venv`
-        # python is NOT forced here because the session name is explicit
         env:
           NOXSESSION: ${{ matrix.session.name }}
           NOX_DEFAULT_VENV_BACKEND: "none"

--- a/noxfile.py
+++ b/noxfile.py
@@ -472,11 +472,15 @@ def dev(session: nox.Session) -> None:
     """Set up a development environment using pdm.
 
     This will:
-    - lock all dependencies with pdm
-    - create a .venv/ directory, overwriting the existing one,
-    - install all dependencies needed for development.
+    - lock all dependencies with uv
+    - create a .venv/ directory, overwriting the existing one
+    - install all dependencies needed for development
     - install the pre-commit hook (prek)
     """
+    # clear venv-specific variables, otherwise this session will inherit and
+    # use the implicit nox script mode venv, rather than the outer .venv
+    session.env.update({"UV_PROJECT_ENVIRONMENT": None, "VIRTUAL_ENV": None})
+
     session.run("uv", "lock", external=True)
     session.run("uv", "venv", "--clear", external=True)
     session.run("uv", "sync", "--all-extras", external=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -469,7 +469,7 @@ def coverage(session: nox.Session) -> None:
 
 @nox.session(default=False, python=False)
 def dev(session: nox.Session) -> None:
-    """Set up a development environment using pdm.
+    """Set up a development environment using uv.
 
     This will:
     - lock all dependencies with uv


### PR DESCRIPTION
## Summary

Despite `@session(python=False)`, nox would use the implicit script-mode venv, which means `nox -s dev` (1) didn't create the main `.venv` as intended and (2) tried to `--clear` its own venv while it was running.
Not quite sure when this started happening, may have been #1362.

<sup>thanks @Snipy7374 c:</sup>

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
