### PR TITLE
ci: update uv to v0.12.5, remove unnecessary `uv venv` call

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -43,8 +43,8 @@ runs:
       id: setup-python
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: '0.9.2'
-        enable-cache: true
+        version: '0.12.5'
+        enable-cache: 'auto'
         # this doesn't install python but pins the uv version; its the same as providing UV_PYTHON
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -192,11 +192,8 @@ jobs:
           python-version: ${{ matrix.session.python }}
 
       - name: Add .venv/bin to PATH
-        id: venv-bin
         run: |
-          uv venv .venv
           dirname "$(uv python find)" >> $GITHUB_PATH
-          echo python="$(uv python find)" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         # `--no-venv` to install in the main pdm venv instead of nox's pyright-specific one
@@ -206,9 +203,6 @@ jobs:
         env:
           NOXSESSION: ${{ matrix.session.name }}
           NOX_DEFAULT_VENV_BACKEND: "none"
-          ## needed to install specific dependencies
-          ## used internally when nox calls pip to install a dependency in the venv
-          PIP_PYTHON: ${{ steps.venv-bin.outputs.python }}
         run: |
           nox --install-only
 


### PR DESCRIPTION
## Summary


## Checklist

- [ ] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
