### PR TITLE
build(deps): update libcst to v1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ docs = [
 ]
 codemod = [
     # run codemods on the repository (mostly automated typing)
-    "libcst==1.8.5",
+    "libcst==1.9.0",
     "autotyping==24.9.0",
     { include-group = "ruff" },
 ]

--- a/scripts/codemods/typed_flags.py
+++ b/scripts/codemods/typed_flags.py
@@ -6,7 +6,6 @@ import types
 from typing import cast
 
 import libcst as cst
-import libcst.codemod.visitors as codevisitors
 import libcst.matchers as m
 from libcst import codemod
 
@@ -116,9 +115,7 @@ class FlagTypings(BaseCodemodCommand):
                 if_block = cast(
                     "cst.If", cst.parse_statement(code, config=self.module.config_for_parsing)
                 )
-                codevisitors.AddImportsVisitor.add_needed_import(
-                    self.context, "typing", "TYPE_CHECKING"
-                )
+                self.add_needed_import("typing", "TYPE_CHECKING")
                 # now we need to add this if_block into the CST of node
                 # find the first function definition and insert it before there
                 for pos, b in enumerate(body):  # noqa: B007
@@ -142,9 +139,7 @@ class FlagTypings(BaseCodemodCommand):
                 decorators=[cst.Decorator(cst.Name("_generated"))],
                 params=old_init.params.with_changes(kwonly_params=kwonly_params, star_kwarg=None),
             )
-            codevisitors.AddImportsVisitor.add_needed_import(
-                self.context, "disnake.utils", "_generated"
-            )
+            self.add_needed_import("disnake.utils", "_generated")
             node = node.deep_replace(old_init, init)  # pyright: ignore[reportAssignmentType]
 
         else:
@@ -166,16 +161,14 @@ class FlagTypings(BaseCodemodCommand):
                 ],
                 params=init.params.with_changes(kwonly_params=kwonly_params, star_kwarg=None),
             )
-            codevisitors.AddImportsVisitor.add_needed_import(self.context, "typing", "overload")
-            codevisitors.AddImportsVisitor.add_needed_import(
-                self.context, "disnake.utils", "_generated"
-            )
+            self.add_needed_import("typing", "overload")
+            self.add_needed_import("disnake.utils", "_generated")
             empty_init = full_init.with_changes(
                 params=cst.Parameters(
                     params=[cst.Param(cst.Name("self"), cst.Annotation(cst.Name("NoReturn")))]
                 )
             )
-            codevisitors.AddImportsVisitor.add_needed_import(self.context, "typing", "NoReturn")
+            self.add_needed_import("typing", "NoReturn")
             pos = body.index(init)
             body.insert(pos, empty_init)
             body.insert(pos, full_init)

--- a/scripts/codemods/typed_permissions.py
+++ b/scripts/codemods/typed_permissions.py
@@ -3,7 +3,6 @@
 import itertools
 
 import libcst as cst
-import libcst.codemod.visitors as codevisitors
 import libcst.matchers as m
 
 from disnake import Permissions
@@ -181,9 +180,7 @@ class PermissionTypings(BaseCodemodCommand):
 
         overload = empty_overload.deep_clone().with_changes(params=params)
 
-        codevisitors.AddImportsVisitor.add_needed_import(self.context, "typing", "overload")
-        codevisitors.AddImportsVisitor.add_needed_import(
-            self.context, "disnake.utils", "_generated"
-        )
+        self.add_needed_import("typing", "overload")
+        self.add_needed_import("disnake.utils", "_generated")
 
         return cst.FlattenSentinel([overload, empty_overload, node])


### PR DESCRIPTION
## Summary

See https://github.com/Instagram/LibCST/releases/tag/v1.9.0.
This mainly just provides support for Python 3.15, and simplifies adding/removing imports.

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [ ] I have formatted the code properly by running `uv run nox -s lint`
    - [ ] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
