### PR TITLE
fix(interactions): remove unbound generic parameter from `ApplicationCommandInteraction` aliases

### DIFF
--- a/changelog/1606.bugfix.rst
+++ b/changelog/1606.bugfix.rst
@@ -1,0 +1,1 @@
+Restore ``isinstance`` functionality of :class:`ApplicationCommandInteraction` aliases (such as ``CommandInteraction``).

--- a/disnake/interactions/application_command.py
+++ b/disnake/interactions/application_command.py
@@ -378,10 +378,10 @@ ApplicationCommandInteractionDataResolved = InteractionDataResolved
 
 
 # People asked about shorter aliases, let's see which one catches on the most
-CommandInteraction = ApplicationCommandInteraction[ClientT]
-CmdInteraction = ApplicationCommandInteraction[ClientT]
-CommandInter = ApplicationCommandInteraction[ClientT]
-CmdInter = ApplicationCommandInteraction[ClientT]
-AppCommandInteraction = ApplicationCommandInteraction[ClientT]
-AppCommandInter = ApplicationCommandInteraction[ClientT]
-AppCmdInter = ApplicationCommandInteraction[ClientT]
+CommandInteraction = ApplicationCommandInteraction
+CmdInteraction = ApplicationCommandInteraction
+CommandInter = ApplicationCommandInteraction
+CmdInter = ApplicationCommandInteraction
+AppCommandInteraction = ApplicationCommandInteraction
+AppCommandInter = ApplicationCommandInteraction
+AppCmdInter = ApplicationCommandInteraction


### PR DESCRIPTION
## Summary

Adding the (unbound) generic `ClientT` parameter to the `ApplicationCommandInteraction` aliases[^1] meant that e.g. `isinstance(x, CommandInteraction)` would not work.
This was changed in https://github.com/DisnakeDev/disnake/commit/8c3af237c6c977cb67a14a8327c710c458ca59a0 as part of #1332, but things should work fine without it as well.

ref: https://canary.discord.com/channels/808030843078836254/942319505915412500/1540732874955689997

## Checklist

- [x] If code changes were made, then they have been tested
    - [ ] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

[^1]: Having this many aliases seems a little silly to me at this point, anyway.