### PR TITLE
feat(commands): support `Annotated[T, Param(...)]`

### DIFF
--- a/changelog/1607.feature.rst
+++ b/changelog/1607.feature.rst
@@ -1,0 +1,1 @@
+|commands| Add new ``arg: Annotated[T, Param(...)]`` syntax for :func:`~ext.commands.Param`. The original syntax of ``arg: T = Param(...)`` remains supported. (See :ref:`param_syntax` for more.)

--- a/changelog/1607.feature.rst
+++ b/changelog/1607.feature.rst
@@ -1,1 +1,3 @@
-|commands| Add new ``arg: Annotated[T, Param(...)]`` syntax for :func:`~ext.commands.Param`. The original syntax of ``arg: T = Param(...)`` remains supported. (See :ref:`param_syntax` for more.)
+|commands| Add new ``arg: Annotated[T, Param(...)]`` syntax for :func:`~ext.commands.Param`. (See :ref:`param_syntax` for more.)
+- The original syntax of ``arg: T = Param(...)`` remains supported.
+- The same applies to injections now, which support ``arg: Annotated[T, Injection(func)]`` in addition to ``arg: T = inject(func)``.

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -419,7 +419,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
             globalns = {}
 
         try:
-            params = get_signature_parameters(function, globalns, skip_standard_params=True)
+            params, _ = get_signature_parameters(function, globalns, skip_standard_params=True)
         except NameError as e:
             msg = (
                 str(e)

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -673,7 +673,7 @@ class ParamInfo:
     ) -> Self:
         default = param.default if param.default is not inspect.Parameter.empty else ...
 
-        if base_param_info:
+        if base_param_info is not None:
             # we copy this ParamInfo instance because it can be used in multiple signatures
             self = base_param_info.copy()
 

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -1072,15 +1072,15 @@ def find_meta_object(param: inspect.Parameter, metadata: Sequence[Any]) -> AnyMe
     if len(candidates) == 0:
         return None
 
-    for obj in candidates:
-        if not isinstance(obj, _AnyMetadata_tp):
-            msg = f'Expected `Param` or `Injection` object for "{param.name}" parameter, not {type(obj)!r}'
-            raise TypeError(msg)
-
     if len(candidates) > 1:
-        msg = f'Found more than one `Param` or `Injection` object for "{param.name}" parameter'
+        msg = f'Found more than one potential `Param` or `Injection` object for "{param.name}" parameter'
         raise TypeError(msg)
-    return candidates[0]
+
+    if not isinstance(candidate := candidates[0], _AnyMetadata_tp):
+        msg = f'Expected `Param` or `Injection` object for "{param.name}" parameter, not {type(candidate)!r}'
+        raise TypeError(msg)
+
+    return candidate
 
 
 def collect_params(

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -874,13 +874,13 @@ class ParamInfo:
             # (we need `__call__` here to get the correct global namespace later, since
             # classes do not have `__globals__`)
             converter_func = converter.__call__
-        _, parameters = isolate_self(converter_func)
+        _, signature = isolate_self(converter_func)
 
-        if len(parameters) != 1:
+        if len(signature.params) != 1:
             msg = "Converters must take precisely two arguments: the interaction and the argument"
             raise TypeError(msg)
 
-        _, parameter = parameters.popitem()
+        _, parameter = signature.params.popitem()
         annotation = parameter.annotation
 
         if parameter.default is not inspect.Parameter.empty and self.required:
@@ -937,7 +937,7 @@ class ParamInfo:
 def safe_call(function: Callable[..., T], /, *possible_args: Any, **possible_kwargs: Any) -> T:
     """Calls a function without providing any extra unexpected arguments"""
     MISSING: Any = object()
-    parameters = get_signature_parameters(function)
+    parameters, _ = get_signature_parameters(function)
 
     kinds = {p.kind for p in parameters.values()}
     arb = {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
@@ -984,20 +984,20 @@ def safe_call(function: Callable[..., T], /, *possible_args: Any, **possible_kwa
 
 def isolate_self(
     function: Callable[..., Any],
-    parameters: dict[str, inspect.Parameter] | None = None,
-) -> tuple[tuple[inspect.Parameter | None, ...], dict[str, inspect.Parameter]]:
+    signature: utils._SignatureData | None = None,
+) -> tuple[tuple[inspect.Parameter | None, ...], utils._SignatureData]:
     """Create parameters without self and the first interaction.
 
-    Optionally accepts a `{str: inspect.Parameter}` dict as an optimization,
+    Optionally accepts already processed signature data as an optimization,
     calls `get_signature_parameters(function)` if not provided.
     """
-    if parameters is None:
-        parameters = get_signature_parameters(function)
-    if not parameters:
-        return (None, None), {}
+    if signature is None:
+        signature = get_signature_parameters(function)
+    if not signature.params:
+        return (None, None), signature
 
-    parameters = dict(parameters)  # shallow copy
-    parametersl = list(parameters.values())
+    parameters = dict(signature.params)  # shallow copy
+    parametersl = list(signature.params.values())
 
     cog_param: inspect.Parameter | None = None
     inter_param: inspect.Parameter | None = None
@@ -1010,7 +1010,7 @@ def isolate_self(
         if issubclass_(annot, ApplicationCommandInteraction) or annot is inspect.Parameter.empty:
             inter_param = parameters.pop(parametersl[0].name)
 
-    return (cog_param, inter_param), parameters
+    return (cog_param, inter_param), utils._SignatureData(parameters, signature.metadata)
 
 
 def classify_autocompleter(autocompleter: AnyAutocompleter) -> None:
@@ -1050,22 +1050,23 @@ def classify_autocompleter(autocompleter: AnyAutocompleter) -> None:
 
 def collect_params(
     function: Callable[..., Any],
-    parameters: dict[str, inspect.Parameter] | None = None,
+    signature: utils._SignatureData | None = None,
 ) -> tuple[str | None, str | None, list[ParamInfo], dict[str, Injection]]:
     """Collect all parameters in a function.
 
-    Optionally accepts a `{str: inspect.Parameter}` dict as an optimization.
+    Optionally accepts already processed signature data as an optimization.
 
     Returns: (`cog parameter`, `interaction parameter`, `param infos`, `injections`)
     """
-    (cog_param, inter_param), parameters = isolate_self(function, parameters)
+    (cog_param, inter_param), signature = isolate_self(function, signature)
 
     doc = disnake.utils.parse_docstring(function)["params"]
 
     paraminfos: list[ParamInfo] = []
     injections: dict[str, Injection] = {}
 
-    for parameter in parameters.values():
+    # TODO: make use of signature.metadata?
+    for parameter in signature.params.values():
         if parameter.kind in [parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD]:
             continue
         if parameter.kind is parameter.POSITIONAL_ONLY:
@@ -1185,10 +1186,10 @@ def expand_params(command: AnySlashCommand) -> list[Option]:
 
     Returns the created options
     """
-    parameters = get_signature_parameters(command.callback)
-    # pass `parameters` down to avoid having to call `get_signature_parameters(func)` another time,
+    signature = get_signature_parameters(command.callback)
+    # pass `signature` down to avoid having to call `get_signature_parameters(func)` another time,
     # which may cause side effects with deferred annotations and warnings
-    _, inter_param, params, injections = collect_params(command.callback, parameters)
+    _, inter_param, params, injections = collect_params(command.callback, signature)
 
     if inter_param is None:
         msg = f"Couldn't find an interaction parameter in {command.callback}"
@@ -1215,7 +1216,7 @@ def expand_params(command: AnySlashCommand) -> list[Option]:
         if param.autocomplete:
             command.autocompleters[param.name] = param.autocomplete
 
-    if issubclass_(parameters[inter_param].annotation, disnake.GuildCommandInteraction):
+    if issubclass_(signature.params[inter_param].annotation, disnake.GuildCommandInteraction):
         command._guild_only = True
 
     return [param.to_option() for param in params]

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -667,12 +667,9 @@ class ParamInfo:
     def from_param(
         cls,
         param: inspect.Parameter,
-        type_hints: dict[str, Any],
         parsed_docstring: dict[str, disnake.utils._DocstringParam] | None = None,
     ) -> Self:
         # hopefully repeated parsing won't cause any problems
-        parsed_docstring = parsed_docstring or {}
-
         if isinstance(param.default, cls):
             # we copy this ParamInfo instance because it can be used in multiple signatures
             self = param.default.copy()
@@ -681,10 +678,9 @@ class ParamInfo:
             self = cls(default)
 
         self.parse_parameter(param)
-        doc = parsed_docstring.get(param.name)
-        if doc:
+        if parsed_docstring and (doc := parsed_docstring.get(param.name)):
             self.parse_doc(doc)
-        self.parse_annotation(type_hints.get(param.name, param.annotation))
+        self.parse_annotation(param.annotation)
 
         return self
 
@@ -1094,7 +1090,7 @@ def collect_params(
                 msg = f"Found two candidates for the cog parameter in {function!r}: {cog_param.name} and {parameter.name}"
                 raise TypeError(msg)
         else:
-            paraminfo = ParamInfo.from_param(parameter, {}, doc)
+            paraminfo = ParamInfo.from_param(parameter, doc)
             paraminfos.append(paraminfo)
 
     return (

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -485,6 +485,7 @@ class LargeInt(int):
 _VERIFY_TYPES: Final[frozenset[OptionType]] = frozenset((OptionType.user, OptionType.mentionable))
 
 
+# TODO(3.0): drop Param() and inject() functions, rename ParamInfo to Param
 class ParamInfo:
     r"""A class that basically connects function params with slash command options.
     The instances of this class are not created manually, but via the functional interface instead.
@@ -670,11 +671,18 @@ class ParamInfo:
         base_param_info: Self | None = None,
         parsed_docstring: dict[str, disnake.utils._DocstringParam] | None = None,
     ) -> Self:
+        default = param.default if param.default is not inspect.Parameter.empty else ...
+
         if base_param_info:
             # we copy this ParamInfo instance because it can be used in multiple signatures
             self = base_param_info.copy()
+
+            # base_param_info can be either from `= Param()` or `: Annotated[T, Param()]`;
+            # to support `arg: Annotated[str, Param(...)] = xyz`, capture the default value in
+            # the latter case
+            if default is not ... and not isinstance(default, cls):
+                self.default = default
         else:
-            default = param.default if param.default is not inspect.Parameter.empty else ...
             self = cls(default)
 
         self.parse_parameter(param)

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -667,12 +667,12 @@ class ParamInfo:
     def from_param(
         cls,
         param: inspect.Parameter,
+        base_param_info: Self | None = None,
         parsed_docstring: dict[str, disnake.utils._DocstringParam] | None = None,
     ) -> Self:
-        # hopefully repeated parsing won't cause any problems
-        if isinstance(param.default, cls):
+        if base_param_info:
             # we copy this ParamInfo instance because it can be used in multiple signatures
-            self = param.default.copy()
+            self = base_param_info.copy()
         else:
             default = param.default if param.default is not inspect.Parameter.empty else ...
             self = cls(default)
@@ -1048,6 +1048,33 @@ def classify_autocompleter(autocompleter: AnyAutocompleter) -> None:
     autocompleter.__has_cog_param__ = positional_param_count == 3
 
 
+AnyMetadata = ParamInfo | Injection
+_AnyMetadata_tp: tuple[type[AnyMetadata], ...] = AnyMetadata.__args__
+
+
+def find_meta_object(param: inspect.Parameter, metadata: Sequence[Any]) -> AnyMetadata | None:
+    """Find any `ParamInfo` or `Injection` in a parameter's default value or Annotated metadata.
+
+    Raises if >1 object was found, e.g. when `arg: Annotated[str, Param(...)] = Param(...)`.
+    """
+    candidates = list(metadata)
+    if isinstance(param.default, _AnyMetadata_tp):
+        candidates.append(param.default)
+
+    if len(candidates) == 0:
+        return None
+
+    for obj in candidates:
+        if not isinstance(obj, _AnyMetadata_tp):
+            msg = f'Expected `Param` or `Injection` object for "{param.name}" parameter, not {type(obj)!r}'
+            raise TypeError(msg)
+
+    if len(candidates) > 1:
+        msg = f'Found more than one `Param` or `Injection` object for "{param.name}" parameter'
+        raise TypeError(msg)
+    return candidates[0]
+
+
 def collect_params(
     function: Callable[..., Any],
     signature: utils._SignatureData | None = None,
@@ -1065,7 +1092,6 @@ def collect_params(
     paraminfos: list[ParamInfo] = []
     injections: dict[str, Injection] = {}
 
-    # TODO: make use of signature.metadata?
     for parameter in signature.params.values():
         if parameter.kind in [parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD]:
             continue
@@ -1073,9 +1099,9 @@ def collect_params(
             msg = "Positional-only parameters cannot be used in commands"
             raise TypeError(msg)
 
-        default = parameter.default
-        if isinstance(default, Injection):
-            injections[parameter.name] = default
+        meta = find_meta_object(parameter, signature.metadata.get(parameter.name, ()))
+        if isinstance(meta, Injection):
+            injections[parameter.name] = meta
         elif parameter.annotation in Injection._registered:
             injections[parameter.name] = Injection._registered[parameter.annotation]
         elif issubclass_(parameter.annotation, ApplicationCommandInteraction):
@@ -1091,7 +1117,7 @@ def collect_params(
                 msg = f"Found two candidates for the cog parameter in {function!r}: {cog_param.name} and {parameter.name}"
                 raise TypeError(msg)
         else:
-            paraminfo = ParamInfo.from_param(parameter, doc)
+            paraminfo = ParamInfo.from_param(parameter, meta, doc)
             paraminfos.append(paraminfo)
 
     return (

--- a/disnake/ext/commands/params.py
+++ b/disnake/ext/commands/params.py
@@ -1063,7 +1063,7 @@ _AnyMetadata_tp: tuple[type[AnyMetadata], ...] = AnyMetadata.__args__
 def find_meta_object(param: inspect.Parameter, metadata: Sequence[Any]) -> AnyMetadata | None:
     """Find any `ParamInfo` or `Injection` in a parameter's default value or Annotated metadata.
 
-    Raises if >1 object was found, e.g. when `arg: Annotated[str, Param(...)] = Param(...)`.
+    Raises if >1 object was found, e.g. when `arg: Annotated[T, Param(...)] = Param(...)`.
     """
     candidates = list(metadata)
     if isinstance(param.default, _AnyMetadata_tp):

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1133,7 +1133,12 @@ def normalise_optional_params(parameters: Iterable[Any]) -> tuple[Any, ...]:
 
 
 def _resolve_typealiastype(
-    tp: Any, globals: dict[str, Any], locals: dict[str, Any], cache: dict[str, Any]
+    tp: Any,
+    globals: dict[str, Any],
+    locals: dict[str, Any],
+    cache: dict[str, Any],
+    *,
+    return_annotated: bool,
 ) -> Any:
     # Use __module__ to get the (global) namespace in which the type alias was defined.
     if mod := sys.modules.get(tp.__module__):
@@ -1146,10 +1151,11 @@ def _resolve_typealiastype(
 
     # Accessing `__value__` automatically evaluates the type alias in the annotation scope.
     # (recurse to resolve possible forwardrefs, aliases, etc.)
-    return evaluate_annotation(tp.__value__, globals, locals, cache)
+    return evaluate_annotation(
+        tp.__value__, globals, locals, cache, return_annotated=return_annotated
+    )
 
 
-# FIXME: this should be split up into smaller functions for clarity and easier maintenance
 def evaluate_annotation(
     tp: Any,
     globals: dict[str, Any],
@@ -1158,6 +1164,11 @@ def evaluate_annotation(
     *,
     implicit_str: bool = True,
     source_info: types.CodeType | None = None,
+    # whether Annotated[X, Y] should be turned into <resolved Y> or Annotated[<resolved X>, <resolved Y>]
+    # (for simplicity, this is forwarded into recursive calls only when they are not operating on
+    # a subsection of the annotation, i.e. mainly implicit forwardrefs and typealiastypes;
+    # we don't care about any inner Annotated[] types, only the outer one, if any)
+    return_annotated: bool = False,
 ) -> Any:
     if isinstance(tp, ForwardRef):
         tp = tp.__forward_arg__
@@ -1165,8 +1176,10 @@ def evaluate_annotation(
         implicit_str = True
 
     if implicit_str and isinstance(tp, str):
-        if tp in cache:
-            return cache[tp]
+        # separate cache entries for true/false, as the evaluate_annotation return type changes
+        cache_key = f"{tp}--annotated" if return_annotated else tp
+        if cache_key in cache:
+            return cache[cache_key]
 
         if source_info is not None:
             # compile the annotation to add filename/line no. data for warnings & tracebacks
@@ -1178,16 +1191,32 @@ def evaluate_annotation(
         # this is how annotations are supposed to be unstringifed
         evaluated = eval(source, globals, locals)  # noqa: S307
         # recurse to resolve nested args further
-        evaluated = evaluate_annotation(evaluated, globals, locals, cache, source_info=source_info)
+        evaluated = evaluate_annotation(
+            evaluated,
+            globals,
+            locals,
+            cache,
+            source_info=source_info,
+            return_annotated=return_annotated,
+        )
 
-        cache[tp] = evaluated
+        cache[cache_key] = evaluated
         return evaluated
 
     # Annotated[X, Y], where Y is the converter we need
+    # (n.b. this must go before any `__args__` logic, as Annotated would match that as well)
     if get_origin(tp) is Annotated:
-        return evaluate_annotation(
+        meta_resolved = evaluate_annotation(
             tp.__metadata__[0], globals, locals, cache, source_info=source_info
         )
+        if not return_annotated:
+            return meta_resolved
+
+        # __origin__ in this case is not `Annotated`, but rather `X` (as above)
+        type_resolved = evaluate_annotation(
+            tp.__origin__, globals, locals, cache, source_info=source_info
+        )
+        return Annotated[type_resolved, meta_resolved]
 
     # GenericAlias / UnionType
     if hasattr(tp, "__args__"):
@@ -1208,7 +1237,7 @@ def evaluate_annotation(
 
         # origin can be a TypeAliasType too, resolve it and continue
         if hasattr(origin, "__value__"):
-            origin = _resolve_typealiastype(origin, globals, locals, cache)
+            origin = _resolve_typealiastype(origin, globals, locals, cache, return_annotated=False)
 
         if origin is Union:
             try:
@@ -1247,7 +1276,7 @@ def evaluate_annotation(
 
     # TypeAliasType, 3.12+
     if hasattr(tp, "__value__"):
-        return _resolve_typealiastype(tp, globals, locals, cache)
+        return _resolve_typealiastype(tp, globals, locals, cache, return_annotated=return_annotated)
 
     return tp
 
@@ -1257,6 +1286,8 @@ def resolve_annotation(
     globalns: dict[str, Any],
     localns: dict[str, Any] | None,
     cache: dict[str, Any] | None,
+    *,
+    return_annotated: bool = False,  # see evaluate_annotation
 ) -> Any:
     if annotation is None:
         return type(None)
@@ -1266,7 +1297,9 @@ def resolve_annotation(
     locals = globalns if localns is None else localns
     if cache is None:
         cache = {}
-    return evaluate_annotation(annotation, globalns, locals, cache)
+    return evaluate_annotation(
+        annotation, globalns, locals, cache, return_annotated=return_annotated
+    )
 
 
 def unwrap_function(function: Callable[..., Any]) -> Callable[..., Any]:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -36,6 +36,7 @@ from typing import (
     ForwardRef,
     Generic,
     Literal,
+    NamedTuple,
     Protocol,
     TypeAlias,
     TypedDict,
@@ -1324,17 +1325,23 @@ def _get_function_globals(function: Callable[..., Any]) -> dict[str, Any]:
 _inspect_empty = inspect.Parameter.empty
 
 
+class _SignatureData(NamedTuple):
+    params: dict[str, inspect.Parameter]  # {param_name: param}
+    metadata: dict[str, Sequence[Any]]  # {param_name: (annotated_args...)}
+
+
 def get_signature_parameters(
     function: Callable[..., Any],
     globalns: dict[str, Any] | None = None,
     *,
     skip_standard_params: bool = False,
-) -> dict[str, inspect.Parameter]:
+) -> _SignatureData:
     # if no globalns provided, unwrap (where needed) and get global namespace from there
     if globalns is None:
         globalns = _get_function_globals(function)
 
     params: dict[str, inspect.Parameter] = {}
+    metadata: dict[str, Sequence[Any]] = {}
     cache: dict[str, Any] = {}
 
     signature = inspect.signature(function)
@@ -1363,12 +1370,22 @@ def get_signature_parameters(
             annotation = type(None)
         else:
             annotation = evaluate_annotation(
-                annotation, globalns, globalns, cache, source_info=function.__code__
+                annotation,
+                globalns,
+                globalns,
+                cache,
+                source_info=function.__code__,
+                return_annotated=True,
             )
+
+            if get_origin(annotation) is Annotated:
+                # separate real type and (potential) ParamInfo or similar
+                annotation, meta = annotation.__origin__, annotation.__metadata__
+                metadata[name] = meta
 
         params[name] = parameter.replace(annotation=annotation)
 
-    return params
+    return _SignatureData(params, metadata)
 
 
 def get_signature_return(function: Callable[..., Any]) -> Any:

--- a/disnake/utils.py
+++ b/disnake/utils.py
@@ -1204,7 +1204,8 @@ def evaluate_annotation(
         cache[cache_key] = evaluated
         return evaluated
 
-    # Annotated[X, Y], where Y is the converter we need
+    # Annotated[X, Y]
+    # (resolve and return only Y if `return_annotated` is false)
     # (n.b. this must go before any `__args__` logic, as Annotated would match that as well)
     if get_origin(tp) is Annotated:
         meta_resolved = evaluate_annotation(

--- a/docs/_static/codeblocks.css
+++ b/docs/_static/codeblocks.css
@@ -73,7 +73,7 @@
 
 /* dark theme: modified "native" */
 :root[data-theme="dark"] .highlight pre { background-color: #2a2a2e }
-:root[data-theme="dark"] .highlight .hll { background-color: #2a2a2e }
+:root[data-theme="dark"] .highlight .hll { background-color: #525252 }
 :root[data-theme="dark"] .highlight .c { color: #999999; font-style: italic } /* Comment */
 :root[data-theme="dark"] .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 :root[data-theme="dark"] .highlight .g { color: #d0d0d0 } /* Generic */

--- a/docs/ext/commands/additional_info.rst
+++ b/docs/ext/commands/additional_info.rst
@@ -45,11 +45,11 @@ because global registration of application commands doesn't depend on sharding.
 Why do ``Param`` and ``Injection``-related functions return ``Any``?
 --------------------------------------------------------------------
 
-If your editor of choice supports type-checking, you may have noticed that :func:`~ext.commands.Param`, :func:`~ext.commands.inject`,
-and :func:`~ext.commands.injection` do not have a specific return type, but at runtime these return :class:`~ext.commands.ParamInfo` and
-:class:`~ext.commands.Injection` respectively.
+The original (but still supported) pre-v2.13 syntax for :func:`~ext.commands.Param` and :func:`~ext.commands.inject`
+required assigning them as the "default value" of a slash command parameter, like this:
 
-A typical example of a slash command might look like this: ::
+.. code-block:: python
+    :emphasize-lines: 4
 
     @bot.slash_command(description="Replies with the given text!")
     async def echo(
@@ -58,10 +58,11 @@ A typical example of a slash command might look like this: ::
     ) -> None:
         await inter.response.send_message(text)
 
-Here, you have two parameters in your command's function: ``inter``, an instance of :class:`disnake.ApplicationCommandInteraction`, and
-``text``, which is somewhat unusual: you annotate ``text`` as ``str``, but at the same time, assign a :class:`~ext.commands.ParamInfo` instance to it.
-That's the thing. When your editor type-checks your (any library's) code, it would normally complain if you tried to do the above, because
-you're trying to assign a ``ParamInfo`` to a ``str`` - however, since the library declares ``Param``'s return type as ``Any``, the type-checker accepts
-your code, because ``str`` (and any type) is a subtype of ``Any``.
+If your editor of choice supports type-checking, you may have noticed that :func:`~ext.commands.Param`, :func:`~ext.commands.inject`,
+and :func:`~ext.commands.injection` do not have a specific return type, but at runtime they return :class:`~ext.commands.ParamInfo` and
+:class:`~ext.commands.Injection` respectively.
 
-The same thing applies to :func:`~ext.commands.inject` and :func:`~ext.commands.injection`.
+A type-checker would normally complain if you tried to do the above, because you're trying to assign a ``ParamInfo`` to a ``str`` - however,
+since the library declares ``Param``'s return type as ``Any``, the type-checker accepts your code, because ``str`` (and any type) is a subtype of ``Any``.
+
+The newer ``text: Annotated[str, commands.Param(...)]`` syntax no longer has any shortcomings like this, but it remains supported for backwards compatibility.

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -214,7 +214,7 @@ and locally parse user provided content to :class:`int`.
     @bot.slash_command()
     async def snowflake(
         inter: disnake.ApplicationCommandInteraction,
-        snowflake: int = commands.Param(large=True),
+        snowflake: Annotated[int, commands.Param(large=True)],
     ):
         ...
 
@@ -247,7 +247,7 @@ For instance, you could restrict an option to only accept positive integers:
     @bot.slash_command()
     async def command(
         inter: disnake.ApplicationCommandInteraction,
-        amount: int = commands.Param(gt=0),
+        amount: Annotated[int, commands.Param(gt=0)],
     ):
         ...
 
@@ -277,8 +277,8 @@ falls outside the specified range.
     @bot.slash_command()
     async def ranges(
         inter: disnake.ApplicationCommandInteraction,
-        a: int = commands.Param(ge=0, le=2**64, large=True),  # 0 - 2**64 int
-        b: commands.Range[commands.LargeInt, 0, 2**64],       # 0 - 2**64 int
+        a: Annotated[int, commands.Param(ge=0, le=2**64, large=True)],  # 0 - 2**64 int
+        b: commands.Range[commands.LargeInt, 0, 2**64],                 # 0 - 2**64 int
     ):
         ...
 
@@ -296,7 +296,7 @@ For instance, you could restrict an option to only accept a single character:
     @bot.slash_command()
     async def charinfo(
         inter: disnake.ApplicationCommandInteraction,
-        character: str = commands.Param(max_length=1),
+        character: Annotated[str, commands.Param(max_length=1)],
     ):
         ...
 
@@ -307,7 +307,7 @@ Or restrict a tag command to limit tag names to 20 characters:
     @bot.slash_command()
     async def tags(
         inter: disnake.ApplicationCommandInteraction,
-        tag: str = commands.Param(max_length=20)
+        tag: Annotated[str, commands.Param(max_length=20)],
     ):
         ...
 
@@ -437,7 +437,7 @@ Or you can simply list the choices in ``commands.Param``:
     @bot.slash_command()
     async def blep(
         inter: disnake.ApplicationCommandInteraction,
-        animal: str = commands.Param(choices={"Dog": "dog", "Cat": "cat", "Penguin": "penguin"})
+        animal: Annotated[str, commands.Param(choices={"Dog": "dog", "Cat": "cat", "Penguin": "penguin"})],
     ):
         await inter.response.send_message(animal)
 
@@ -446,7 +446,7 @@ Or you can simply list the choices in ``commands.Param``:
     @bot.slash_command()
     async def blep(
         inter: disnake.ApplicationCommandInteraction,
-        animal: str = commands.Param(choices=["Dog", "Cat", "Penguin"])
+        animal: Annotated[str, commands.Param(choices=["Dog", "Cat", "Penguin"])],
     ):
         await inter.response.send_message(animal)
 
@@ -474,7 +474,7 @@ For example:
     @bot.slash_command()
     async def example(
         inter: disnake.ApplicationCommandInteraction,
-        language: str = commands.Param(autocomplete=autocomp_langs)
+        language: Annotated[str, commands.Param(autocomplete=autocomp_langs)],
     ):
         ...
 
@@ -638,10 +638,10 @@ This would create the same command as the code above, though you're free to chan
     @bot.slash_command(name=Localized("add_5", key="ADD_NUM_NAME"), description=Localized(key="ADD_NUM_DESCRIPTION"))
     async def _add_5_slash(
         inter: disnake.ApplicationCommandInteraction,
-        num: int = commands.Param(
+        num: Annotated[int, commands.Param(
             name=Localized(key="COOL_NUMBER_NAME"),
             description=Localized(key="COOL_NUMBER_DESCRIPTION")
-        ),
+        )],
     ):
         """
         Adds 5 to a number.
@@ -662,10 +662,10 @@ While not recommended, it is also possible to avoid using ``.json`` files at all
     )
     async def add_5(
         inter: disnake.ApplicationCommandInteraction,
-        num: int = commands.Param(
+        num: Annotated[int, commands.Param(
             name=Localized(data={Locale.de: "zahl"}),
             description=Localized(data={Locale.de: "Eine Zahl"}),
-        ),
+        )],
     ):
         ...
 
@@ -680,13 +680,13 @@ Choices/Autocomplete
     @bot.slash_command()
     async def example(
         inter: disnake.ApplicationCommandInteraction,
-        animal: str = commands.Param(choices=[
+        animal: Annotated[str, commands.Param(choices=[
             # alternatively:
             # OptionChoice(Localized("Cat", key="OPTION_CAT"), "Cat")
             Localized("Cat", key="OPTION_CAT"),
             Localized("Dolphin", key="OPTION_DOLPHIN"),
-        ]),
-        language: str = commands.Param(autocomplete=autocomp_langs),
+        ])],
+        language: Annotated[str, commands.Param(autocomplete=autocomp_langs)],
     ):
         ...
 

--- a/docs/ext/commands/slash_commands.rst
+++ b/docs/ext/commands/slash_commands.rst
@@ -125,7 +125,7 @@ You may have as many options as you want but the order matters, an optional opti
 Option Types
 ++++++++++++
 
-You might already be familiar with discord.py's converters, slash commands have a very similar equivalent in the form of option types.
+You might already be familiar with converters; slash commands have a very similar equivalent in the form of option types.
 Discord itself supports only a few built-in types which are guaranteed to be enforced:
 
 - :class:`str`
@@ -167,6 +167,36 @@ Other types may be converted implicitly, using the builtin :ref:`ext_commands_di
   Note that a :class:`~disnake.User` annotation can also result in a :class:`~disnake.Member` being received.
 
   \*\*\* Corresponds to any mentionable type, currently equivalent to ``User | Member | Role``.
+
+
+Parameter Descriptors
++++++++++++++++++++++
+
+A slash command's parameter can have additional configuration/metadata, depending on the type. For instance,
+you may e.g. rename a parameter, pass the input through a converter function, or restrict a :class:`str` parameter's
+minimum and/or maximum length (which will be enforced by the Discord API).
+
+To facilitate this, :func:`~ext.commands.Param` can be used with :data:`typing.Annotated` to add all sorts of metadata to a parameter, like this:
+
+.. code-block:: python
+    :emphasize-lines: 4
+
+    @bot.slash_command()
+    async def echo(
+        inter: disnake.ApplicationCommandInteraction,
+        text: Annotated[str, commands.Param(max_length=10)],
+        suffix: Annotated[str, commands.Param(name="emoji", choices=["😊", "😔"])]
+    ) -> None:
+        await inter.response.send_message(text + " " + suffix)
+
+This way, the parameters in this snippet remain :class:`str` options, while e.g. additionally restricting the length to 10 characters using ``Param(max_length=10)``, all while keeping your editor/type-checker happy.
+
+Other features include minimum/maximum values for numbers, restricting parameters to a fixed set of choices, restricting an :class:`Attachment` option to certain file types, and more. See below for more detailed information.
+
+.. note::
+    Prior to v2.13, :func:`~ext.commands.Param` was used by assigning it as a parameter's "default value" (similar to fastapi's syntax),
+    rather than using it in conjunction with :data:`typing.Annotated`, as seen in :ref:`why_params_and_injections_return_any`.
+    While this **remains supported** for the time being, we encourage users to migrate to the ``Annotated[T, Param(...)]`` syntax, as it is more flexible and pythonic.
 
 
 .. _large_integers:
@@ -353,42 +383,6 @@ If you prefer the real RST format, you can still use it:
         """
         ...
 
-
-Parameter Descriptors
-+++++++++++++++++++++
-
-Python has no truly *clean* way to provide metadata for parameters, so disnake uses the same approach as fastapi using
-parameter defaults. At the current time there's only :class:`~disnake.ext.commands.Param`.
-
-With this you may set the name, description, custom converters, :ref:`autocompleters`, and more.
-
-.. code-block:: python3
-
-    @bot.slash_command()
-    async def math(
-        interaction: disnake.ApplicationCommandInteraction,
-        a: int = commands.Param(le=10),
-        b: int = commands.Param(le=10),
-        op: str = commands.Param(name="operator", choices=["+", "-", "/", "*"])
-    ):
-        """
-        Perform an operation on two numbers as long as both of them are less than or equal to 10
-        """
-        ...
-
-.. code-block:: python3
-
-    @bot.slash_command()
-    async def multiply(
-        interaction: disnake.ApplicationCommandInteraction,
-        clean: str = commands.Param(converter=lambda inter, arg: arg.replace("@", "\\@")
-    ):
-        ...
-
-
-.. note ::
-    The converter parameter only ever takes in a **function**, not a Converter class.
-    Converter classes are completely unusable in disnake due to their inconsistent typing.
 
 .. _option_choices:
 

--- a/examples/interactions/autocomplete.py
+++ b/examples/interactions/autocomplete.py
@@ -3,6 +3,7 @@
 """An example showcasing the two ways of adding autocompletion to slash command options."""
 
 import os
+from typing import Annotated
 
 import disnake
 from disnake.ext import commands
@@ -29,7 +30,7 @@ async def autocomplete_langs(inter, string: str) -> list[str]:
 @bot.slash_command()
 async def languages_1(
     inter: disnake.CommandInteraction,
-    language: str = commands.Param(autocomplete=autocomplete_langs),
+    language: Annotated[str, commands.Param(autocomplete=autocomplete_langs)],
 ): ...
 
 

--- a/examples/interactions/converters.py
+++ b/examples/interactions/converters.py
@@ -3,6 +3,7 @@
 """An example using converters with slash commands."""
 
 import os
+from typing import Annotated
 
 import disnake
 from disnake.ext import commands
@@ -15,7 +16,7 @@ bot = commands.Bot(command_prefix=commands.when_mentioned)
 @bot.slash_command()
 async def clean_command(
     inter: disnake.CommandInteraction[commands.Bot],
-    text: str = commands.Param(converter=lambda inter, text: text.replace("@", "\\@")),
+    text: Annotated[str, commands.Param(converter=lambda inter, text: text.replace("@", "\\@"))],
 ): ...
 
 
@@ -29,7 +30,7 @@ def avatar_converter(inter: disnake.CommandInteraction, user: disnake.User) -> s
 @bot.slash_command()
 async def command_with_avatar(
     inter: disnake.CommandInteraction,
-    avatar: str = commands.Param(converter=avatar_converter),
+    avatar: Annotated[str, commands.Param(converter=avatar_converter)],
 ): ...
 
 
@@ -47,7 +48,7 @@ class SomeCustomClass:
 @bot.slash_command()
 async def command_with_clsmethod(
     inter: disnake.CommandInteraction,
-    some: SomeCustomClass = commands.Param(converter=SomeCustomClass.from_option),
+    some: Annotated[SomeCustomClass, commands.Param(converter=SomeCustomClass.from_option)],
 ): ...
 
 

--- a/examples/interactions/injections.py
+++ b/examples/interactions/injections.py
@@ -54,7 +54,7 @@ async def get_config(
 async def injected1(
     inter: disnake.CommandInteraction,
     number: int,
-    config: Annotated[Config, commands.inject(get_config)],
+    config: Annotated[Config, commands.Injection(get_config)],
 ):
     """A command which takes in a number and some config parameters
 
@@ -68,7 +68,7 @@ async def injected1(
 async def injected2(
     inter: disnake.CommandInteraction,
     string: str,
-    config: Annotated[Config, commands.inject(get_config)],
+    config: Annotated[Config, commands.Injection(get_config)],
 ):
     """A command which takes in a string and some config parameters
 

--- a/examples/interactions/injections.py
+++ b/examples/interactions/injections.py
@@ -2,7 +2,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 import disnake
 from disnake.ext import commands
@@ -48,13 +48,13 @@ async def get_config(
 
 
 # Note that the following command will have 4 options:
-# `number`, `locale`, `timezone` and `theme`.
+# `number`, `locale`, `theme` and `notifications`.
 # `config` will be whatever `get_config()` returns.
 @bot.slash_command()
 async def injected1(
     inter: disnake.CommandInteraction,
     number: int,
-    config: Config = commands.inject(get_config),
+    config: Annotated[Config, commands.inject(get_config)],
 ):
     """A command which takes in a number and some config parameters
 
@@ -68,7 +68,7 @@ async def injected1(
 async def injected2(
     inter: disnake.CommandInteraction,
     string: str,
-    config: Config = commands.inject(get_config),
+    config: Annotated[Config, commands.inject(get_config)],
 ):
     """A command which takes in a string and some config parameters
 

--- a/examples/interactions/localizations.py
+++ b/examples/interactions/localizations.py
@@ -3,7 +3,7 @@
 """An example on how to set up localized application commands."""
 
 import os
-from typing import Any
+from typing import Annotated, Any
 
 import disnake
 from disnake import Localized, OptionChoice
@@ -46,13 +46,16 @@ async def highscore(
     inter: disnake.CommandInteraction,
     user: disnake.User,
     game: str,
-    interval: str = commands.Param(
-        choices=[
-            OptionChoice(Localized("Last Day", key="CHOICE_DAY"), "day"),
-            OptionChoice(Localized("Last Week", key="CHOICE_WEEK"), "week"),
-            OptionChoice(Localized("Last Month", key="CHOICE_MONTH"), "month"),
-        ]
-    ),
+    interval: Annotated[
+        str,
+        commands.Param(
+            choices=[
+                OptionChoice(Localized("Last Day", key="CHOICE_DAY"), "day"),
+                OptionChoice(Localized("Last Week", key="CHOICE_WEEK"), "week"),
+                OptionChoice(Localized("Last Month", key="CHOICE_MONTH"), "month"),
+            ]
+        ),
+    ],
 ):
     """Shows the highscore of the selected user within the specified interval.
     {{ HIGHSCORE_COMMAND }}

--- a/examples/interactions/param.py
+++ b/examples/interactions/param.py
@@ -3,6 +3,7 @@
 """Some examples showing how to customize slash command options."""
 
 import os
+from typing import Annotated
 
 import disnake
 from disnake.ext import commands
@@ -61,8 +62,9 @@ async def description(
 @bot.slash_command()
 async def defaults(
     inter: disnake.CommandInteraction[commands.Bot],
+    *,
     string: str = "this is a default value",
-    user: disnake.User = commands.Param(lambda inter: inter.author),
+    user: Annotated[disnake.User, commands.Param(lambda inter: inter.author)],
 ): ...
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,8 +297,6 @@ ignore-fully-untyped = true
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = [
-    "disnake.ext.commands.inject",
-    "disnake.ext.commands.Param",
     "disnake.webhook.async_.AsyncWebhookAdapter",
 ]
 

--- a/tests/ext/commands/test_base_core.py
+++ b/tests/ext/commands/test_base_core.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 import warnings
+from typing import Annotated
 
 import pytest
 
@@ -154,7 +155,7 @@ def test_localization_copy() -> None:
         async def cmd(
             self,
             inter,
-            param: int = commands.Param(name=disnake.Localized("param", key="PARAM")),
+            param: Annotated[int, commands.Param(name=disnake.Localized("param", key="PARAM"))],
         ) -> None: ...
 
     # Ensure the command copy that happens on cog init doesn't raise a LocalizationWarning for the options.

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -2,15 +2,15 @@
 
 import math
 from collections.abc import Callable
-from typing import Any, Optional, Union, cast
+from typing import Annotated, Any, Optional, Union, cast
 from unittest import mock
 
 import pytest
 
 import disnake
-from disnake import Member, OptionType, Role, User
+from disnake import Member, Option, OptionType, Role, User
 from disnake.ext import commands
-from disnake.ext.commands.params import _BaseRange, _Range, _String
+from disnake.ext.commands.params import Param, _BaseRange, _Range, _String
 
 
 class TestParamInfo:
@@ -311,3 +311,37 @@ class TestIsolateSelf:
         assert cog is None
         assert inter is not None
         assert sig.params.keys() == {"a"}
+
+
+class TestExpandParams:
+    def _expand_params(
+        self, func: Callable[..., Any]
+    ) -> tuple[list[Option], dict[str, commands.Injection], list[commands.ParamInfo]]:
+        _, _, params, injections = commands.params.collect_params(func)
+        return [p.to_option() for p in params], injections, params
+
+    @pytest.mark.parametrize("default_value", [..., 67])
+    def test_param_as_default(self, default_value: Any) -> None:
+        def func(
+            num: int = Param(default_value, description="does stuff", ge=7),
+        ) -> None: ...
+
+        opts, _, _ = self._expand_params(func)
+        assert opts == [
+            Option(
+                "num", "does stuff", OptionType.integer, required=default_value is ..., min_value=7
+            )
+        ]
+
+    @pytest.mark.parametrize("default_value", [..., 67])
+    def test_param_as_annotated(self, default_value: Any) -> None:
+        def func(
+            num: Annotated[int, Param(default_value, description="does stuff", ge=7)],
+        ) -> None: ...
+
+        opts, _, _ = self._expand_params(func)
+        assert opts == [
+            Option(
+                "num", "does stuff", OptionType.integer, required=default_value is ..., min_value=7
+            )
+        ]

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -345,3 +345,12 @@ class TestExpandParams:
                 "num", "does stuff", OptionType.integer, required=default_value is ..., min_value=7
             )
         ]
+
+    def test_param_as_annotated_with_default(self) -> None:
+        def func(
+            num: Annotated[int, Param(ge=7)] = 67,
+        ) -> None: ...
+
+        opts, _, params = self._expand_params(func)
+        assert opts == [Option("num", "-", OptionType.integer, required=False, min_value=7)]
+        assert params[0].default == 67

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -261,45 +261,45 @@ class TestIsolateSelf:
     def test_function_simple(self) -> None:
         def func(a: int) -> None: ...
 
-        (cog, inter), params = commands.params.isolate_self(func)
+        (cog, inter), sig = commands.params.isolate_self(func)
         assert cog is None
         assert inter is None
-        assert params.keys() == {"a"}
+        assert sig.params.keys() == {"a"}
 
     def test_function_inter(self) -> None:
         def func(inter: disnake.ApplicationCommandInteraction, a: int) -> None: ...
 
-        (cog, inter), params = commands.params.isolate_self(func)
+        (cog, inter), sig = commands.params.isolate_self(func)
         assert cog is None  # should not be set
         assert inter is not None
-        assert params.keys() == {"a"}
+        assert sig.params.keys() == {"a"}
 
     def test_unbound_method(self) -> None:
         class Cog(commands.Cog):
             def func(self, inter: disnake.ApplicationCommandInteraction, a: int) -> None: ...
 
-        (cog, inter), params = commands.params.isolate_self(Cog.func)
+        (cog, inter), sig = commands.params.isolate_self(Cog.func)
         assert cog is not None  # *should* be set here
         assert inter is not None
-        assert params.keys() == {"a"}
+        assert sig.params.keys() == {"a"}
 
     # I don't think the param parsing logic ever handles bound methods, but testing for regressions anyway
     def test_bound_method(self) -> None:
         class Cog(commands.Cog):
             def func(self, inter: disnake.ApplicationCommandInteraction, a: int) -> None: ...
 
-        (cog, inter), params = commands.params.isolate_self(Cog().func)
+        (cog, inter), sig = commands.params.isolate_self(Cog().func)
         assert cog is None  # should not be set here, since method is already bound
         assert inter is not None
-        assert params.keys() == {"a"}
+        assert sig.params.keys() == {"a"}
 
     def test_generic(self) -> None:
         def func(inter: disnake.ApplicationCommandInteraction[commands.Bot], a: int) -> None: ...
 
-        (cog, inter), params = commands.params.isolate_self(func)
+        (cog, inter), sig = commands.params.isolate_self(func)
         assert cog is None
         assert inter is not None
-        assert params.keys() == {"a"}
+        assert sig.params.keys() == {"a"}
 
     def test_inter_union(self) -> None:
         def func(
@@ -307,7 +307,7 @@ class TestIsolateSelf:
             a: int,
         ) -> None: ...
 
-        (cog, inter), params = commands.params.isolate_self(func)
+        (cog, inter), sig = commands.params.isolate_self(func)
         assert cog is None
         assert inter is not None
-        assert params.keys() == {"a"}
+        assert sig.params.keys() == {"a"}

--- a/tests/ext/commands/test_params.py
+++ b/tests/ext/commands/test_params.py
@@ -10,7 +10,7 @@ import pytest
 import disnake
 from disnake import Member, Option, OptionType, Role, User
 from disnake.ext import commands
-from disnake.ext.commands.params import Param, _BaseRange, _Range, _String
+from disnake.ext.commands.params import Injection, Param, _BaseRange, _Range, _String, inject
 
 
 class TestParamInfo:
@@ -314,7 +314,7 @@ class TestIsolateSelf:
 
 
 class TestExpandParams:
-    def _expand_params(
+    def _collect_params(
         self, func: Callable[..., Any]
     ) -> tuple[list[Option], dict[str, commands.Injection], list[commands.ParamInfo]]:
         _, _, params, injections = commands.params.collect_params(func)
@@ -326,7 +326,7 @@ class TestExpandParams:
             num: int = Param(default_value, description="does stuff", ge=7),
         ) -> None: ...
 
-        opts, _, _ = self._expand_params(func)
+        opts, _, _ = self._collect_params(func)
         assert opts == [
             Option(
                 "num", "does stuff", OptionType.integer, required=default_value is ..., min_value=7
@@ -336,10 +336,12 @@ class TestExpandParams:
     @pytest.mark.parametrize("default_value", [..., 67])
     def test_param_as_annotated(self, default_value: Any) -> None:
         def func(
+            # setting a default this way is technically supported and fine, it just may result
+            # in the parameter changing positions as required args must go before optional ones
             num: Annotated[int, Param(default_value, description="does stuff", ge=7)],
         ) -> None: ...
 
-        opts, _, _ = self._expand_params(func)
+        opts, _, _ = self._collect_params(func)
         assert opts == [
             Option(
                 "num", "does stuff", OptionType.integer, required=default_value is ..., min_value=7
@@ -351,6 +353,32 @@ class TestExpandParams:
             num: Annotated[int, Param(ge=7)] = 67,
         ) -> None: ...
 
-        opts, _, params = self._expand_params(func)
+        opts, _, params = self._collect_params(func)
         assert opts == [Option("num", "-", OptionType.integer, required=False, min_value=7)]
         assert params[0].default == 67
+
+    def test_injection_as_annotated(self) -> None:
+        def inject_func(num: int) -> int:
+            return num + 1
+
+        def func(
+            i: Annotated[int, Injection(inject_func)],
+        ) -> None: ...
+
+        _, inj, params = self._collect_params(func)
+        # collect_params does not flatten injection functions, expand_params does
+        assert params == []
+        assert len(inj) == 1
+
+    def test_multiple_param_injection(self) -> None:
+        def inject_func(num: int) -> int:
+            return num + 1
+
+        def func(
+            # this should not work; Param is not supported for injected args
+            # (in general, more than one Param/Injection object per parameter not supported for obvious reasons)
+            i: Annotated[int, Param()] = inject(inject_func),
+        ) -> None: ...
+
+        with pytest.raises(TypeError, match=r"Found more than one"):
+            self._collect_params(func)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -814,6 +814,26 @@ def test_resolve_annotation_literal() -> None:
         utils.resolve_annotation(Literal[timezone.utc, 3], globals(), locals(), {})
 
 
+@pytest.mark.parametrize(
+    ("tp", "return_annotated", "expected"),
+    [
+        (Annotated["str", str.casefold], False, str.casefold),
+        (Annotated["str", str.casefold], True, Annotated[str, str.casefold]),
+        # Annotated should be handled correctly as a forwardref
+        ('Annotated["str", str.casefold]', False, str.casefold),
+        ('Annotated["str", str.casefold]', True, Annotated[str, str.casefold]),
+        # any inner Annotated[] should fall back to the default behavior, i.e. returning its metadata
+        (int | Annotated[str, "bool"], False, int | bool),
+        (int | Annotated[str, "bool"], True, int | bool),
+    ],
+)
+def test_resolve_annotation_annotated(tp, return_annotated, expected) -> None:
+    assert (
+        utils.resolve_annotation(tp, globals(), locals(), None, return_annotated=return_annotated)
+        == expected
+    )
+
+
 # declared here as `TypeAliasType` is only valid in class/module scopes
 if TYPE_CHECKING or sys.version_info >= (3, 12):
     # this is equivalent to `type CoolList = List[int]`


### PR DESCRIPTION
## Summary

Since we're now free to use `typing.Annotated` after dropping 3.8 a while ago, it's time to make `Param()` a little more pythonic~

This adds support for `arg: Annotated[int, Param(...)]`, superseding the previous fastapi-like syntax of `arg: int = Param(...)`.
The "old" syntax is **not deprecated**, and won't be for a while, at least until v3.0; keeping support for it is a matter of like two lines of code (plus the `Param() -> Any` return type workaround), so I don't mind it a whole lot.

Similarly to `Param`, the same thing applies to `Injection` now, which originally used `arg: T = inject(func)`.

While I've tried to test all of this, it touches some pretty fundamental parameter parsing stuff nonetheless, so I'd love for others to test this branch on their code as well, even just with the previous syntax (and seeing if anything happens to break). c:

Resolves #1433.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [ ] This PR fixes an issue
- [x] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
