### PR TITLE
feat(commands): generalize `@is_nsfw()` check for potential future channel types

### DIFF
--- a/changelog/1609.bugfix.rst
+++ b/changelog/1609.bugfix.rst
@@ -1,1 +1,0 @@
-|commands| Support :class:`ForumChannel` and :class:`MediaChannel` in :func:`~ext.commands.is_nsfw` check.

--- a/changelog/1609.bugfix.rst
+++ b/changelog/1609.bugfix.rst
@@ -1,0 +1,1 @@
+|commands| Support :class:`ForumChannel` and :class:`MediaChannel` in :func:`~ext.commands.is_nsfw` check.

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -2557,8 +2557,10 @@ def is_nsfw() -> Callable[[T], T]:
                 (
                     disnake.TextChannel,
                     disnake.VoiceChannel,
-                    disnake.Thread,
                     disnake.StageChannel,
+                    disnake.Thread,
+                    disnake.ForumChannel,
+                    disnake.MediaChannel,
                 ),
             )
             and ch.is_nsfw()

--- a/disnake/ext/commands/core.py
+++ b/disnake/ext/commands/core.py
@@ -2552,18 +2552,7 @@ def is_nsfw() -> Callable[[T], T]:
     def pred(ctx: AnyContext) -> bool:
         ch = ctx.channel
         if ctx.guild is None or (
-            isinstance(
-                ch,
-                (
-                    disnake.TextChannel,
-                    disnake.VoiceChannel,
-                    disnake.StageChannel,
-                    disnake.Thread,
-                    disnake.ForumChannel,
-                    disnake.MediaChannel,
-                ),
-            )
-            and ch.is_nsfw()
+            isinstance(ch, (disnake.abc.GuildChannel, disnake.Thread)) and ch.is_nsfw()
         ):
             return True
         raise NSFWChannelRequired(ch)  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Summary

Manually maintaining this list isn't great, but alternatively something like `callable(getattr(ch, "is_nsfw", None)) and ch.is_nsfw()  # type: ignore` feels even worse.
New channel types don't get added all that often, after all.

## Checklist

- [x] If code changes were made, then they have been tested
    - [x] I have updated the documentation to reflect the changes
    - [x] I have formatted the code properly by running `uv run nox -s lint`
    - [x] I have type-checked the code by running `uv run nox -s pyright`
- [x] This PR fixes an issue
- [ ] This PR adds something new (e.g. new method or parameters)
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
